### PR TITLE
Alternative to pyiron_base#1044

### DIFF
--- a/pyiron_contrib/nofiles/lammps.py
+++ b/pyiron_contrib/nofiles/lammps.py
@@ -1,38 +1,20 @@
 import os
 import importlib
 from pyiron_atomistics.lammps.interactive import LammpsInteractive
+from pyiron_contrib.nofiles.wrapper import wrap_without_files
 
 try:  # mpi4py is only supported on Linux and Mac Os X
     from pylammpsmpi import LammpsLibrary
 except ImportError:
     pass
 
+LammpsInteractiveWithoutOutputBase = wrap_without_files(
+        LammpsInteractive, "LammpsInteractiveWithoutOutputBase",
+        LammpsInteractive.interactive_flush,
+        LammpsInteractive.interactive_close
+)
 
-class LammpsInteractiveWithoutOutput(LammpsInteractive):
-    def __init__(self, project, job_name):
-        super(LammpsInteractiveWithoutOutput, self).__init__(project, job_name)
-        self._interactive_disable_log_file = False
-
-    def to_hdf(self, hdf=None, group_name=None):
-        """
-
-        Args:
-            hdf:
-            group_name:
-
-        Returns:
-
-        """
-        if not self._interactive_disable_log_file:
-            super(LammpsInteractiveWithoutOutput, self).to_hdf(
-                hdf=hdf, group_name=group_name
-            )
-
-    def interactive_flush(self, path="interactive", include_last_step=False):
-        if not self._interactive_disable_log_file:
-            super(LammpsInteractiveWithoutOutput, self).interactive_flush(
-                path=path, include_last_step=include_last_step
-            )
+class LammpsInteractiveWithoutOutput(LammpsInteractiveWithoutOutputBase):
 
     def interactive_initialize_interface(self):
         if not self._interactive_disable_log_file:
@@ -61,11 +43,3 @@ class LammpsInteractiveWithoutOutput(LammpsInteractive):
             )
         self._reset_interactive_run_command()
         self.interactive_structure_setter(self.structure)
-
-    def interactive_close(self):
-        if not self._interactive_disable_log_file:
-            super(LammpsInteractiveWithoutOutput).interactive_close()
-
-    def refresh_job_status(self):
-        if not self._interactive_disable_log_file:
-            super(LammpsInteractiveWithoutOutput).refresh_job_status()

--- a/pyiron_contrib/nofiles/wrapper.py
+++ b/pyiron_contrib/nofiles/wrapper.py
@@ -1,0 +1,65 @@
+from functools import wraps
+
+def wrap_without_files(cls, name, *methods):
+    """
+    Returns a subclass that defines the _interactive_disable_log_file flag and
+    overrides to_hdf, child_project and refresh_job_status to neither actually
+    write anything nor register the job with the database.
+
+    Additional methods (!, not method names) can be given to also wrap them so
+    that they are only called when the flag is not set.
+
+    Args:
+        cls (type): base class to derive from
+        name (str): name of the new class
+        *methods (functions): additional methods to be wrapped.
+
+    Returns:
+        type: subclass of cls that creates jobs that don't touch HDF or the
+        database
+    """
+
+    def init(self, project, job_name):
+        self._interactive_disable_log_file = False
+        super(cls, self).__init__(project=project, job_name=job_name)
+
+    @property
+    @wraps(cls.child_project)
+    def child_project(self):
+        if not self._interactive_disable_log_file:
+            return super(cls, self).child_project
+        else:
+            return self.project
+
+    @wraps(cls.to_hdf)
+    def to_hdf(self, *args, **kwargs):
+        if not self._interactive_disable_log_file:
+            super(cls, self).to_hdf(*args, **kwargs)
+
+    @wraps(cls.refresh_job_status)
+    def refresh_job_status(self):
+        if not self._interactive_disable_log_file:
+            return super(cls, self).refresh_job_status()
+
+    body = {
+        '__init__': init,
+        'to_hdf': to_hdf,
+        'child_project': child_project,
+        'refresh_job_status': refresh_job_status
+    }
+
+    def wrap_meth(meth):
+        """Return a method that calls its super() only if the flag is not set."""
+        @wraps(meth)
+        def wrapper(self, *args, **kwargs):
+            if self._interactive_disable_log_file:
+                return getattr(
+                        super(cls, self),
+                        meth.__name__
+                )(self, *args, **kwargs)
+        return wrapper
+
+    for meth in methods:
+        body[meth.__name__] = wrap_meth(meth)
+
+    return type(name, (cls,), body)

--- a/pyiron_contrib/nofiles/wrapper.py
+++ b/pyiron_contrib/nofiles/wrapper.py
@@ -23,14 +23,6 @@ def wrap_without_files(cls, name, *methods):
         self._interactive_disable_log_file = False
         super(cls, self).__init__(project=project, job_name=job_name)
 
-    @property
-    @wraps(cls.child_project)
-    def child_project(self):
-        if not self._interactive_disable_log_file:
-            return super(cls, self).child_project
-        else:
-            return self.project
-
     @wraps(cls.to_hdf)
     def to_hdf(self, *args, **kwargs):
         if not self._interactive_disable_log_file:
@@ -44,9 +36,19 @@ def wrap_without_files(cls, name, *methods):
     body = {
         '__init__': init,
         'to_hdf': to_hdf,
-        'child_project': child_project,
         'refresh_job_status': refresh_job_status
     }
+
+    if hasattr(cls, 'child_project'): # isinstance(cls, GenericMaster)
+        @property
+        @wraps(cls.child_project)
+        def child_project(self):
+            if not self._interactive_disable_log_file:
+                return super(cls, self).child_project
+            else:
+                return self.project
+
+        body['child_project'] = child_project
 
     def wrap_meth(meth):
         """Return a method that calls its super() only if the flag is not set."""

--- a/pyiron_contrib/nofiles/wrapper.py
+++ b/pyiron_contrib/nofiles/wrapper.py
@@ -58,7 +58,7 @@ def wrap_without_files(cls, name, *methods):
                 return getattr(
                         super(cls, self),
                         meth.__name__
-                )(self, *args, **kwargs)
+                )(*args, **kwargs)
         return wrapper
 
     for meth in methods:


### PR DESCRIPTION
There's some higher order voodoo involved, but this should take care of the repetitive boiler plate you had to write for the nofile classes @jan-janssen .  I couldn't test in detail whether it works, because there seem to be problems in the rest of the code (I couldn't instantiate the original LammpsInteractiveWithoutOutput, e.g.; in this version you can instantiate it but it fails later in other code when you run it), so some debugging may be required, but I think the path to use it for the other classes should be clear.