### PR TITLE
output and parse complete force vector

### DIFF
--- a/pyiron_contrib/atomistic/atomicrex/fit_properties.py
+++ b/pyiron_contrib/atomistic/atomicrex/fit_properties.py
@@ -26,6 +26,7 @@ class ARFitProperty(InputList):
             tolerance=None,
             min_val=None,
             max_val=None,
+            output_all=None,
             *args,
             **kwargs
     ):
@@ -44,7 +45,7 @@ class ARFitProperty(InputList):
         self.min_val = min_val
         self.max_val = max_val
         self.final_value = None
-
+        self.output_all = output_all
 
     @property
     def prop(self):
@@ -125,6 +126,8 @@ class ARFitProperty(InputList):
                 raise ValueError("Squared-relative residual style is not implemented for forces in atomicrex")
             if self.min_val is not None or self.max_val is not None:
                 raise ValueError("Min and Max val can only be given for scalar properties")
+            if self.output_all:
+                xml.set("output-all", f"{self.output_all}".lower())
             else:
                 xml.set("residual-style", f"{self.residual_style}")
         return xml
@@ -170,6 +173,7 @@ class ARFitPropertyList(InputList):
             tolerance=None,
             min_val=None,
             max_val=None,
+            output_all=True,
     ):
         """
         Adds a fittable property to the fit properties
@@ -188,8 +192,10 @@ class ARFitPropertyList(InputList):
             output (bool, optional): Determines if the value is written to output.
             Could cause parsing problems if False. Defaults to True.
             tolerance (float, optional): See atomicrex documentation. Defaults to None.
-            min_val ([type], optional): [description]. Defaults to None.
-            max_val ([type], optional): [description]. Defaults to None.
+            min_val (float, optional): Only scalar properties, if relaxation enabled. Defaults to None.
+            max_val (float, optional): Only scalar properties, if relaxation enabled. Defaults to None.
+            output_all (bool, optional): Only vector properties. Determines if full vector is written to output. Defaults to True.
+
         """    
         self[prop] = ARFitProperty(
             prop = prop,
@@ -202,6 +208,7 @@ class ARFitPropertyList(InputList):
             tolerance = tolerance,
             min_val = min_val,
             max_val = max_val,
+            output_all=output_all,
         )
 
     def to_xml_element(self):

--- a/pyiron_contrib/atomistic/atomicrex/structure_list.py
+++ b/pyiron_contrib/atomistic/atomicrex/structure_list.py
@@ -1,6 +1,7 @@
 import posixpath
 import xml.etree.ElementTree as ET
 
+import numpy as np
 from ase import Atoms as ASEAtoms
 from pyiron_base import InputList
 from pyiron import pyiron_to_ase, ase_to_pyiron, Atoms
@@ -269,16 +270,35 @@ class ARStructureList(object):
 
         Args:
             struct_lines (list[str]): lines from atomicrex output that contain structure information.
-        """        
+        """ 
+        force_vec_triggered = False   
         for l in struct_lines:
             l = l.strip()
-            if l.startswith("Structure"):
+            
+            if force_vec_triggered:
+                if l.startswith("atomic-forces:"):
+                    l = l.split()
+                    index = int(l[1])
+                    final_forces[index, 0] = float(l[2].lstrip("(").rstrip(","))
+                    final_forces[index, 1] = float(l[3].rstrip(","))
+                    final_forces[index, 2] = float(l[4].rstrip(")"))
+                else:
+                    force_vec_triggered = False
+                    s.fit_properties["atomic-forces"].final_value = final_forces
+
+            elif l.startswith("Structure"):
                 s_id = l.split("'")[1]
                 s = self._structure_dict[s_id]
+            
             else:
-                prop, f_val = ARFitProperty._parse_final_value(line=l)
-                if prop in s.fit_properties:
-                    s.fit_properties[prop].final_value = f_val
+                if not l.startswith("atomic-forces avg/max:"):
+                    prop, f_val = ARFitProperty._parse_final_value(line=l)
+                    if prop in s.fit_properties:
+                        s.fit_properties[prop].final_value = f_val
+                else:
+                    force_vec_triggered = True
+                    final_forces = np.zeros((len(s.structure), 3))
+
 
 
 def write_modified_poscar(identifier, structure, forces, directory):


### PR DESCRIPTION
Changed default behavior to print out and parse the complete force vector for every structure in the fitting process.