### PR TITLE
TrainingContainer: Save to hdf after get_neighbors

### DIFF
--- a/pyiron_contrib/atomistics/atomistics/job/trainingcontainer.py
+++ b/pyiron_contrib/atomistics/atomistics/job/trainingcontainer.py
@@ -210,6 +210,7 @@ class TrainingContainer(GenericJob, HasStructure):
     def run_static(self):
         if self.input.save_neighbors:
             self.get_neighbors()
+            self.to_hdf()
         self.status.finished = True
 
     def run_if_interactive(self):


### PR DESCRIPTION
Without the extra call it would compute the neighbors, but not save them.