### PR TITLE
Extract FlattenedStorage from StructureStorage

### DIFF
--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -15,64 +15,6 @@ from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
 
 class FlattenedStorage:
-    """
-    Class that can write and read lots of structures from and to hdf quickly.
-
-    This is done by storing positions, cells, etc. into large arrays instead of writing every structure into a new
-    group.  Structures are stored together with an identifier that should be unique.  The class can be initialized with
-    the number of structures and the total number of atoms in all structures, but re-allocates memory as necessary when
-    more (or larger) structures are added than initially anticipated.
-
-    You can add structures and a human-readable name with :method:`.add_structure()`.
-
-    >>> container = StructureStorage()
-    >>> container.add_structure(Atoms(...), "fcc")
-    >>> container.add_structure(Atoms(...), "hcp")
-    >>> container.add_structure(Atoms(...), "bcc")
-
-    Accessing stored structures works with :method:`.get_strucure()`.  You can either pass the identifier you passed
-    when adding the structure or the numeric index
-
-    >>> container.get_structure(frame=0) == container.get_structure(frame="fcc")
-    True
-
-    Custom arrays may also be defined on the container
-
-    >>> container.add_array("energy", shape=(), dtype=np.float64, fill=-1, per="structure")
-
-    You can then pass arrays of the corresponding shape to :method:`add_structure()`
-
-    >>> container.add_structure(Atoms(...), "grain_boundary", energy=3.14)
-
-    Saved arrays are accessed with :method:`.get_array()`
-
-    >>> container.get_array("energy", 3)
-    3.14
-    >>> container.get_array("energy", 0)
-    -1
-
-    It is also possible to use the same names in :method:`.get_array()` as in :method:`.get_structure()`.
-
-    >>> container.get_array("energy", 0) == container.get_array("energy", "fcc")
-    True
-
-    The length of the container is the number of structures inside it.
-
-    >>> len(container)
-    4
-
-    By default the following arrays are defined for each structure:
-        - identifier    shape=(),    dtype=str,          per structure; human readable name of the structure
-        - cell          shape=(3,3), dtype=np.float64,   per structure; cell shape
-        - pbc           shape=(3,),  dtype=bool          per structure; periodic boundary conditions
-        - symbols:      shape=(),    dtype=str,          per atom; chemical symbol
-        - positions:    shape=(3,),  dtype=np.float64,   per atom: atomic positions
-    If a structure has spins/magnetic moments defined on its atoms these will be saved in a per atom array as well.  In
-    that case, however all structures in the container must either have all collinear spins or all non-collinear spins.
-
-    When adding new array follow the convention that per-structure arrays should be named in singular and per-atom
-    arrays should be named in plural.
-    """
 
     __version__ = "0.1.0"
     __hdf_version__ = "0.1.0"
@@ -404,6 +346,64 @@ class FlattenedStorage:
 
 
 class StructureStorage(FlattenedStorage, HasStructure):
+    """
+    Class that can write and read lots of structures from and to hdf quickly.
+
+    This is done by storing positions, cells, etc. into large arrays instead of writing every structure into a new
+    group.  Structures are stored together with an identifier that should be unique.  The class can be initialized with
+    the number of structures and the total number of atoms in all structures, but re-allocates memory as necessary when
+    more (or larger) structures are added than initially anticipated.
+
+    You can add structures and a human-readable name with :method:`.add_structure()`.
+
+    >>> container = StructureStorage()
+    >>> container.add_structure(Atoms(...), "fcc")
+    >>> container.add_structure(Atoms(...), "hcp")
+    >>> container.add_structure(Atoms(...), "bcc")
+
+    Accessing stored structures works with :method:`.get_strucure()`.  You can either pass the identifier you passed
+    when adding the structure or the numeric index
+
+    >>> container.get_structure(frame=0) == container.get_structure(frame="fcc")
+    True
+
+    Custom arrays may also be defined on the container
+
+    >>> container.add_array("energy", shape=(), dtype=np.float64, fill=-1, per="structure")
+
+    You can then pass arrays of the corresponding shape to :method:`add_structure()`
+
+    >>> container.add_structure(Atoms(...), "grain_boundary", energy=3.14)
+
+    Saved arrays are accessed with :method:`.get_array()`
+
+    >>> container.get_array("energy", 3)
+    3.14
+    >>> container.get_array("energy", 0)
+    -1
+
+    It is also possible to use the same names in :method:`.get_array()` as in :method:`.get_structure()`.
+
+    >>> container.get_array("energy", 0) == container.get_array("energy", "fcc")
+    True
+
+    The length of the container is the number of structures inside it.
+
+    >>> len(container)
+    4
+
+    By default the following arrays are defined for each structure:
+        - identifier    shape=(),    dtype=str,          per structure; human readable name of the structure
+        - cell          shape=(3,3), dtype=np.float64,   per structure; cell shape
+        - pbc           shape=(3,),  dtype=bool          per structure; periodic boundary conditions
+        - symbols:      shape=(),    dtype=str,          per atom; chemical symbol
+        - positions:    shape=(3,),  dtype=np.float64,   per atom: atomic positions
+    If a structure has spins/magnetic moments defined on its atoms these will be saved in a per atom array as well.  In
+    that case, however all structures in the container must either have all collinear spins or all non-collinear spins.
+
+    When adding new array follow the convention that per-structure arrays should be named in singular and per-atom
+    arrays should be named in plural.
+    """
 
     @property
     def symbols(self):

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -116,41 +116,6 @@ class FlattenedStorage:
                 "pbc": np.empty((self._num_atoms_alloc, 3), dtype=bool)
         }
 
