### PR TITLE
Add a method 'has_array' to StructureStorage to check for existance of array

### DIFF
--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -165,55 +165,6 @@ class StructureStorage(HasStructure):
         end = start + self._per_structure_arrays["length"][frame]
         return slice(start, end, 1)
 
-    def get_array(self, name, frame):
-        """
-        Fetch array for given structure.
-
-        Works for per atom and per arrays.
-
-        Args:
-            name (str): name of the array to fetch
-            frame (int, str): selects structure to fetch, as in :method:`.get_structure()`
-
-        Returns:
-            :class:`numpy.ndarray`: requested array
-
-        Raises:
-            `KeyError`: if array with name does not exists
-        """
-
-        if isinstance(frame, str):
-            frame = self._translate_frame(frame)
-        if name in self._per_atom_arrays:
-            return self._per_atom_arrays[name][self._get_per_atom_slice(frame)]
-        elif name in self._per_structure_arrays:
-            return self._per_structure_arrays[name][frame]
-        else:
-            raise KeyError(f"no array named {name} defined on StructureStorage")
-
-    def set_array(self, name, frame, value):
-        """
-        Add array for given structure.
-
-        Works for per atom and per arrays.
-
-        Args:
-            name (str): name of array to set
-            frame (int, str): selects structure to set, as in :method:`.get_strucure()`
-
-        Raises:
-            `KeyError`: if array with name does not exists
-        """
-
-        if isinstance(frame, str):
-            frame = self._translate_frame(frame)
-        if name in self._per_atom_arrays:
-            self._per_atom_arrays[name][self._get_per_atom_slice(frame)] = value
-        elif name in self._per_structure_arrays:
-            self._per_structure_arrays[name][frame] = value
-        else:
-            raise KeyError(f"no array named {name} defined on StructureStorage")
-
     def _resize_atoms(self, new):
         self._num_atoms_alloc = new
         for k, a in self._per_atom_arrays.items():
@@ -288,6 +239,83 @@ class StructureStorage(HasStructure):
             store[name] = np.empty(shape=shape, dtype=dtype)
         else:
             store[name] = np.full(shape=shape, fill_value=fill, dtype=dtype)
+
+    def get_array(self, name, frame):
+        """
+        Fetch array for given structure.
+
+        Works for per atom and per arrays.
+
+        Args:
+            name (str): name of the array to fetch
+            frame (int, str): selects structure to fetch, as in :method:`.get_structure()`
+
+        Returns:
+            :class:`numpy.ndarray`: requested array
+
+        Raises:
+            `KeyError`: if array with name does not exists
+        """
+
+        if isinstance(frame, str):
+            frame = self._translate_frame(frame)
+        if name in self._per_atom_arrays:
+            return self._per_atom_arrays[name][self._get_per_atom_slice(frame)]
+        elif name in self._per_structure_arrays:
+            return self._per_structure_arrays[name][frame]
+        else:
+            raise KeyError(f"no array named {name} defined on StructureStorage")
+
+    def set_array(self, name, frame, value):
+        """
+        Add array for given structure.
+
+        Works for per atom and per arrays.
+
+        Args:
+            name (str): name of array to set
+            frame (int, str): selects structure to set, as in :method:`.get_strucure()`
+
+        Raises:
+            `KeyError`: if array with name does not exists
+        """
+
+        if isinstance(frame, str):
+            frame = self._translate_frame(frame)
+        if name in self._per_atom_arrays:
+            self._per_atom_arrays[name][self._get_per_atom_slice(frame)] = value
+        elif name in self._per_structure_arrays:
+            self._per_structure_arrays[name][frame] = value
+        else:
+            raise KeyError(f"no array named {name} defined on StructureStorage")
+
+    def has_array(self, name):
+        """
+        Checks whether an array of the given name exists and returns meta data given to :method:`.add_array()`.
+
+
+        >>> container.has_array("energy")
+        {'shape': (), 'dtype': np.float64, 'per': 'atom'}
+        >>> container.has_array("fnorble")
+        None
+
+        Args:
+            name (str): name of the array to check
+
+        Returns:
+            None: if array does not exist
+            dict: if array exists, 
+        """
+        if name in self._per_atom_arrays:
+            a = self._per_atom_arrays[name]
+            per = "atom"
+        elif name in self._per_structure_arrays:
+            a = self._per_structure_arrays[name]
+            per = "structure"
+        else:
+            return None
+        return {shape: a.shape[1:], "dtype": a.dtype, "per": per}
+
 
     def add_structure(self, structure, identifier=None, **arrays):
         """

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -314,7 +314,7 @@ class StructureStorage(HasStructure):
             per = "structure"
         else:
             return None
-        return {shape: a.shape[1:], "dtype": a.dtype, "per": per}
+        return {"shape": a.shape[1:], "dtype": a.dtype, "per": per}
 
 
     def add_structure(self, structure, identifier=None, **arrays):

--- a/tests/atomistics/job/test_structurestorage.py
+++ b/tests/atomistics/job/test_structurestorage.py
@@ -104,6 +104,8 @@ class TestContainer(TestWithProject):
         self.assertEqual(pbc["shape"], (3,), "has_array returns wrong shape for per atom array.")
         self.assertEqual(pbc["per"], "atom", "has_array returns wrong per for per atom array.")
 
+        self.assertEqual(self.cont.has_array("missing"), None, "has_array does not return None for nonexisting array.")
+
     def test_get_structure(self):
         """Structure from get_structure should match thoes add with add_structure exactly."""
 

--- a/tests/atomistics/job/test_structurestorage.py
+++ b/tests/atomistics/job/test_structurestorage.py
@@ -91,6 +91,19 @@ class TestContainer(TestWithProject):
             self.assertTrue(np.allclose(self.cont.get_array("positions", i), structure.positions),
                             f"set_array modified arrray for different structure than instructured.")
 
+    def test_has_array(self):
+        """hasarray should return correct information for added array; None otherwise."""
+
+        pbc = self.cont.has_array("pbc")
+        self.assertEqual(pbc["dtype"], bool, "has_array returns wrong dtype for per structure array.")
+        self.assertEqual(pbc["shape"], (3,), "has_array returns wrong shape for per structure array.")
+        self.assertEqual(pbc["per"], "structure", "has_array returns wrong per for per structure array.")
+
+        pbc = self.cont.has_array("positions")
+        self.assertEqual(pbc["dtype"], np.float64, "has_array returns wrong dtype for per atom array.")
+        self.assertEqual(pbc["shape"], (3,), "has_array returns wrong shape for per atom array.")
+        self.assertEqual(pbc["per"], "atom", "has_array returns wrong per for per atom array.")
+
     def test_get_structure(self):
         """Structure from get_structure should match thoes add with add_structure exactly."""
 


### PR DESCRIPTION
As the title says, this gives you a way to check if you need to create a new array (via `add_array`) and then populate it (via `set_array`) or if it already exists.  This is useful if you're adding computationally costly arrays in a notebook or workflow and want to skip it if already there.