### PR TITLE
No files fails better

### DIFF
--- a/pyiron_contrib/nofiles/elastic.py
+++ b/pyiron_contrib/nofiles/elastic.py
@@ -11,7 +11,7 @@ class ElasticMatrixJobWithoutFiles(ElasticMatrixJob):
                 "state.update({'disable_database': True})`, and try again."
             )
         super(ElasticMatrixJobWithoutFiles, self).__init__(project, job_name)
-        self._interactive_disable_log_file = False
+        self._interactive_disable_log_file = True
 
     @property
     def child_project(self):

--- a/pyiron_contrib/nofiles/elastic.py
+++ b/pyiron_contrib/nofiles/elastic.py
@@ -1,9 +1,15 @@
-from pyiron_base import GenericMaster
+from pyiron_base import GenericMaster, state
 from pyiron_gpl.elastic.elastic import ElasticMatrixJob
 
 
 class ElasticMatrixJobWithoutFiles(ElasticMatrixJob):
     def __init__(self, project, job_name):
+        if not state.database.database_is_disabled:
+            raise RuntimeError(
+                "To run a `Without` job, the database must first be disabled. Please "
+                "`from pyiron_base import state; "
+                "state.update({'disable_database': True})`, and try again."
+            )
         super(ElasticMatrixJobWithoutFiles, self).__init__(project, job_name)
         self._interactive_disable_log_file = False
 

--- a/pyiron_contrib/nofiles/lammps.py
+++ b/pyiron_contrib/nofiles/lammps.py
@@ -18,7 +18,7 @@ class LammpsInteractiveWithoutOutput(LammpsInteractive):
                 "state.update({'disable_database': True})`, and try again."
             )
         super().__init__(project, job_name)
-        self._interactive_disable_log_file = False
+        self._interactive_disable_log_file = True
 
     def to_hdf(self, hdf=None, group_name=None):
         """

--- a/pyiron_contrib/nofiles/lammps.py
+++ b/pyiron_contrib/nofiles/lammps.py
@@ -10,7 +10,7 @@ except ImportError:
 
 class LammpsInteractiveWithoutOutput(LammpsInteractive):
     def __init__(self, project, job_name):
-        super(LammpsInteractiveWithoutOutput, self).__init__(project, job_name)
+        super().__init__(project, job_name)
         self._interactive_disable_log_file = False
 
     def to_hdf(self, hdf=None, group_name=None):
@@ -64,8 +64,8 @@ class LammpsInteractiveWithoutOutput(LammpsInteractive):
 
     def interactive_close(self):
         if not self._interactive_disable_log_file:
-            super(LammpsInteractiveWithoutOutput).interactive_close()
+            super().interactive_close()
 
     def refresh_job_status(self):
         if not self._interactive_disable_log_file:
-            super(LammpsInteractiveWithoutOutput).refresh_job_status()
+            super().refresh_job_status()

--- a/pyiron_contrib/nofiles/lammps.py
+++ b/pyiron_contrib/nofiles/lammps.py
@@ -1,6 +1,7 @@
 import os
 import importlib
 from pyiron_atomistics.lammps.interactive import LammpsInteractive
+from pyiron_base import state
 
 try:  # mpi4py is only supported on Linux and Mac Os X
     from pylammpsmpi import LammpsLibrary
@@ -10,6 +11,12 @@ except ImportError:
 
 class LammpsInteractiveWithoutOutput(LammpsInteractive):
     def __init__(self, project, job_name):
+        if not state.database.database_is_disabled:
+            raise RuntimeError(
+                "To run a `Without` job, the database must first be disabled. Please "
+                "`from pyiron_base import state; "
+                "state.update({'disable_database': True})`, and try again."
+            )
         super().__init__(project, job_name)
         self._interactive_disable_log_file = False
 

--- a/pyiron_contrib/nofiles/master.py
+++ b/pyiron_contrib/nofiles/master.py
@@ -1,6 +1,6 @@
 import pandas
 from pympipool import Pool
-from pyiron_base import DataContainer, GenericJob
+from pyiron_base import DataContainer, GenericJob, state
 from pyiron_atomistics.project import Project
 from pyiron_atomistics.atomistics.structure.atoms import (
     Atoms,
@@ -12,6 +12,12 @@ from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 
 class GenericJobNoFiles(GenericJob):
     def __init__(self, project, job_name):
+        if not state.database.database_is_disabled:
+            raise RuntimeError(
+                "To run a `Without` job, the database must first be disabled. Please "
+                "`from pyiron_base import state; "
+                "state.update({'disable_database': True})`, and try again."
+            )
         super(GenericJobNoFiles, self).__init__(project, job_name)
 
         # internal variables

--- a/pyiron_contrib/nofiles/master.py
+++ b/pyiron_contrib/nofiles/master.py
@@ -22,7 +22,7 @@ class GenericJobNoFiles(GenericJob):
 
         # internal variables
         self._python_only_job = True
-        self._interactive_disable_log_file = False
+        self._interactive_disable_log_file = True
 
     def refresh_job_status(self):
         if not self._interactive_disable_log_file:

--- a/pyiron_contrib/nofiles/murn.py
+++ b/pyiron_contrib/nofiles/murn.py
@@ -13,7 +13,7 @@ class MurnaghanWithoutFiles(Murnaghan):
                 "state.update({'disable_database': True})`, and try again."
             )
         super(MurnaghanWithoutFiles, self).__init__(project, job_name)
-        self._interactive_disable_log_file = False
+        self._interactive_disable_log_file = True
 
     @property
     def child_project(self):

--- a/pyiron_contrib/nofiles/murn.py
+++ b/pyiron_contrib/nofiles/murn.py
@@ -1,11 +1,17 @@
 import pandas
 import numpy as np
-from pyiron_base import GenericMaster
+from pyiron_base import GenericMaster, state
 from pyiron_atomistics.atomistics.master.murnaghan import Murnaghan
 
 
 class MurnaghanWithoutFiles(Murnaghan):
     def __init__(self, project, job_name):
+        if not state.database.database_is_disabled:
+            raise RuntimeError(
+                "To run a `Without` job, the database must first be disabled. Please "
+                "`from pyiron_base import state; "
+                "state.update({'disable_database': True})`, and try again."
+            )
         super(MurnaghanWithoutFiles, self).__init__(project, job_name)
         self._interactive_disable_log_file = False
 

--- a/pyiron_contrib/nofiles/phonopy.py
+++ b/pyiron_contrib/nofiles/phonopy.py
@@ -1,9 +1,15 @@
-from pyiron_base import GenericMaster
+from pyiron_base import GenericMaster, state
 from pyiron_atomistics.atomistics.master.phonopy import PhonopyJob
 
 
 class PhonopyJobWithoutFiles(PhonopyJob):
     def __init__(self, project, job_name):
+        if not state.database.database_is_disabled:
+            raise RuntimeError(
+                "To run a `Without` job, the database must first be disabled. Please "
+                "`from pyiron_base import state; "
+                "state.update({'disable_database': True})`, and try again."
+            )
         super(PhonopyJobWithoutFiles, self).__init__(project, job_name)
         self._interactive_disable_log_file = False
 

--- a/pyiron_contrib/nofiles/phonopy.py
+++ b/pyiron_contrib/nofiles/phonopy.py
@@ -11,7 +11,7 @@ class PhonopyJobWithoutFiles(PhonopyJob):
                 "state.update({'disable_database': True})`, and try again."
             )
         super(PhonopyJobWithoutFiles, self).__init__(project, job_name)
-        self._interactive_disable_log_file = False
+        self._interactive_disable_log_file = True
 
     @property
     def child_project(self):

--- a/pyiron_contrib/nofiles/sqs.py
+++ b/pyiron_contrib/nofiles/sqs.py
@@ -11,7 +11,7 @@ class SQSJobWithoutOutput(SQSJob):
                 "state.update({'disable_database': True})`, and try again."
             )
         super(SQSJobWithoutOutput, self).__init__(project, job_name)
-        self._interactive_disable_log_file = False
+        self._interactive_disable_log_file = True
 
     def to_hdf(self, hdf=None, group_name=None):
         """

