### PR TITLE
Fix copy final to initial params

### DIFF
--- a/pyiron_contrib/atomistics/atomicrex/function_factory.py
+++ b/pyiron_contrib/atomistics/atomicrex/function_factory.py
@@ -58,8 +58,18 @@ class FunctionFactory(PyironFactory):
     def sum(identifier, species=["*", "*"]):
         return Sum(identifier=identifier, species=species)
 
+class BaseFunctionMixin():
+    def copy_final_to_initial_params(self):
+        for param in self.parameters.values():
+            param.copy_final_to_start_value()
 
-class Sum(DataContainer):
+class MetaFunctionMixin():
+    def copy_final_to_initial_params(self):
+        for f in self.functions.values():
+            f.copy_final_to_inital_params()
+
+
+class Sum(DataContainer, MetaFunctionMixin):
     def __init__(self, identifier=None, species=None):
         super().__init__()
         self.identifier = identifier
@@ -82,7 +92,7 @@ class Sum(DataContainer):
             raise KeyError(f"Function {identifier} not found in sum {self.identifier}")
 
 
-class SpecialFunction(DataContainer):
+class SpecialFunction(DataContainer, BaseFunctionMixin):
     """
     Analytic functions defined within atomicrex should inherit from this class
     https://atomicrex.org/potentials/functions.html#index-1
@@ -136,7 +146,7 @@ class SpecialFunction(DataContainer):
         param = leftover[0].rstrip(":")
         self.parameters[param].final_value = value
 
-class Poly(DataContainer):
+class Poly(DataContainer, BaseFunctionMixin):
     """
     Polynomial interpolation function.
     """    
@@ -155,7 +165,7 @@ class Poly(DataContainer):
         return poly
 
 
-class Spline(DataContainer):
+class Spline(DataContainer, BaseFunctionMixin):
     """
     Spline interpolation function
     """
@@ -468,7 +478,7 @@ class GaussianFunc(SpecialFunction):
         return super()._to_xml_element(name="gaussian")
 
 
-class UserFunction(DataContainer):
+class UserFunction(DataContainer, BaseFunctionMixin):
     """
     Analytic functions that are not implemented in atomicrex
     can be provided as user functions.

--- a/pyiron_contrib/atomistics/atomicrex/function_factory.py
+++ b/pyiron_contrib/atomistics/atomicrex/function_factory.py
@@ -66,7 +66,7 @@ class BaseFunctionMixin():
 class MetaFunctionMixin():
     def copy_final_to_initial_params(self):
         for f in self.functions.values():
-            f.copy_final_to_inital_params()
+            f.copy_final_to_initial_params()
 
 
 class Sum(DataContainer, MetaFunctionMixin):

--- a/pyiron_contrib/atomistics/atomicrex/potential_factory.py
+++ b/pyiron_contrib/atomistics/atomicrex/potential_factory.py
@@ -506,8 +506,8 @@ class EAMPotential(AbstractPotential):
         """        
         for functions in (self.pair_interactions, self.electron_densities, self.embedding_energies):
             for f in functions.values():
-                for param in f.parameters.values():
-                    param.copy_final_to_start_value()
+                f.copy_final_to_initial_params()
+                
 
     def _potential_as_pd_df(self, job):
         """


### PR DESCRIPTION
copying final to initial parameters broke for Sum functions. This fixes it and uses Mixin classes for the functionality to clean up the code