### PR TITLE
Add __init__.py for mlip tests

### DIFF
--- a/pyiron_contrib/atomistics/mlip/parser.py
+++ b/pyiron_contrib/atomistics/mlip/parser.py
@@ -98,9 +98,6 @@ def _make_potential_parser():
 
     return parser
 
-# function exist just to keep namespace clean
-_potential_parser = _make_potential_parser()
-
 def potential(potential_string):
     """
     Parse an MTP potential for mlip.
@@ -112,7 +109,7 @@ def potential(potential_string):
         ValueError: failed to parse potential
     """
     try:
-        result = _potential_parser.parse_string(potential_string).as_dict()
+        result = _make_potential_parser().parse_string(potential_string).as_dict()
         result["radial"]["basis_type"] = result["radial"]["basis_type"][2:] # strip RB prefix
         # Convert to numpy arrays
         for pair, func in result["radial"]["funcs"].items():

--- a/tests/atomistics/mlip/test_parser.py
+++ b/tests/atomistics/mlip/test_parser.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from pyiron_contrib.atomistics.mlip.parser import potential
 
 mtp08 = """
@@ -60,6 +62,19 @@ class TestMlipParser(unittest.TestCase):
     def test_parse(self):
         try:
             result = potential(mtp08)
+            for pair in result["radial"]["funcs"]:
+                self.assertTrue(isinstance(result["radial"]["funcs"][pair], np.ndarray),
+                                "Entry list not parsed as numpy array!")
+            self.assertTrue(isinstance(result["alpha_index_basic"], np.ndarray),
+                            "Entry list not parsed as numpy array!")
+            self.assertTrue(isinstance(result["alpha_index_times"], np.ndarray),
+                            "Entry list not parsed as numpy array!")
+            self.assertTrue(isinstance(result["alpha_moment_mapping"], np.ndarray),
+                            "Entry list not parsed as numpy array!")
+            self.assertTrue(isinstance(result["species_coeffs"], np.ndarray),
+                            "Entry list not parsed as numpy array!")
+            self.assertTrue(isinstance(result["moment_coeffs"], np.ndarray),
+                            "Entry list not parsed as numpy array!")
         except ValueError:
             self.fail("Well-formated potential should not raise an error.")
 


### PR DESCRIPTION
An update to pyparsing broke the Mlip job and we didn't notice, because I had forgotten to add the `__init__.py` file to the test directory.