-    @property
-    def symbols(self):
-        """:meta private:"""
-        return self._per_atom_arrays["symbols"]
-
-    @property
-    def positions(self):
-        """:meta private:"""
-        return self._per_atom_arrays["positions"]
-
-    @property
-    def start_index(self):
-        """:meta private:"""
-        return self._per_structure_arrays["start_index"]
-
-    @property
-    def length(self):
-        """:meta private:"""
-        return self._per_structure_arrays["length"]
-
-    @property
-    def identifier(self):
-        """:meta private:"""
-        return self._per_structure_arrays["identifier"]
-
-    @property
-    def cell(self):
-        """:meta private:"""
-        return self._per_structure_arrays["cell"]
-
-    @property
-    def pbc(self):
-        """:meta private:"""
-        return self._per_structure_arrays["pbc"]
-
     def get_elements(self):
         """
         Return a list of chemical elements in the training set.
@@ -439,6 +404,41 @@ class FlattenedStorage:
 
 
 class StructureStorage(FlattenedStorage, HasStructure):
+
+    @property
+    def symbols(self):
+        """:meta private:"""
+        return self._per_atom_arrays["symbols"]
+
+    @property
+    def positions(self):
+        """:meta private:"""
+        return self._per_atom_arrays["positions"]
+
+    @property
+    def start_index(self):
+        """:meta private:"""
+        return self._per_structure_arrays["start_index"]
+
+    @property
+    def length(self):
+        """:meta private:"""
+        return self._per_structure_arrays["length"]
+
+    @property
+    def identifier(self):
+        """:meta private:"""
+        return self._per_structure_arrays["identifier"]
+
+    @property
+    def cell(self):
+        """:meta private:"""
+        return self._per_structure_arrays["cell"]
+
+    @property
+    def pbc(self):
+        """:meta private:"""
+        return self._per_structure_arrays["pbc"]
 
     def _translate_frame(self, frame):
         for i, name in enumerate(self._per_structure_arrays["identifier"]):

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -295,6 +295,36 @@ class FlattenedStorage:
             store[name] = np.full(shape=shape, fill_value=fill, dtype=dtype)
 
     def add_chunk(self, chunk_length, identifier=None, **arrays):
+        """
+        Add a new chunk to the storeage.
+
+        Additional keyword arguments given specify arrays to store for the chunk.  If an array with the given keyword
+        name does not exist yet, it will be added to the container.
+
+        >>> container = FlattenedStorage()
+        >>> container.add_chunk(2, identifier="A", energy=3.14)
+        >>> container.get_array("energy", 0)
+        3.14
+
+        If the first axis of the extra array matches the length of the chunk, it will be added as an per element array,
+        otherwise as an per chunk array.
+
+        >>> container.add_chunk(2, identifier="B", forces=2 * [[0,0,0]])
+        >>> len(container.get_array("forces", 1)) == 2
+        True
+
+        Reshaping the array to have the first axis be length 1 forces the array to be set as per chunk array.  That axis
+        will then be stripped.
+
+        >>> container.add_chunk(2, identifier="C", pressure=np.eye(3)[np.newaxis, :, :])
+        >>> container.get_array("pressure", 2).shape
+        (3, 3)
+
+        Args:
+            chunk_length (int): length of the new chunk
+            identifier (str, optional): human-readable name for the chunk, if None use current chunk index as string
+            **kwargs: additional arrays to store for the chunk
+        """
 
         if identifier is None:
             identifier = str(self.num_chunks)

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -249,14 +249,15 @@ class FlattenedStorage:
         # len of structure to index into the initialized arrays
         i = self.current_atom_index + n
 
-        self._per_atom_arrays["symbols"][self.current_atom_index:i] = np.array(structure.symbols)
-        self._per_atom_arrays["positions"][self.current_atom_index:i] = structure.positions
-
         self._per_structure_arrays["start_index"][self.current_structure_index] = self.current_atom_index
         self._per_structure_arrays["length"][self.current_structure_index] = n
-        self._per_structure_arrays["identifier"][self.current_structure_index] = identifier
-        self._per_structure_arrays["cell"][self.current_structure_index] = structure.cell.array
-        self._per_structure_arrays["pbc"][self.current_structure_index] = structure.pbc
+
+        self.set_array("symbols", self.current_structure_index, np.array(structure.symbols))
+        self.set_array("positions", self.current_structure_index, structure.positions)
+
+        self.set_array("identifier", self.current_structure_index, identifier)
+        self.set_array("cell", self.current_structure_index, structure.cell.array)
+        self.set_array("pbc", self.current_structure_index, structure.pbc)
 
         if structure.spins is not None:
             arrays["spins"] = structure.spins

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -239,11 +239,11 @@ class FlattenedStorage:
 
         Adding an array with the same name twice is ignored, if dtype and shape match, otherwise raises an exception.
 
-        >>> container = StructureStorage()
-        >>> container.add_chunk(Atoms(...), "foo")
-        >>> container.add_array("energy", shape=(), dtype=np.float64, fill=42, per="chunk")
-        >>> container.get_array("energy", 0)
-        42
+        >>> store = FlattenedStorage()
+        >>> store.add_chunk(1, "foo")
+        >>> store.add_array("energy", shape=(), dtype=np.float64, fill=42, per="chunk")
+        >>> store.get_array("energy", 0)
+        42.0
 
         Args:
             name (str): name of the new array

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -87,6 +87,11 @@ class FlattenedStorage:
     119
     >>> store.get_array("even", 3)
     array([14, 16, 18, 20])
+
+    It is usually not necessary to call :method:`.add_array` before :method:`.add_chunk`, the type of the array will be
+    inferred in this case.
+
+    Arrays may be of more complicated shape, too, see :method:`.add_array` for details.
     """
 
     __version__ = "0.1.0"

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -130,15 +130,6 @@ class FlattenedStorage:
     def __len__(self):
         return self.current_chunk_index
 
