### PR TITLE
Interactive Structure Storage Master

### DIFF
--- a/pyiron_contrib/__init__.py
+++ b/pyiron_contrib/__init__.py
@@ -42,6 +42,7 @@ JOB_CLASS_DICT['Mlip'] = 'pyiron_contrib.atomistics.mlip.mlip'
 JOB_CLASS_DICT['LammpsMlip'] = 'pyiron_contrib.atomistics.mlip.lammps'
 JOB_CLASS_DICT['MlipJob'] = 'pyiron_contrib.atomistics.mlip.mlipjob'
 JOB_CLASS_DICT['Atomicrex'] = 'pyiron_contrib.atomistics.atomicrex.atomicrex_job'
+JOB_CLASS_DICT['StructureListMasterInteractive'] = 'pyiron_contrib.atomistics.atomistics.job.structurelistmasterinteractive'
 
 
 from ._version import get_versions

--- a/pyiron_contrib/__init__.py
+++ b/pyiron_contrib/__init__.py
@@ -42,7 +42,7 @@ JOB_CLASS_DICT['Mlip'] = 'pyiron_contrib.atomistics.mlip.mlip'
 JOB_CLASS_DICT['LammpsMlip'] = 'pyiron_contrib.atomistics.mlip.lammps'
 JOB_CLASS_DICT['MlipJob'] = 'pyiron_contrib.atomistics.mlip.mlipjob'
 JOB_CLASS_DICT['Atomicrex'] = 'pyiron_contrib.atomistics.atomicrex.atomicrex_job'
-JOB_CLASS_DICT['StructureListMasterInteractive'] = 'pyiron_contrib.atomistics.atomistics.job.structurelistmasterinteractive'
+JOB_CLASS_DICT['StructureMasterInt'] = 'pyiron_contrib.atomistics.atomistics.job.structurelistmasterinteractive'
 
 
 from ._version import get_versions

--- a/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
@@ -16,7 +16,7 @@ __date__ = "Jun 14, 2021"
 
 from pyiron_base import GenericMaster, DataContainer
 
-class StructureListMasterInteractive(GenericMaster):
+class StructureMasterInt(GenericMaster):
     """
     Runs given structures with given reference job.
 

--- a/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
@@ -58,7 +58,7 @@ class StructureMasterInt(GenericMaster):
         self.ref_job.validate_ready_to_run()
         copy = self.ref_job.copy_to(
                 project=self.project_hdf5,
-                new_job_name="calculator",
+                new_job_name=f"{self.name}_calculator",
                 new_database_entry=True
         )
         self.append(copy)

--- a/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
@@ -14,6 +14,7 @@ __status__ = "development"
 __date__ = "Jun 14, 2021"
 
 
+from pyiron_contrib.atomistics.atomistics.job.structurestorage import StructureStorage
 from pyiron_base import GenericMaster, DataContainer
 
 class StructureMasterInt(GenericMaster):
@@ -49,6 +50,17 @@ class StructureMasterInt(GenericMaster):
     @container.setter
     def container(self, container):
         self.input.container = container
+
+    def add_structure(self, structure):
+        """
+        Add a structure to the StructureStorage to calculate.  If no container set yet, create an empty one.
+
+        Args:
+            structure (Atoms): structure to add to calculation
+        """
+        if self.input.container is None:
+            self.input.container = StructureStorage()
+        self.input.container.add_structure(structure)
 
     def validate_ready_to_run(self):
         if self.input.container is None:

--- a/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurelistmasterinteractive.py
@@ -1,0 +1,94 @@
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+
+"""
+Job class to run a reference jobs on all structures in a given container via an interactive job.
+"""
+
+__author__ = "Marvin Poul"
+__copyright__ = "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH " \
+                "- Computational Materials Design (CM) Department"
+__version__ = "0.1"
+__maintainer__ = "Marvin Poul"
+__email__ = "poul@mpie.de"
+__status__ = "development"
+__date__ = "Jun 14, 2021"
+
+
+from pyiron_base import GenericMaster, DataContainer
+
+class StructureListMasterInteractive(GenericMaster):
+    """
+    Runs given structures with given reference job.
+
+    This example shows how to run a simple energy vs distance calculation for a dimer.
+
+    >>> from pyiron_atomistics import Project
+    >>> from pyiron_contrib.atomistics.atomistics.job.structurestorage import StructureStorage
+    >>> pr = Project("container")
+    >>> container = StructureStorage()
+    >>> for d in [0.7, 0.8, 0.9, 1, 1.1, 1.2]:
+    ...     container.add_structure(pr.create.structure.atoms(["Fe", "Fe"], positions=[[0,0,0], [0,0,d]], cell=[10,10,10])
+    >>> ref = pr.create.job.Lammps("ref")
+    >>> ref.structure = container.get_structure()
+    >>> ref.calc_static()
+    >>> master = pr.create.job.StructureContainerInteractive("master")
+    >>> master.container = container
+    >>> master.ref_job = ref
+    >>> master.run()
+    """
+
+    def __init__(self, project=None, job_name=None):
+        super().__init__(project=project, job_name=job_name)
+        self.input = DataContainer(table_name="parameters")
+        self.input.container = None
+
+    @property
+    def container(self):
+        return self.input.container
+
+    @container.setter
+    def container(self, container):
+        self.input.container = container
+
+    def validate_ready_to_run(self):
+        if self.input.container is None:
+            raise ValueError("No structure container set!")
+        if self.ref_job is None:
+            raise ValueError("No reference job set!")
+        self.ref_job.validate_ready_to_run()
+        copy = self.ref_job.copy_to(
+                project=self.project_hdf5,
+                new_job_name="calculator",
+                new_database_entry=True
+        )
+        self.append(copy)
+
+
+    def run_static(self):
+        self.status.running = True
+
+        j = self.pop()
+
+        j.interactive_open()
+        j.interactive_enforce_structure_reset = True
+        for structure in self.container.iter_structures():
+            j.structure = structure
+            j.run()
+        j.interactive_close()
+
+        self.status.collect = True
+        self.run()
+
+    def collect_output(self):
+        self.to_hdf()
+
+    def write_input(self):
+        pass
+
+    def to_hdf(self, hdf=None, group_name=None):
+        super().to_hdf(hdf=hdf, group_name=group_name)
+        self.input.to_hdf(hdf=self.project_hdf5)
+
+    def from_hdf(self, hdf=None, group_name=None):
+        super().from_hdf(hdf=hdf, group_name=group_name)
+        self.input.from_hdf(hdf=self.project_hdf5)


### PR DESCRIPTION
Add a new job class like `StructureListMaster` from `pyiron_atomistics`, but using `StructureStorage` and an interactive job.

It's not quite done yet, but I wanted to discuss three issues:
1. the interactive reference job lives next to the master for now, because I couldn't figure out how to make it a child job.  @raynol-dsouza I imagine the protocols do similar setups all the time, how is it handled there?
2. There's no output on the master yet, how do we usually forward output from child jobs to master jobs.  Should I overload `master.output` to look into `master.ref_job.output` or do we copy the HDF5 content directly?
3. `VaspInteractive` doesn't seem to support `interactive_enforce_structure_reset`.  Is that because VASP can't deal with arbitrary structures during an interactive run (sphinx can) or is it not needed in this case? (Maybe @sudarsan-surendralal?)