### PR TITLE
removed cryptic class name in pyiron_contrib.protocol.utils.types

### DIFF
--- a/pyiron_contrib/protocol/generic.py
+++ b/pyiron_contrib/protocol/generic.py
@@ -514,7 +514,6 @@ class Protocol(Vertex, PyironJobTypeRegistry):
             group_name (str): HDF5 subgroup name - optional
         """
 
-        self.logger.warning("%s %s" %(hdf, type(hdf)))
         if hdf is None:
             hdf = self.project_hdf5
         if self._is_master:

--- a/pyiron_contrib/protocol/utils/types.py
+++ b/pyiron_contrib/protocol/utils/types.py
@@ -80,7 +80,7 @@ class PyironJobTypeRegistryMetaType(ABCMeta):
         class_module = cls.__module__
         key = (class_module, class_name)
         # construct the new class name
-        new_class_name = '%s%s%s' % (class_name, 'Protocol', hex(abs(hash(class_name))))
+        new_class_name = class_name
         # we place a `__artificial__` attribute in the type information to indicate that it is a dynamically created type
         # when calling `type(new_class_name, new_bases, new_spec)` we construct a subclass of cls, thus it is a
         # recsursive call to this method, we have to avoid that


### PR DESCRIPTION
Fixes TYPE attribute bug
Because of the dynmically generated wrapped GenericJob-derived types were had cryptic class names
The  type name of the type identifier did not match the type None, thus when retrieving the class name one obtains `None` and consequently the **TYPE** attribute in HDF5 to be `"<class 'NoneType'>"`