-    def get_elements(self):
-        """
-        Return a list of chemical elements in the training set.
-
-        Returns:
-            :class:`list`: list of unique elements in the training set as strings of their standard abbreviations
-        """
-        return list(set(self._per_element_arrays["symbols"]))
-
     def _get_per_element_slice(self, frame):
         start = self._per_chunk_arrays["start_index"][frame]
         end = start + self._per_chunk_arrays["length"][frame]
@@ -502,6 +493,16 @@ class StructureStorage(FlattenedStorage, HasStructure):
     def pbc(self):
         """:meta private:"""
         return self._per_chunk_arrays["pbc"]
+
+
+    def get_elements(self):
+        """
+        Return a list of chemical elements in the training set.
+
+        Returns:
+            :class:`list`: list of unique elements in the training set as strings of their standard abbreviations
+        """
+        return list(set(self._per_element_arrays["symbols"]))
 
     def add_structure(self, structure, identifier=None, **arrays):
         """

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -212,10 +212,12 @@ class FlattenedStorage:
 
         if per == "structure":
             per = "chunk"
-            warnings.warn("per=\"structure\" is deprecated, use pr=\"chunk\"", category=DeprecationWarning)
+            warnings.warn("per=\"structure\" is deprecated, use pr=\"chunk\"",
+                          category=DeprecationWarning, stacklevel=2)
         if per == "atom":
             per = "element"
-            warnings.warn("per=\"atom\" is deprecated, use pr=\"element\"", category=DeprecationWarning)
+            warnings.warn("per=\"atom\" is deprecated, use pr=\"element\"",
+                          category=DeprecationWarning, stacklevel=2)
 
         if name in self._per_element_arrays:
             a = self._per_element_arrays[name]

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -14,7 +14,7 @@ import h5py
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
 
-class StructureStorage(HasStructure):
+class FlattenedStorage(HasStructure):
     """
     Class that can write and read lots of structures from and to hdf quickly.
 
