### PR TITLE
Calculate and parse per energy structures for test/train sets

### DIFF
--- a/pyiron_contrib/atomistics/mlip/mlip.py
+++ b/pyiron_contrib/atomistics/mlip/mlip.py
@@ -10,7 +10,7 @@ import os
 import pandas as pd
 import posixpath
 import scipy.constants
-from pyiron_base import Settings, GenericParameters, GenericJob, Executable
+from pyiron_base import Settings, GenericParameters, GenericJob, Executable, FlattenedStorage
 from pyiron_atomistics import ase_to_pyiron
 from pyiron_contrib.atomistics.mlip.cfgs import savecfgs, loadcfgs, Cfg
 from pyiron_contrib.atomistics.mlip.potential import MtpPotential
@@ -163,8 +163,27 @@ class Mlip(GenericJob):
         else:
             grades_lst, job_id_grades_lst, timestep_grades_lst = [], [], []
         self._potential.load(os.path.join(self.working_directory, "Trained.mtp_"))
-        training_energies = np.loadtxt(os.path.join(self.working_directory, "training_energies.txt"))
-        testing_energies  = np.loadtxt(os.path.join(self.working_directory, "testing_energies.txt"))
+
+        training_store = FlattenedStorage()
+        training_store.add_array('energy', dtype=np.float64, shape=(1,), per='chunk')
+        training_store.add_array('forces', dtype=np.float64, shape=(3,), per='element')
+        training_store.add_array('stress', dtype=np.float64, shape=(6,), per='chunk')
+        training_store.add_array('grade',  dtype=np.float64, shape=(1,), per='chunk')
+        for cfg in loadcfgs(os.path.join(self.working_directory, "training_efs.cfg")):
+            training_store.add_chunk(len(cfg.pos), identifier=cfg.desc,
+                    energy=cfg.energy, forces=cfg.forces, stress=cfg.stresses, grade=cfg.grade
+            )
+
+        testing_store = FlattenedStorage()
+        testing_store.add_array('energy', dtype=np.float64, shape=(1,), per='chunk')
+        testing_store.add_array('forces', dtype=np.float64, shape=(3,), per='element')
+        testing_store.add_array('stress', dtype=np.float64, shape=(6,), per='chunk')
+        testing_store.add_array('grade',  dtype=np.float64, shape=(1,), per='chunk')
+        for cfg in loadcfgs(os.path.join(self.working_directory, "testing_efs.cfg")):
+            testing_store.add_chunk(len(cfg.pos), identifier=cfg.desc,
+                    energy=cfg.energy, forces=cfg.forces, stress=cfg.stresses, grade=cfg.grade
+            )
+
         with self.project_hdf5.open('output') as hdf5_output:
             hdf5_output['grades'] = grades_lst
             hdf5_output['job_id'] = job_id_grades_lst
@@ -176,6 +195,8 @@ class Mlip(GenericJob):
             self._potential.to_hdf(hdf=hdf5_output)
             hdf5_output['training_energies'] = training_energies
             hdf5_output['testing_energies'] = testing_energies
+            training_store.to_hdf(hdf=hdf5_output, group_name="training_efs")
+            testing_store.to_hdf(hdf=hdf5_output, group_name="testing_efs")
 
     def get_structure(self, iteration_step=-1):
         job = self.project.load(self['output/job_id_diff'][iteration_step])
@@ -462,9 +483,7 @@ $MLP_COMMAND_SERIAL calc-grade Trained.mtp_ training.cfg testing.cfg grades.cfg 
 $MLP_COMMAND_SERIAL calc-errors Trained.mtp_ training.cfg > training.errors
 $MLP_COMMAND_SERIAL calc-errors Trained.mtp_ testing.cfg > testing.errors
 $MLP_COMMAND_SERIAL calc-efs Trained.mtp_ training.cfg training_efs.cfg
-grep Energy -A 1 training_efs.cfg | awk 'NR%3==2 {print}' > training_energies.txt
 $MLP_COMMAND_SERIAL calc-efs Trained.mtp_ testing.cfg testing_efs.cfg
-grep Energy -A 1 testing_efs.cfg | awk 'NR%3==2 {print}' > testing_energies.txt
 $MLP_COMMAND_SERIAL select-add Trained.mtp_ training.cfg testing.cfg diff.cfg > select.log
 cp training.cfg training_new.cfg 
 cat diff.cfg >> training_new.cfg


### PR DESCRIPTION
Simply modifies the shell script to run a few extra commands to calculate the energy for every structure in the training set and collect them to HDF afterwards.

@muh-hassani I think this needs the new version of `mlip` and I'm not sure if you/we on the cluster have the sources.  I can provide them and a shell script to build them.