### PR TITLE
MLIP: Check array correctly

### DIFF
--- a/pyiron_contrib/atomistics/mlip/mlip.py
+++ b/pyiron_contrib/atomistics/mlip/mlip.py
@@ -369,7 +369,7 @@ class Mlip(GenericJob, PotentialFit):
                     if job._container.has_array("stress"):
                         volume = np.abs(np.linalg.det(cell_lst[-1]))
                         stress_lst.append(job._container.get_array("stress", time_step) * volume)
-                        if np.isnan(stress_lst[-1]):
+                        if np.isnan(stress_lst[-1]).any():
                             stress_lst[-1] = None
                     track_lst.append(str(ham.job_id) + '_' + str(time_step))
                 continue


### PR DESCRIPTION
Fixes an oversight in #434 by checking an array of booleans correctly.