### PR TITLE
Add convenience from lammps potentials to Mlip job

### DIFF
--- a/pyiron_contrib/atomistics/mlip/mlip.py
+++ b/pyiron_contrib/atomistics/mlip/mlip.py
@@ -69,6 +69,15 @@ class Mlip(GenericJob):
     def potential_dataframe(self, elements=None):
         """
         :class:`pandas.DataFrame`: potential dataframe for lammps jobs
+
+        .. attention::
+
+            The `elements` argument must be given for in any case for non-unary alloys, as the scrapping code from the
+            training data is currently broken!
+
+        Args:
+            elements (list of str, optional): name of elements in this potential in the order of their indices in pyiron
+                                              structures, if not given use elements seen in training data
         """
         if elements is None:
             elements = self.input["species"]

--- a/pyiron_contrib/atomistics/mlip/mlip.py
+++ b/pyiron_contrib/atomistics/mlip/mlip.py
@@ -65,6 +65,21 @@ class Mlip(GenericJob):
         if os.path.exists(pot) and os.path.exists(states):
             return [pot, states]
 
+    def potential_dataframe(self, elements):
+        """
+        :class:`pandas.DataFrame`: potential dataframe for lammps jobs
+        """
+        if self.status.finished:
+            return pd.DataFrame({
+                        'Name': [''.join(elements)],
+                        'Filename': [[self.potential_files[0]]],
+                        'Model': ['Custom'],
+                        'Species': [elements],
+                        'Config': [['pair_style mlip mlip.ini\n',
+                                    'pair_coeff * *\n'
+                        ]]
+            })
+
     def set_input_to_read_only(self):
         """
         This function enforces read-only mode for the input classes, but it has to be implement in the individual


### PR DESCRIPTION
It contains a small hack that breaks the element detection for non-unary potentials.  It (and the workaround) are documented and I'll fix it when I'll actually use multiple elements.