### PR TITLE
Remove needs for notebook CI job

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build-notebooks:
-    needs: commit-updated-env
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This was a careless copy-paste error on the part of my past self when using _part_ of the centralized CI. In the centralized context this happens in a broader multi-job workflow; here it's in a standalone workflow so we need to get rid of the job dependency.