@@ -471,3 +471,6 @@ class StructureStorage(HasStructure):
 
     def _number_of_structures(self):
         return len(self)
+
+class StructureStorage(FlattenedStorage):
+    pass

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -333,9 +333,8 @@ class FlattenedStorage:
         """
         Checks whether an array of the given name exists and returns meta data given to :method:`.add_array()`.
 
-
         >>> container.has_array("energy")
-        {'shape': (), 'dtype': np.float64, 'per': 'atom'}
+        {'shape': (), 'dtype': np.float64, 'per': 'chunk'}
         >>> container.has_array("fnorble")
         None
 

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -252,12 +252,12 @@ class FlattenedStorage:
         self._per_structure_arrays["start_index"][self.current_structure_index] = self.current_atom_index
         self._per_structure_arrays["length"][self.current_structure_index] = n
 
-        self.set_array("symbols", self.current_structure_index, np.array(structure.symbols))
-        self.set_array("positions", self.current_structure_index, structure.positions)
+        arrays["symbols"] = np.array(structure.symbols)
+        arrays["positions"] = structure.positions
 
-        self.set_array("identifier", self.current_structure_index, identifier)
-        self.set_array("cell", self.current_structure_index, structure.cell.array)
-        self.set_array("pbc", self.current_structure_index, structure.pbc)
+        arrays["identifier"] = identifier
+        arrays["cell"] = structure.cell.array
+        arrays["pbc"] = structure.pbc
 
         if structure.spins is not None:
             arrays["spins"] = structure.spins
@@ -321,7 +321,6 @@ class FlattenedStorage:
                                              dtype=h5py.string_dtype('utf8', a.dtype.itemsize))
                 else:
                     hdf_arrays[k] = a
-
 
     def from_hdf(self, hdf, group_name="flat_storage"):
         with hdf.open(group_name) as hdf_s_lst:
@@ -441,6 +440,7 @@ class StructureStorage(FlattenedStorage, HasStructure):
         """:meta private:"""
         return self._per_structure_arrays["pbc"]
 
+
     def _translate_frame(self, frame):
         for i, name in enumerate(self._per_structure_arrays["identifier"]):
             if name == frame:
@@ -462,6 +462,7 @@ class StructureStorage(FlattenedStorage, HasStructure):
 
     def _number_of_structures(self):
         return len(self)
+
 
     def to_hdf(self, hdf, group_name="structures"):
         # just overwrite group_name default

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -196,7 +196,7 @@ class FlattenedStorage:
         else:
             store[name] = np.full(shape=shape, fill_value=fill, dtype=dtype)
 
-    def add_structure(self, chunk_length, identifier=None, **arrays):
+    def add_chunk(self, chunk_length, identifier=None, **arrays):
 
         if identifier is None:
             identifier = str(self.num_structures)
@@ -437,13 +437,13 @@ class StructureStorage(FlattenedStorage, HasStructure):
         if structure.spins is not None:
             arrays["spins"] = structure.spins
 
-        super().add_structure(len(structure),
-                              identifier=identifier,
-                              symbols=np.array(structure.symbols),
-                              positions=structure.positions,
-                              cell=structure.cell.array,
-                              pbc=structure.pbc,
-                              **arrays)
+        self.add_chunk(len(structure),
+                       identifier=identifier,
+                       symbols=np.array(structure.symbols),
+                       positions=structure.positions,
+                       cell=structure.cell.array,
+                       pbc=structure.pbc,
+                       **arrays)
 
 
     def _translate_frame(self, frame):

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -41,23 +41,17 @@ class FlattenedStorage:
 
         self._init_arrays()
 
-    def __len__(self):
-        return self.current_chunk_index
-
     def _init_arrays(self):
-        self._per_element_arrays = {
-                # 2 character unicode array for chemical symbols
-                "symbols": np.full(self._num_elements_alloc, "XX", dtype=np.dtype("U2")),
-                "positions": np.empty((self._num_elements_alloc, 3))
-        }
+        self._per_element_arrays = {}
 
         self._per_chunk_arrays = {
                 "start_index": np.empty(self._num_chunks_alloc, dtype=np.int32),
                 "length": np.empty(self._num_chunks_alloc, dtype=np.int32),
-                "identifier": np.empty(self._num_chunks_alloc, dtype=np.dtype("U20")),
-                "cell": np.empty((self._num_chunks_alloc, 3, 3)),
-                "pbc": np.empty((self._num_elements_alloc, 3), dtype=bool)
+                "identifier": np.empty(self._num_chunks_alloc, dtype=np.dtype("U20"))
         }
+
+    def __len__(self):
+        return self.current_chunk_index
 
     def get_elements(self):
         """
