### PR TITLE
Compatibility to old atomicrex jobs

### DIFF
--- a/pyiron_contrib/atomistics/atomicrex/structure_list.py
+++ b/pyiron_contrib/atomistics/atomicrex/structure_list.py
@@ -196,8 +196,12 @@ class ARStructureContainer:
                 num_atoms = h["flattened_structures/num_atoms"]
                 group_name_2 = "flattened_structures"
             else:
-                num_structures = h["structures/num_chunks"] or h["structures/num_structures"]
-                num_atoms = h["structures/num_elements"]  or h["structures/num_atoms"]
+                try:
+                    num_structures = h["structures/num_chunks"]
+                    num_atoms = h["structures/num_elements"]
+                except:
+                    num_structures = h["structures/num_structures"]
+                    num_atoms = h["structures/num_atoms"]
                 group_name_2 = "structures"
 
             self._init_structure_container(num_structures, num_atoms)
@@ -592,7 +596,6 @@ class ARStructureList(object):
                     else:
                         force_vec_triggered = True
                         final_forces = np.empty((len(s.structure), 3))
-
 
 
 def write_modified_poscar(identifier, forces, directory, structure=None, positions=None, cell=None, symbols=None):

--- a/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
+++ b/pyiron_contrib/atomistics/atomistics/job/structurestorage.py
@@ -474,8 +474,12 @@ class FlattenedStorage:
     def from_hdf(self, hdf, group_name="flat_storage"):
         with hdf.open(group_name) as hdf_s_lst:
             version = hdf_s_lst.get("HDF_VERSION", "0.0.0")
-            num_chunks = hdf_s_lst["num_chunks"] or hdf_s_lst["num_structures"]
-            num_elements = hdf_s_lst["num_elements"] or hdf_s_lst["num_atoms"]
+            try:
+                num_chunks = hdf_s_lst["num_chunks"]
+                num_elements = hdf_s_lst["num_elements"]
+            except:
+                num_chunks = hdf_s_lst["num_structures"]
+                num_elements = hdf_s_lst["num_atoms"]
             self._num_chunks_alloc = self.num_chunks = self.current_chunk_index = num_chunks
             self._num_elements_alloc = self.num_elements = self.current_element_index = num_elements
 


### PR DESCRIPTION
The or expression is not evaluated completely since an error is thrown when the key does not exist in the hdf file. I am not sure if anyone besides me uses this for production calculations, so I guess I can load all atomicrex jobs and use job.to_hdf using this branch instead of adding this into the actual code.
Alternatively I would suggest adding it to the code but additionally printing a deprecation warning and the workaround to make sure that anyone using this can apply it and than we can remove it when bumping version numbers at some point.
I am fine with both, just want to hear what you would prefer @pmrv 

