### PR TITLE
Set the pyiron config for CI workflows

### DIFF
--- a/.ci_support/pyironconfig.py
+++ b/.ci_support/pyironconfig.py
@@ -1,0 +1,19 @@
+import os
+
+
+def main():
+    current_path = os.path.abspath(os.path.curdir)
+    top_level_path = current_path.replace('\\', '/')
+    resource_path = os.path.join(current_path, "tests", "static").replace('\\', '/')
+    pyiron_config = os.path.expanduser('~/.pyiron').replace('\\', '/')
+    if not os.path.exists(pyiron_config):
+        with open(pyiron_config, 'w') as f:
+            f.writelines(['[DEFAULT]\n',
+                          'PROJECT_PATHS = ' + top_level_path + '\n',
+                          'RESOURCE_PATHS = ' + resource_path + '\n'])
+    else:
+        print('config exists')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Setup
       shell: bash -l {0}
       run: |
+        python .ci_support/pyironconfig.py
         pip install --pre pyiron_base pyiron_atomistics
         pip install --no-deps .
     - name: Test

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Setup
       shell: bash -l {0}
       run: |
+        python .ci_support/pyironconfig.py
         pip install --pre pyiron_base pyiron_atomistics
         pip install --no-deps .
     - name: Test


### PR DESCRIPTION
Puts contrib CI in line with atomistics etc. by setting the pyiron config for our github workflows. Became an issue for compatibility tests over in [base #519](https://github.com/pyiron/pyiron_base/pull/519).