@@ -383,6 +377,16 @@ class StructureStorage(FlattenedStorage, HasStructure):
             num_structures (int): number of structures to pre-allocate
         """
         super().__init__(num_elements=num_atoms, num_chunks=num_structures)
+
+    def _init_arrays(self):
+        super()._init_arrays()
+        # 2 character unicode array for chemical symbols
+        self._per_element_arrays["symbols"] = np.full(self._num_elements_alloc, "XX", dtype=np.dtype("U2"))
+        self._per_element_arrays["positions"] = np.empty((self._num_elements_alloc, 3))
+
+        self._per_chunk_arrays["cell"] = np.empty((self._num_chunks_alloc, 3, 3))
+        self._per_chunk_arrays["pbc"] = np.empty((self._num_elements_alloc, 3), dtype=bool)
+
 
     @property
     def symbols(self):

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -14,7 +14,7 @@ import h5py
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
 
-class FlattenedStorage(HasStructure):
+class FlattenedStorage:
     """
     Class that can write and read lots of structures from and to hdf quickly.
 
@@ -450,6 +450,8 @@ class FlattenedStorage(HasStructure):
                 self._per_structure_arrays["pbc"] = np.full((self.num_structures, 3), True)
 
 
+class StructureStorage(FlattenedStorage, HasStructure):
+
     def _translate_frame(self, frame):
         for i, name in enumerate(self._per_structure_arrays["identifier"]):
             if name == frame:
@@ -471,6 +473,3 @@ class FlattenedStorage(HasStructure):
 
     def _number_of_structures(self):
         return len(self)
-
-class StructureStorage(FlattenedStorage):
-    pass

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -344,14 +344,14 @@ class FlattenedStorage:
 
         Returns:
             None: if array does not exist
