### PR TITLE
Do not fail job when potential parser fails

### DIFF
--- a/pyiron_contrib/atomistics/mlip/mlip.py
+++ b/pyiron_contrib/atomistics/mlip/mlip.py
@@ -115,7 +115,7 @@ class Mlip(GenericJob, PotentialFit):
 
     @property
     def potential(self):
-        if self.status.finished:
+        if self.status.finished and self._potential is not None:
             return self._potential
         else:
             raise ValueError("potential only available on successfully finished jobs")
@@ -192,7 +192,11 @@ class Mlip(GenericJob, PotentialFit):
             _, _, _, _, _, _, grades_lst, job_id_grades_lst, timestep_grades_lst = read_cgfs(file_name)
         else:
             grades_lst, job_id_grades_lst, timestep_grades_lst = [], [], []
-        self._potential.load(os.path.join(self.working_directory, "Trained.mtp_"))
+        try:
+            self._potential.load(os.path.join(self.working_directory, "Trained.mtp_"))
+        except:
+            self.logger.warn('Failed to parse potential file! job.potential will not be available.')
+            self._potential = None
 
         training_store = FlattenedStorage()
         training_store.add_array('energy', dtype=np.float64, shape=(), per='chunk')
@@ -220,7 +224,8 @@ class Mlip(GenericJob, PotentialFit):
             hdf5_output['timestep_diff'] = timestep_diff_lst
             hdf5_output['job_id_new'] = job_id_new_training_lst
             hdf5_output['timestep_new'] = timestep_new_training_lst
-            self._potential.to_hdf(hdf=hdf5_output)
+            if self._potential is not None:
+                self._potential.to_hdf(hdf=hdf5_output)
             training_store.to_hdf(hdf=hdf5_output, group_name="training_efs")
             testing_store.to_hdf(hdf=hdf5_output, group_name="testing_efs")
 

--- a/pyiron_contrib/atomistics/mlip/parser.py
+++ b/pyiron_contrib/atomistics/mlip/parser.py
@@ -63,8 +63,8 @@ def _make_potential_parser():
             + pp.IndentedBlock(
                     radial_func_types \
                             + pp.IndentedBlock(radial_func_coeffs + NL)[1, ...]
-              )
-            )[1, ...]
+              )[1, ...]
+            )
 
     radial_funcs = radial_funcs.set_results_name("funcs")
     radial_funcs = pp.ungroup(radial_funcs).set_results_name("funcs")


### PR DESCRIPTION
The current MTP potential parser breaks for multicomponent systems.
This is just a stop gap until I get it fixed.