--- a/pyiron_contrib/nofiles/sqs.py
+++ b/pyiron_contrib/nofiles/sqs.py
@@ -1,8 +1,15 @@
 from pyiron_atomistics.atomistics.job.sqs import SQSJob, get_sqs_structures
+from pyiron_base import state
 
 
 class SQSJobWithoutOutput(SQSJob):
     def __init__(self, project, job_name):
+        if not state.database.database_is_disabled:
+            raise RuntimeError(
+                "To run a `Without` job, the database must first be disabled. Please "
+                "`from pyiron_base import state; "
+                "state.update({'disable_database': True})`, and try again."
+            )
         super(SQSJobWithoutOutput, self).__init__(project, job_name)
         self._interactive_disable_log_file = False
 

--- a/tests/unit/no_files/test_lammps.py
+++ b/tests/unit/no_files/test_lammps.py
@@ -1,0 +1,16 @@
+from pyiron_base._tests import TestWithCleanProject
+import pyiron_contrib
+
+
+class LammpsInteractiveWithoutOutput(TestWithCleanProject):
+    def test_clean_database_failure(self):
+        og_status = self.project.state.settings.configuration["disable_database"]
+        self.project.state.update({"disable_database": False})
+
+        with self.assertRaises(RuntimeError):
+            self.project.create.job.LammpsInteractiveWithoutOutput("foo")
+
+        self.project.state.update({"disable_database": True})
+        self.project.create.job.LammpsInteractiveWithoutOutput("foo")
+
+        self.project.state.update({"disable_database": og_status})


### PR DESCRIPTION
- Fixes a bug where `super(LammpsInteractiveWithoutOutput)` tries to access a method that doesn't exist (just needed to remove the explicit class direction in the super call)
- Fails cleanly and informatively if the user tries to instantiate a `Without` job while the database is active
- Changes the default behaviour to assume that the user actually wants the functionality the `Without` job supplies, i.e. `self._interactive_disable_log_file = True` by default

@pmrv I guess this should make #603 ok. Right now I just copy-pasted the functionality across _all_ the `Without` classes, so that PR is exactly the sort of centralization that makes sense next.

Closes #608.