### PR TITLE
Some QoL update for active learning in MLIP

### DIFF
--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -92,7 +92,10 @@ write-cfgs:skip 0
         if not self._selection_enabled:
             raise ValueError("Selected structures are only available after calling enable_active_learning()!")
         if self._selected_structures is None:
-            self._selected_structures = StructureStorage()
+            if "selected" in self["output"].list_groups():
+                self._selected_structures = self["output/selected"].to_object()
+            else:
+                self._selected_structures = StructureStorage()
         return self._selected_structures
 
     def collect_output(self):

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -106,7 +106,8 @@ write-cfgs:skip 0
                 for cfg in loadcfgs(file_name):
                     self.selected_structures.add_structure(
                             Atoms(species=self.structure.species, indices=cfg.types, positions=cfg.pos, cell=cfg.lat,
-                                  pbc=[True, True, True])
+                                  pbc=[True, True, True]),
+                            mv_grade=cfg.grade
                     )
                 cell, positions, forces, stress, energy, indicies, grades, jobids, timesteps = read_cgfs(file_name=file_name)
                 with self.project_hdf5.open("output/mlip") as hdf5_output:

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -45,7 +45,7 @@ class LammpsMlip(LammpsInteractive):
         self.input.mlip.write_file(file_name="mlip.ini", cwd=self.working_directory)
 
     def convergence_check(self):
-        for line in self["error.msg"]:
+        for line in self["error.out"]:
             if line.startswith("MLIP: Breaking threshold exceeded"): return False
         return True
 

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -3,8 +3,10 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import os
-from pyiron.lammps.base import Input
-from pyiron.lammps.interactive import LammpsInteractive
+from pyiron_atomistics.lammps.base import Input
+from pyiron_atomistics.lammps.interactive import LammpsInteractive
+from pyiron_atomistics.atomistics.structure.atoms import Atoms
+from pyiron_atomistics.atomistics.structure.structurestorage import StructureStorage
 from pyiron_contrib.atomistics.mlip.mlip import read_cgfs
 from pyiron_contrib.atomistics.mlip.cfgs import loadcfgs
 from pyiron_base import GenericParameters

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -41,14 +41,23 @@ class LammpsMlip(LammpsInteractive):
             self.input.mlip['mtp-filename'] = os.path.basename(self.potential['Filename'][0][0])
         self.input.mlip.write_file(file_name="mlip.ini", cwd=self.working_directory)
 
-    def enable_active_learning(self, threshold=2.0, threshold_break=5.0, filename='selected.cfg'):
+    def enable_active_learning(self, threshold=2.0, threshold_break=5.0):
+        """
+        Enable active learning during MD run.
+
+        Automatically collect structures on which the potential is extrapolating.
+
+        Args:
+            threshold (float): select structures with extrapolation grade larger than this
+            threshold_break (float): stop the MD run after seeing a structure with extrapolation grade larger than this
+        """
         self.input.mlip.load_string(f"""\
 mtp-filename auto
 calculate-efs TRUE
 select TRUE
 select:threshold {threshold}
 select:threshold-break {threshold_break}
-select:save-selected {filename}
+select:save-selected selected.cfg
 select:load-state state.mvs
 select:log selection.log
 write-cfgs:skip 0

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -80,7 +80,8 @@ write-cfgs:skip 0
                 selected = StructureStorage()
                 for cfg in loadcfgs(file_name):
                     selected.add_structure(
-                            Atoms(species=self.structure.species, indices=cfg.types, positions=cfg.pos, cell=cfg.lat)
+                            Atoms(species=self.structure.species, indices=cfg.types, positions=cfg.pos, cell=cfg.lat,
+                                  pbc=[True, True, True])
                     )
                 selected.to_hdf(self.project_hdf5.open("output"), "selected")
                 cell, positions, forces, stress, energy, indicies, grades, jobids, timesteps = read_cgfs(file_name=file_name)

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -42,6 +42,11 @@ class LammpsMlip(LammpsInteractive):
             self.input.mlip['mtp-filename'] = os.path.basename(self.potential['Filename'][0][0])
         self.input.mlip.write_file(file_name="mlip.ini", cwd=self.working_directory)
 
+    def convergence_check(self):
+        for line in self["error.msg"]:
+            if line.startswith("MLIP: Breaking threshold exceeded"): return False
+        return True
+
     def enable_active_learning(self, threshold=2.0, threshold_break=5.0):
         """
         Enable active learning during MD run.
@@ -52,6 +57,7 @@ class LammpsMlip(LammpsInteractive):
             threshold (float): select structures with extrapolation grade larger than this
             threshold_break (float): stop the MD run after seeing a structure with extrapolation grade larger than this
         """
+        self.executable.accepted_return_codes += [8]
         self.input.mlip.load_string(f"""\
 mtp-filename auto
 calculate-efs TRUE

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -77,6 +77,10 @@ write-cfgs:skip 0
         return os.path.join(self.working_directory, self.input.mlip['select:save-selected'])
 
     @property
+    def _selection_enabled(self):
+        return self.input.mlip["select"] == "TRUE"
+
+    @property
     def selected_structures(self):
         """
         :class:`.StructureStorage`: structures that the potential extrapolated on during the run.
@@ -85,7 +89,7 @@ write-cfgs:skip 0
         """
         if not (self.status.finished or self.status.not_converged):
             raise ValueError("Selected structures are only available once the job has finished!")
-        if not os.path.exists(self._get_selection_file()):
+        if self._selection_enabled:
             raise ValueError("Selected structures are only available after calling enable_active_learning()!")
         if self._selected_structures is None:
             self._selected_structures = StructureStorage()
@@ -101,7 +105,6 @@ write-cfgs:skip 0
                             Atoms(species=self.structure.species, indices=cfg.types, positions=cfg.pos, cell=cfg.lat,
                                   pbc=[True, True, True])
                     )
