### PR TITLE
Fix import of DataContainer in ImageJob

### DIFF
--- a/pyiron_contrib/image/job.py
+++ b/pyiron_contrib/image/job.py
@@ -12,7 +12,7 @@ from os.path import abspath
 
 from pyiron_contrib.image.image import Image
 from pyiron_contrib.image.utils import DistributingList
-from pyiron_base.generic.inputlist import DataContainer
+from pyiron_base import DataContainer
 
 from pyiron_contrib.image.custom_filters import brightness_filter
 


### PR DESCRIPTION
Seems that snuck past #121.  `pyiron_base.generic.inputlist` import DataContainer, so nothing should break, but I suppose it's better to import from the canonical location.