### PR TITLE
Use DataContainer instead of the deprecated InputList

### DIFF
--- a/pyiron_contrib/atomistic/atomicrex/fit_properties.py
+++ b/pyiron_contrib/atomistic/atomicrex/fit_properties.py
@@ -1,9 +1,9 @@
 import xml.etree.ElementTree as ET
 
-from pyiron_base import InputList
+from pyiron_base import DataContainer
 
 
-class ARFitProperty(InputList):
+class ARFitProperty(DataContainer):
     """
     Class to describe properties that can be fitted using atomicrex.
     Property and target value have to be given,
@@ -152,9 +152,9 @@ class ARFitProperty(InputList):
 
 
 
-class ARFitPropertyList(InputList):
+class ARFitPropertyList(DataContainer):
     """
-    InputList of ARFitProperties that additionally provides utility functions
+    DataContainer of ARFitProperties that additionally provides utility functions
     that allow convenient addition of fit properties to a structure.
     Also provides internal functionality.
     """

--- a/pyiron_contrib/atomistic/atomicrex/function_factory.py
+++ b/pyiron_contrib/atomistic/atomicrex/function_factory.py
@@ -4,7 +4,7 @@ import copy
 import numpy as np
 import matplotlib.pyplot as plt
 
-from pyiron_base import PyironFactory, InputList
+from pyiron_base import PyironFactory, DataContainer
 
 
 
@@ -55,7 +55,7 @@ class FunctionFactory(PyironFactory):
         return Gaussian(identifier, prefactor, eta, mu, species)
 
 
-class SpecialFunction(InputList):
+class SpecialFunction(DataContainer):
     """
     Analytic functions defined within atomicrex should inherit from this class
     https://atomicrex.org/potentials/functions.html#index-1
@@ -102,7 +102,7 @@ class SpecialFunction(InputList):
             return plot(self.func)
 
 
-class Poly(InputList):
+class Poly(DataContainer):
     """
     Polynomial interpolation function.
     """    
@@ -121,7 +121,7 @@ class Poly(InputList):
         return poly
 
 
-class Spline(InputList):
+class Spline(DataContainer):
     """
     Spline interpolation function
     """
@@ -373,7 +373,7 @@ class Gaussian(SpecialFunction):
         return super()._to_xml_element(name="morse-A")
 
 
-class UserFunction(InputList):
+class UserFunction(DataContainer):
     """
     Analytic functions that are not implemented in atomicrex
     can be provided as user functions.
@@ -421,7 +421,7 @@ class UserFunction(InputList):
             return screening
 
 
-class FunctionParameter(InputList):
+class FunctionParameter(DataContainer):
     """
     Function parameter. For detailed information
     about the attributes see the atomicrex documentation.
@@ -467,7 +467,7 @@ class FunctionParameter(InputList):
                 self.start_val = copy.copy(self.final_value)
             
 
-class FunctionParameterList(InputList):
+class FunctionParameterList(DataContainer):
     def __init__(self):
         super().__init__(table_name="FunctionParameterList")
 
@@ -531,7 +531,7 @@ class PolyCoeff(FunctionParameter):
         root.set("n", self.n)
 
 
-class PolyCoeffList(InputList):
+class PolyCoeffList(DataContainer):
     def __init__(self):
         super().__init__(table_name="PolyCoeffList")
 
@@ -586,7 +586,7 @@ class Node(FunctionParameter):
         return node
 
 
-class NodeList(InputList):
+class NodeList(DataContainer):
     def __init__(self):
         super().__init__(table_name="NodeList")
 

--- a/pyiron_contrib/atomistic/atomicrex/general_input.py
+++ b/pyiron_contrib/atomistic/atomicrex/general_input.py
@@ -4,13 +4,13 @@ import posixpath
 import numpy as np
 from ase.data import atomic_masses, atomic_numbers
 
-from pyiron_base import InputList, PyironFactory
+from pyiron_base import DataContainer, PyironFactory
 
 from pyiron_contrib.atomistic.atomicrex.utility_functions import write_pretty_xml
 from pyiron_contrib.atomistic.atomicrex.potential_factory import ARPotFactory
 from pyiron_contrib.atomistic.atomicrex.function_factory import FunctionFactory
 
-class GeneralARInput(InputList):
+class GeneralARInput(DataContainer):
     """
     Class to store general input of an atomicrex job,
     f.e. the fit algorithm.
@@ -79,9 +79,9 @@ class GeneralARInput(InputList):
         write_pretty_xml(job, file_name)
 
 
-class AtomTypes(InputList):
+class AtomTypes(DataContainer):
     """
-        InputList used to specify elements in the fit job.
+        DataContainer used to specify elements in the fit job.
         Elements can be added using dictionary or attribute syntax.
         Their value should None or a (mass, index) tuple as value.
         If value is None the mass and index are taken from the ase package.