-            dict: if array exists, 
+            dict: if array exists, keys corresponds to the shape, dtype and per arguments of :method:`.add_array`
         """
         if name in self._per_element_arrays:
             a = self._per_element_arrays[name]
-            per = "atom"
+            per = "element"
         elif name in self._per_chunk_arrays:
             a = self._per_chunk_arrays[name]
-            per = "structure"
+            per = "chunk"
         else:
             return None
         return {"shape": a.shape[1:], "dtype": a.dtype, "per": per}

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -157,7 +157,6 @@ class FlattenedStorage:
             # values in chunk_list may either be a sequence of chunk_length, scalars (see hasattr check) or a sequence of
             # length 1
             if any(hasattr(c, '__len__') and len(c) != chunk_length and len(c) != 1 for c in chunk_list):
-                # breakpoint()
                 raise ValueError("Inconsistent chunk length in initializer!")
             self.add_chunk(chunk_length, **{k: c for k, c in zip(keys, chunk_list)})
 

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -253,14 +253,14 @@ class FlattenedStorage:
 
         if name in self._per_element_arrays:
             a = self._per_element_arrays[name]
-            if a.shape[1:] != shape or a.dtype != dtype or per != "element":
+            if a.shape[1:] != shape or not np.can_cast(dtype, a.dtype) or per != "element":
                 raise ValueError(f"Array with name '{name}' exists with shape {a.shape[1:]} and dtype {a.dtype}.")
             else:
                 return
 
         if name in self._per_chunk_arrays:
             a = self._per_chunk_arrays[name]
-            if a.shape[1:] != shape or a.dtype != dtype or per != "chunk":
+            if a.shape[1:] != shape or not np.can_cast(dtype, a.dtype) or per != "chunk":
                 raise ValueError(f"Array with name '{name}' exists with shape {a.shape[1:]} and dtype {a.dtype}.")
             else:
                 return

--- a/pyiron_contrib/atomistics/atomistics/job/trainingcontainer.py
+++ b/pyiron_contrib/atomistics/atomistics/job/trainingcontainer.py
@@ -48,8 +48,8 @@ class TrainingContainer(GenericJob, HasStructure):
         self.__name__ = "TrainingContainer"
         self.__hdf_version__ = "0.2.0"
         self._container = StructureStorage()
-        self._container.add_array("energy", dtype=np.float64, per="structure")
-        self._container.add_array("forces", shape=(3,), dtype=np.float64, per="atom")
+        self._container.add_array("energy", dtype=np.float64, per="chunk")
+        self._container.add_array("forces", shape=(3,), dtype=np.float64, per="element")
         self._table_cache = None
 
     @property

--- a/tests/atomistics/job/test_structurestorage.py
+++ b/tests/atomistics/job/test_structurestorage.py
@@ -92,6 +92,21 @@ class TestFlattenedStorage(TestWithProject):
         with self.assertRaises(ValueError, msg="No error on initializers of different length!"):
             FlattenedStorage(foo=[ [1] ], bar=[ [2], [2, 3] ])
 
+    def test_find_chunk(self):
+        """find_chunk() should return the correct indices given an identifier."""
+
+        store = FlattenedStorage()
+        store.add_chunk(2, "first", integers=[1, 2])
+        store.add_chunk(3, integers=[3, 4, 5])
+        store.add_chunk(1, "third", integers=[5])
+
+        self.assertEqual(store.find_chunk("first"), 0, "Incorrect chunk index returned!")
+        self.assertEqual(store.find_chunk("1"), 1, "Incorrect chunk index returned for unamed identifier!")
+        self.assertEqual(store.find_chunk("third"), 2, "Incorrect chunk index returned!")
+
+        with self.assertRaises(KeyError, msg="No KeyError raised on non-existing identifier!"):
+            store.find_chunk("asdf")
+
 class TestContainer(TestWithProject):
 
     @classmethod

--- a/tests/atomistics/job/test_structurestorage.py
+++ b/tests/atomistics/job/test_structurestorage.py
@@ -14,8 +14,8 @@ class TestFlattenedStorage(TestWithProject):
         """Custom arrays added with add_array should be properly allocated with matching shape, dtype and fill"""
 
         self.store.add_array("energy", per="chunk")
-        self.store.add_array("forces", shape=(3,), per="atom")
-        self.store.add_array("fnorble", shape=(), dtype=np.int64, fill=0, per="atom")
+        self.store.add_array("forces", shape=(3,), per="element")
+        self.store.add_array("fnorble", shape=(), dtype=np.int64, fill=0, per="element")
 
         self.assertTrue("energy" in self.store._per_chunk_arrays,
                         "no 'energy' array present after adding it with add_array()")
@@ -32,7 +32,7 @@ class TestFlattenedStorage(TestWithProject):
         self.assertTrue((self.store._per_element_arrays["fnorble"] == 0).all(),
                          "'fnorble' array not initialized with given fill value")
 
-        self.store.add_array("fnorble", shape=(), dtype=np.int64, fill=42, per="atom")
+        self.store.add_array("fnorble", shape=(), dtype=np.int64, fill=42, per="element")
         self.assertTrue(not (self.store._per_element_arrays["fnorble"] == 42).all(),
                          "Duplicate add_array call was not ignored")
 

--- a/tests/atomistics/job/test_structurestorage.py
+++ b/tests/atomistics/job/test_structurestorage.py
@@ -162,6 +162,25 @@ class TestFlattenedStorage(TestWithProject):
         with self.assertRaises(KeyError, msg="Non-existing identifier!"):
             store.get_array("even", "foo")
 
+    def test_has_array(self):
+        """hasarray should return correct information for added array; None otherwise."""
+
+        store = FlattenedStorage()
+        store.add_array("energy", per="chunk")
+        store.add_array("forces", shape=(3,), per="element")
+
+        info = store.has_array("energy")
+        self.assertEqual(info["dtype"], np.float64, "has_array returns wrong dtype for per structure array.")
+        self.assertEqual(info["shape"], (), "has_array returns wrong shape for per structure array.")
+        self.assertEqual(info["per"], "chunk", "has_array returns wrong per for per structure array.")
+
+        info = store.has_array("forces")
+        self.assertEqual(info["dtype"], np.float64, "has_array returns wrong dtype for per atom array.")
+        self.assertEqual(info["shape"], (3,), "has_array returns wrong shape for per atom array.")
+        self.assertEqual(info["per"], "element", "has_array returns wrong per for per atom array.")
+
+        self.assertEqual(store.has_array("missing"), None, "has_array does not return None for nonexisting array.")
+
 class TestContainer(TestWithProject):
 
     @classmethod
@@ -210,21 +229,6 @@ class TestContainer(TestWithProject):
 
             self.assertTrue(np.allclose(self.cont.get_array("positions", i), structure.positions),
                             f"set_array modified arrray for different structure than instructured.")
-
-    def test_has_array(self):
-        """hasarray should return correct information for added array; None otherwise."""
-
-        pbc = self.cont.has_array("pbc")
-        self.assertEqual(pbc["dtype"], bool, "has_array returns wrong dtype for per structure array.")
-        self.assertEqual(pbc["shape"], (3,), "has_array returns wrong shape for per structure array.")
-        self.assertEqual(pbc["per"], "structure", "has_array returns wrong per for per structure array.")
-
-        pbc = self.cont.has_array("positions")
-        self.assertEqual(pbc["dtype"], np.float64, "has_array returns wrong dtype for per atom array.")
-        self.assertEqual(pbc["shape"], (3,), "has_array returns wrong shape for per atom array.")
-        self.assertEqual(pbc["per"], "atom", "has_array returns wrong per for per atom array.")
-
-        self.assertEqual(self.cont.has_array("missing"), None, "has_array does not return None for nonexisting array.")
 
     def test_get_structure(self):
         """Structure from get_structure should match thoes add with add_structure exactly."""

--- a/tests/atomistics/job/test_structurestorage.py
+++ b/tests/atomistics/job/test_structurestorage.py
@@ -217,3 +217,17 @@ class TestContainer(TestWithProject):
                          "num_atoms does not match after reading from HDF twice.")
         for s1, s2 in zip(self.cont.iter_structures(), cont_read.iter_structures()):
             self.assertEqual(s1, s2, "Structure from get_structure not matching after reading from HDF twice.")
+
+        self.assertEqual(set(self.cont._per_atom_arrays.keys()),
+                         set(cont_read._per_atom_arrays.keys()),
+                         "per atom arrays read are not the same as written")
+        self.assertEqual(set(self.cont._per_structure_arrays.keys()),
+                         set(cont_read._per_structure_arrays.keys()),
+                         "per structure arrays read are not the same as written")
+
+        for n in self.cont._per_atom_arrays:
+            self.assertTrue((self.cont._per_atom_arrays[n] == cont_read._per_atom_arrays[n]).all(),
+                            f"per atom array {n} read is not the same as writen")
+        for n in self.cont._per_structure_arrays:
+            self.assertTrue((self.cont._per_structure_arrays[n] == cont_read._per_structure_arrays[n]).all(),
+                            f"per structure array {n} read is not the same as writen")

--- a/tests/atomistics/job/test_trainingcontainer.py
+++ b/tests/atomistics/job/test_trainingcontainer.py
@@ -58,6 +58,12 @@ class TestTrainingContainer(TestWithCleanProject):
         for i in range(len(self.container._table)):
             self.assertEqual(self.container.get_structure(i), container_from_hdf.get_structure(i),
                              f"{i}th structure not the same after reading/writing.")
+            self.assertTrue((self.container._container.get_array("energy", i) \
+                                == container_from_hdf._container.get_array("energy", i)).all(),
+                            "Energy not the same after reading/writing.")
+            self.assertTrue((self.container._container.get_array("forces", i) \
+                                == container_from_hdf._container.get_array("forces", i)).all(),
+                            "Energy not the same after reading/writing.")
 
         self.assertTrue(self.container.to_pandas().equals(container_from_hdf.to_pandas()),
                         "Conversion to pandas not the same after reading/writing.")


### PR DESCRIPTION
Separates the general ragged array storage from the structure specific parts.

I think this will be useful at some point for things like 

https://github.com/pyiron/pyiron_atomistics/pull/251

(which is why I added @sudarsan-surendralal), but this take a little bit more to trickle down to base and atomistics.