### PR TITLE
Add a stripped down container for potential training data

### DIFF
--- a/pyiron_contrib/__init__.py
+++ b/pyiron_contrib/__init__.py
@@ -24,6 +24,7 @@ JOB_CLASS_DICT['Mixer'] = 'pyiron_contrib.atomistic.interactive.mixer'
 JOB_CLASS_DICT['ParameterMaster'] = 'pyiron_contrib.atomistic.dft.parametermaster'
 JOB_CLASS_DICT['MonteCarloMaster'] = 'pyiron_contrib.atomistic.interactive.montecarlo'
 JOB_CLASS_DICT['RandSpg'] = 'pyiron_contrib.atomistic.atomistics.structures.randspg'
+JOB_CLASS_DICT['TrainingContainer'] = 'pyiron_contrib.atomistic.atomistics.job.trainingcontainer'
 
 from ._version import get_versions
 

--- a/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
+++ b/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
@@ -48,6 +48,18 @@ class TrainingContainer(GenericJob):
                  "number_of_atoms": len(structure)},
                 ignore_index=True)
 
+    def include_dataset(self, dataset):
+        """
+        Add a pandas DataFrame to the saved structures.
+
+        The dataframe should have the following columns:
+            - name: human readable name of the structure
+            - atoms(:class:`ase.Atoms`): the atomic structure
+            - energy(float): energy of the whole structure
+            - forces (Nx3 array of float): per atom forces, where N is the number of atoms in the structure
+        """
+        self._table = self._table.append(dataset, ignore_index=True)
+
     def to_pandas(self):
         """
         Export list of structure to pandas table for external fitting codes.

--- a/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
+++ b/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
@@ -1,0 +1,85 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+"""
+Extends the :class:`.StructureContainer` to store energies and forces with the structures.
+"""
+
+import os.path
+import pandas as pd
+
+from pyiron_atomistics import pyiron_to_ase
+from pyiron_atomistics.atomistics.structure.atoms import Atoms
+from pyiron_base import GenericJob
+
+class TrainingContainer(GenericJob):
+    """
+    Stores ASE structres with energies and forces.
+    """
+
+    def __init__(self, job_name, project):
+        super().__init__(job_name, project)
+        self._table = pd.DataFrame({
+            "name": [],
+            "atoms": [],
+            "energy": [],
+            "forces": [],
+            "number_of_atoms": []
+        })
+
+    def include_structure(self, structure, energy, forces=None, name=None):
+        """
+        Add new structure to structure list and save energy and forces with it.
+
+        For consistency with the rest of pyiron, energy should be in units of eV and forces in eV/A, but no conversion
+        is performed.
+
+        Args:
+            structure_or_job (:class:`~.Atoms`, :class:`ase.Atoms`): if :class:`~.Atoms` convert to :class:`ase.Atoms`
+            energy (float): energy of the whole structure
+            forces (Nx3 array of float, optional): per atom forces, where N is the number of atoms in the structure
+            name (str, optional): name describing the structure
+        """
+        if isinstance(structure, Atoms):
+            structure = pyiron_to_ase(structure)
+        self._table = self._table.append(
+                {"name": name, "atoms": structure, "energy": energy, "forces": forces,
+                 "number_of_atoms": len(structure)},
+                ignore_index=True)
+
+    def to_pandas(self):
+        """
+        Export list of structure to pandas table for external fitting codes.
+
+        The table contains the following columns:
+            - 'ase_atoms': the structure as a :class:`.Atoms` object
+            - 'energy': the energy of the full structure
+            - 'forces': the per atom forces as a :class:`numpy.ndarray`, shape Nx3
+            - 'number_of_atoms': the number of atoms in the structure, N
+
+        Returns:
+            :class:`pandas.DataFrame`: collected structures
+        """
+        return self._table
+
+    def write_input(self):
+        pass
+
+    def collect_output(self):
+        pass
+
+    def run_static(self):
+        self.status.finished = True
+
+    def run_if_interactive(self):
+        self.to_hdf()
+        self.status.finished = True
+
+    def to_hdf(self, hdf=None, group_name=None):
+        super().to_hdf(hdf=hdf, group_name=group_name)
+        self._table.to_hdf(self.project_hdf5.file_name, self.name + "/output/structure_table")
+
+    def from_hdf(self, hdf=None, group_name=None):
+        super().from_hdf(hdf=hdf, group_name=group_name)
+        self._table = pd.read_hdf(self.project_hdf5.file_name, self.name + "/output/structure_table")

--- a/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
+++ b/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
@@ -32,11 +32,11 @@ from pyiron_base import GenericJob
 
 class TrainingContainer(GenericJob):
     """
-    Stores ASE structres with energies and forces.
+    Stores ASE structures with energies and forces.
     """
 
-    def __init__(self, job_name, project):
-        super().__init__(job_name, project)
+    def __init__(self, project, job_name):
+        super().__init__(project=project, job_name=job_name)
         self._table = pd.DataFrame({
             "name": [],
             "atoms": [],

--- a/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
+++ b/pyiron_contrib/atomistic/atomistics/job/trainingcontainer.py
@@ -3,10 +3,27 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 """
-Extends the :class:`.StructureContainer` to store energies and forces with the structures.
+Store structures together with energies and forces for potential fitting applications.
+
+Basic usage:
+>>> pr = Project("training")
+>>> container = pr.create.job.TrainingContainer("small_structures")
+
+Let's make a structure and invent some forces
+>>> structure = pr.create.structure.ase_bulk("Fe")
+>>> forces = numpy.array([-1, 1, -1])
+>>> container.include_structure(structure, energy=-1.234, forces=forces, name="Fe_bcc")
+
+If you have a lot of precomputed structures you may also add them in bulk from a pandas DataFrame
+>>> df = pandas.DataFrame({ "name": "Fe_bcc", "atoms": structure, "energy": -1.234, "forces": forces })
+>>> container.include_dataset(df)
+
+You can retrieve the full database with :method:`~.TrainingContainer.to_pandas()` like this
+>>> container.to_pandas()
+    name    atoms   energy  forces  number_of_atoms
+    Fe_bcc  ...
 """
 
-import os.path
 import pandas as pd
 
 from pyiron_atomistics import pyiron_to_ase


### PR DESCRIPTION
This is the container we discussed in the meeting today.  It takes structures, energies and forces and saves them in a pandas table, which is then saved to HDF5.

For reasons beyond my mortal comprehension (and beyond what I can fix right now), pickling a dataframe with our Atoms class fails, so I left the structures as ASE atoms for now.  I will look into it next week and then change the storage accordingly, for now it'll have to do.