@@ -181,7 +181,7 @@ class AlgorithmFactory(PyironFactory):
         return NloptAlgorithm(name="GN_ISRES", stopval=stopval, max_iter=max_iter, maxtime=maxtime, ftol_rel=ftol_rel, ftol_abs=ftol_abs, xtol_rel=xtol_rel, seed=seed)
 
 
-class AtomicrexAlgorithm(InputList):
+class AtomicrexAlgorithm(DataContainer):
     """
     Class to inherit from. If more algorithms will be implemented in atomicrex
     at some point they can be implemented similar to the AR_LBFGS class.
@@ -229,7 +229,7 @@ class SpaMinimizer:
         return spa
 
 
-class NloptAlgorithm(InputList):
+class NloptAlgorithm(DataContainer):
     """
     Nlopt algorithms should inherit from this class.
     """    

--- a/pyiron_contrib/atomistic/atomicrex/output.py
+++ b/pyiron_contrib/atomistic/atomicrex/output.py
@@ -1,6 +1,6 @@
-from pyiron_base import InputList
+from pyiron_base import DataContainer
 
-class Output(InputList):
+class Output(DataContainer):
     """
     Class to store general output quantities.
     Final properties and function parameter values are stored within

--- a/pyiron_contrib/atomistic/atomicrex/potential_factory.py
+++ b/pyiron_contrib/atomistic/atomicrex/potential_factory.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from pyiron_base import PyironFactory, InputList
+from pyiron_base import PyironFactory, DataContainer
 from pyiron_contrib.atomistic.atomicrex.function_factory import FunctionFactory
 from pyiron_contrib.atomistic.atomicrex.utility_functions import write_pretty_xml
 
@@ -29,7 +29,7 @@ class ARPotFactory(PyironFactory):
         return LJPotential(sigma, epsilon, cutoff, species=species, identifier=identifier)
 
 
-class AbstractPotential(InputList):
+class AbstractPotential(DataContainer):
     """Potentials should inherit from this class for hdf5 storage.
     """    
     def __init__(self, init=None, table_name="potential"):
@@ -109,9 +109,9 @@ class EAMPotential(AbstractPotential):
     def __init__(self, init=None, identifier=None, export_file=None, rho_range_factor=None, resolution=None, species=None):
         super().__init__(init=init)
         if init is None:
-            self.pair_interactions = InputList(table_name="pair_interactions")
-            self.electron_densities = InputList(table_name="electron_densities")
-            self.embedding_energies = InputList(table_name="embedding_energies")
+            self.pair_interactions = DataContainer(table_name="pair_interactions")
+            self.electron_densities = DataContainer(table_name="electron_densities")
+            self.embedding_energies = DataContainer(table_name="embedding_energies")
             self.identifier = identifier
             self.export_file = export_file
             self.rho_range_factor = rho_range_factor

--- a/pyiron_contrib/atomistic/atomicrex/structure_list.py
+++ b/pyiron_contrib/atomistic/atomicrex/structure_list.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 
 import numpy as np
 from ase import Atoms as ASEAtoms
-from pyiron_base import InputList
+from pyiron_base import DataContainer
 from pyiron import pyiron_to_ase, ase_to_pyiron, Atoms
 
 from pyiron_contrib.atomistic.atomicrex.fit_properties import ARFitPropertyList, ARFitProperty

--- a/pyiron_contrib/atomistic/runner/job.py
+++ b/pyiron_contrib/atomistic/runner/job.py
@@ -8,7 +8,7 @@ Demonstrator job for the RuNNer Neural Network Potential.
 import os.path
 from glob import glob
 
-from pyiron_base import GenericJob, Executable, Settings, InputList
+from pyiron_base import GenericJob, Executable, Settings, DataContainer
 
 import numpy as np
 import pandas as pd
@@ -33,7 +33,7 @@ class RunnerFit(GenericJob):
         super().__init__(project, job_name) 
         self._training_ids = []
 
-        self.input = InputList(table_name="input")
+        self.input = DataContainer(table_name="input")
         self.input.element = "Cu"
 
         s.publication_add(self.publication)

--- a/pyiron_contrib/image/job.py
+++ b/pyiron_contrib/image/job.py
@@ -12,7 +12,7 @@ from os.path import abspath
 
 from pyiron_contrib.image.image import Image
 from pyiron_contrib.image.utils import DistributingList
-from pyiron_base.generic.inputlist import InputList
+from pyiron_base.generic.inputlist import DataContainer
 
 from pyiron_contrib.image.custom_filters import brightness_filter
 
@@ -45,8 +45,8 @@ class ImageJob(GenericJob):
         super(ImageJob, self).__init__(project, job_name)
         self.__name__ = "ImageJob"
         self._images = DistributingList()
-        self.input = InputList(table_name ="input")
-        self.output = InputList(table_name ="output")
+        self.input = DataContainer(table_name ="input")
+        self.output = DataContainer(table_name ="output")
 
 
     @property


### PR DESCRIPTION
Following the introduction of `DataContainer` which deprecates `InputList` in [pyiron_base PR 257](https://github.com/pyiron/pyiron_base/pull/257).