-                selected_structures.to_hdf(self.project_hdf5.open("output"), "selected")
                 cell, positions, forces, stress, energy, indicies, grades, jobids, timesteps = read_cgfs(file_name=file_name)
                 with self.project_hdf5.open("output/mlip") as hdf5_output:
                     hdf5_output['forces'] = forces
@@ -110,6 +113,7 @@ write-cfgs:skip 0
                     hdf5_output['cells'] = cell
                     hdf5_output['positions'] = positions
                     hdf5_output['indicies'] = indicies
+            self.selected_structures.to_hdf(self.project_hdf5.open("output"), "selected")
 
 
 class MlipInput(Input):

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -41,14 +41,14 @@ class LammpsMlip(LammpsInteractive):
             self.input.mlip['mtp-filename'] = os.path.basename(self.potential['Filename'][0][0])
         self.input.mlip.write_file(file_name="mlip.ini", cwd=self.working_directory)
 
-    def enable_active_learning(self):
-        self.input.mlip.load_string("""\
+    def enable_active_learning(self, threshold=2.0, threshold_break=5.0, filename='selected.cfg'):
+        self.input.mlip.load_string(f"""\
 mtp-filename auto
 calculate-efs TRUE
 select TRUE
-select:threshold 2.0
-select:threshold-break 5.0
-select:save-selected selected.cfg
+select:threshold {threshold}
+select:threshold-break {threshold_break}
+select:save-selected {filename}
 select:load-state state.mvs
 select:log selection.log
 write-cfgs:skip 0

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -87,9 +87,9 @@ write-cfgs:skip 0
 
         Only available if :method:`.enable_active_learning` was called and once the job has been collected.
         """
-        if not (self.status.finished or self.status.not_converged):
+        if not (self.status.collect or self.status.finished or self.status.not_converged):
             raise ValueError("Selected structures are only available once the job has finished!")
-        if self._selection_enabled:
+        if not self._selection_enabled:
             raise ValueError("Selected structures are only available after calling enable_active_learning()!")
         if self._selected_structures is None:
             self._selected_structures = StructureStorage()

--- a/pyiron_contrib/atomistics/mlip/lammps.py
+++ b/pyiron_contrib/atomistics/mlip/lammps.py
@@ -6,6 +6,7 @@ import os
 from pyiron.lammps.base import Input
 from pyiron.lammps.interactive import LammpsInteractive
 from pyiron_contrib.atomistics.mlip.mlip import read_cgfs
+from pyiron_contrib.atomistics.mlip.cfgs import loadcfgs
 from pyiron_base import GenericParameters
 
 __author__ = "Jan Janssen"
@@ -68,6 +69,12 @@ write-cfgs:skip 0
         if 'select:save-selected' in self.input.mlip._dataset['Parameter']:
             file_name = os.path.join(self.working_directory, self.input.mlip['select:save-selected'])
             if os.path.exists(file_name):
+                selected = StructureStorage()
+                for cfg in loadcfgs(file_name):
+                    selected.add_structure(
+                            Atoms(species=self.structure.species, indices=cfg.types, positions=cfg.pos, cell=cfg.lat)
+                    )
+                selected.to_hdf(self.project_hdf5.open("output"), "selected")
                 cell, positions, forces, stress, energy, indicies, grades, jobids, timesteps = read_cgfs(file_name=file_name)
                 with self.project_hdf5.open("output/mlip") as hdf5_output:
                     hdf5_output['forces'] = forces

--- a/pyiron_contrib/atomistics/mlip/mlip.py
+++ b/pyiron_contrib/atomistics/mlip/mlip.py
@@ -89,7 +89,7 @@ class Mlip(GenericJob):
         if self.status.finished:
             return pd.DataFrame({
                         "Name": ["".join(elements)],
-                        "Filename": [[self.potential_files[0]]],
+                        "Filename": [self.potential_files],
                         "Model": ["Custom"],
                         "Species": [elements],
                         "Config": [["pair_style mlip mlip.ini\n",


### PR DESCRIPTION
This makes the `enable_activelearning` method a bit more configurable and collects the selected structures in a `StructureContainer` that also saves the extrapolation grades.

There's currently a problem where jobs that are submitted and exceed the breaking threshold will be labeled as aborted rather than not converged due to [this issue](https://github.com/pyiron/pyiron_base/pull/728) in pyiron_base.