### PR TITLE
Revert "Lammps is case-sensitive about pair_style"

### DIFF
--- a/pyiron_contrib/atomistics/mlip/mlip.py
+++ b/pyiron_contrib/atomistics/mlip/mlip.py
@@ -92,7 +92,7 @@ class Mlip(GenericJob):
                         "Filename": [[self.potential_files[0]]],
                         "Model": ["Custom"],
                         "Species": [elements],
-                        "Config": [["pair_style MLIP mlip.ini\n",
+                        "Config": [["pair_style mlip mlip.ini\n",
                                     "pair_coeff * *\n"
                         ]]
             })


### PR DESCRIPTION
This reverts commit 293201f621241df5724d728a62c8c0d91da4ffaa.

I seemed to get confused in #255, actually small-case `mlip` is the correct way to spell it.