### PR TITLE
Node decorator

### DIFF
--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -9,7 +9,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f07d24e33b8f4d7f89b04056becab428",
+       "model_id": "5791768f5bad44f7ab2038bcf689aed2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -27,7 +27,7 @@
     }
    ],
    "source": [
-    "from pyiron_contrib.workflow import nodes  # TODO: Update pre-built nodes\n",
+    "from pyiron_contrib.workflow import nodes\n",
     "from pyiron_contrib.workflow.node import Node\n",
     "from pyiron_contrib.workflow.workflow import Workflow"
    ]
@@ -354,11 +354,11 @@
     {
      "data": {
       "text/plain": [
-       "{'n1': <pyiron_contrib.workflow.node.Node at 0x151a69950>,\n",
-       " 'n2': <pyiron_contrib.workflow.node.Node at 0x1524fdb90>,\n",
-       " 'n3': <pyiron_contrib.workflow.node.Node at 0x151d97bd0>,\n",
-       " 'n4': <pyiron_contrib.workflow.node.Node at 0x15251f150>,\n",
-       " 'n5': <pyiron_contrib.workflow.node.Node at 0x112acdc10>}"
+       "{'n1': <pyiron_contrib.workflow.node.Node at 0x14f7c6710>,\n",
+       " 'n2': <pyiron_contrib.workflow.node.Node at 0x14ed06d10>,\n",
+       " 'n3': <pyiron_contrib.workflow.node.Node at 0x14ed7b150>,\n",
+       " 'n4': <pyiron_contrib.workflow.node.Node at 0x14f7c7d10>,\n",
+       " 'n5': <pyiron_contrib.workflow.node.Node at 0x14ed08490>}"
       ]
      },
      "execution_count": 12,
@@ -451,10 +451,10 @@
     }
    ],
    "source": [
-    "wf.structure = nodes.BulkStructure(repeat=3, cubic=True, element=\"Al\")\n",
-    "wf.engine = nodes.Lammps(structure=wf.structure.outputs.structure)\n",
-    "wf.calc = nodes.CalcMD(job=wf.engine.outputs.job)\n",
-    "wf.plot = nodes.Scatter(\n",
+    "wf.structure = nodes.bulk_structure(repeat=3, cubic=True, element=\"Al\")\n",
+    "wf.engine = nodes.lammps(structure=wf.structure.outputs.structure)\n",
+    "wf.calc = nodes.calc_md(job=wf.engine.outputs.job)\n",
+    "wf.plot = nodes.scatter(\n",
     "    x=wf.calc.outputs.steps, \n",
     "    y=wf.calc.outputs.temperature\n",
     ")"

--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -9,7 +9,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5791768f5bad44f7ab2038bcf689aed2",
+       "model_id": "370eb41f32934bdb8efdd4cc32d0eeec",
        "version_major": 2,
        "version_minor": 0
       },
@@ -27,8 +27,7 @@
     }
    ],
    "source": [
-    "from pyiron_contrib.workflow import nodes\n",
-    "from pyiron_contrib.workflow.node import Node\n",
+    "from pyiron_contrib.workflow.node import Node, node\n",
     "from pyiron_contrib.workflow.workflow import Workflow"
    ]
   },
@@ -40,11 +39,12 @@
     "# Pyiron workflows: Introduction and Syntax\n",
     "\n",
     "Here we will highlight:\n",
-    "- The two (and a half) ways of defining a node\n",
-    "- The two x two ways of setting node channel values/connections\n",
+    "- How to instantiate a node\n",
+    "- How to make reusable node classes\n",
+    "- A variety of ways to set node channel data\n",
+    "- How to connect node inputs and outputs together\n",
     "- The four ways of adding nodes to a workflow\n",
-    "\n",
-    "Then we will present a simple working example (TODO)"
+    "- How to import and use pre-defined nodes "
    ]
   },
   {
@@ -52,7 +52,7 @@
    "id": "f4e75528-3ea7-4feb-8167-533d439f798d",
    "metadata": {},
    "source": [
-    "## Defining a node\n",
+    "## Instantiating a node\n",
     "\n",
     "Nodes can be defined on-the-fly by passing any callable to the `Node` class, along with a string (tuple of strings) giving names for the output value(s)."
    ]
@@ -76,7 +76,7 @@
     "    return x+1, x-1\n",
     "\n",
     "try:\n",
-    "    node = Node(plus_minus_one, \"p1\", \"m1\")\n",
+    "    pm_node = Node(plus_minus_one, \"p1\", \"m1\")\n",
     "except TypeError:\n",
     "    print(\"This won't quite work yet!\")"
    ]
@@ -102,7 +102,7 @@
     "def plus_minus_one(x: int | float = 1) -> tuple[int | float, int | float]:\n",
     "    return x+1, x-1\n",
     "\n",
-    "node = Node(plus_minus_one, \"p1\", \"m1\")"
+    "pm_node = Node(plus_minus_one, \"p1\", \"m1\")"
    ]
   },
   {
@@ -128,7 +128,7 @@
     }
    ],
    "source": [
-    "print(node.inputs.labels, node.outputs.labels)"
+    "print(pm_node.inputs.labels, pm_node.outputs.labels)"
    ]
   },
   {
@@ -146,7 +146,7 @@
     }
    ],
    "source": [
-    "print(node.inputs.x.type_hint)"
+    "print(pm_node.inputs.x.type_hint)"
    ]
   },
   {
@@ -172,7 +172,7 @@
     }
    ],
    "source": [
-    "print(node.outputs.to_value_dict())"
+    "print(pm_node.outputs.to_value_dict())"
    ]
   },
   {
@@ -198,8 +198,8 @@
     }
    ],
    "source": [
-    "node.inputs.x.update(2)\n",
-    "print(node.outputs.to_value_dict())"
+    "pm_node.inputs.x.update(2)\n",
+    "print(pm_node.outputs.to_value_dict())"
    ]
   },
   {
@@ -217,8 +217,8 @@
     }
    ],
    "source": [
-    "node.inputs.x = 3\n",
-    "print(node.outputs.to_value_dict())"
+    "pm_node.inputs.x = 3\n",
+    "print(pm_node.outputs.to_value_dict())"
    ]
   },
   {
@@ -226,7 +226,11 @@
    "id": "07a22cee-e340-4551-bb81-07d8be1d152b",
    "metadata": {},
    "source": [
-    "If we're going to use a node many times, we may want to define a new sub-class of `Node` to handle this"
+    "## Reusable node classes\n",
+    "\n",
+    "If we're going to use a node many times, we may want to define a new sub-class of `Node` to handle this.\n",
+    "\n",
+    "The can be done directly by inheriting from `Node` and overriding it's `__init__` function so that the core functionality of the node (i.e. the node function and output labels) are set in stone. Here we do this very succinctly using `functools.partialmethod`:"
    ]
   },
   {
@@ -251,8 +255,6 @@
    "id": "0d7f1c64-c495-4986-a67d-e46782881731",
    "metadata": {},
    "source": [
-    "We could also have done this without `partialmethod` by simply overriding `__init__`, but this way is much tidier.\n",
-    "\n",
     "Note that we only need a single string for `output_labels` when we only return a single value, and that the node's `label` takes (by default) the name of the `node_function`:"
    ]
   },
@@ -288,15 +290,68 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af45e7a1-0a8d-4ad6-9363-ed2bcfe4c405",
+   "id": "fd88faa3-d321-4ab2-93b9-17583ce716b7",
    "metadata": {},
    "source": [
-    "Next, we want to make connections between nodes. Instead of `update` we can use the `connect` method to accomplish this, or we can do it with the other syntactic sugar we saw for regular data:"
+    "We can also define new node classes _even more succinctly_ by using the `@node` decorator! Under the hood it is doing the same stuff we just did above, but here all you need to do is decorate the function you want to have as a node and provide labels for the output:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "7fb1799c-b87b-4e7d-ba92-1b0d2d01028d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@node(\"difference\")\n",
+    "def subtractor(x: int|float, y: int|float) -> int|float:\n",
+    "    return x - y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4819c6e5-1e52-414d-a39d-9e3940b99725",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "class name = Subtractor\n",
+      "label = subtractor\n",
+      "z = -1\n"
+     ]
+    }
+   ],
+   "source": [
+    "sub = subtractor(x=2, y=3)\n",
+    "print(\"class name =\",sub.__class__.__name__)\n",
+    "print(\"label =\", sub.label)\n",
+    "print(\"z =\", sub.outputs.difference)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c799b0e5-ac4a-4b45-b632-715259630107",
+   "metadata": {},
+   "source": [
+    "Note that the new class uses a CamelCase version of the function name, has the method-resolution-order (i.e. parentage) that we expect."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af45e7a1-0a8d-4ad6-9363-ed2bcfe4c405",
+   "metadata": {},
+   "source": [
+    "## Node connections \n",
+    "\n",
+    "Next, we want to make connections between nodes. Instead of `update` we can use the `connect` method to accomplish this, or we can do it with the other syntactic sugar we saw for regular data (i.e. direct attribute access or using kwargs at instantiation):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "594be0e7-c145-4e6f-a2ac-1cb8b34290c2",
    "metadata": {},
    "outputs": [
@@ -339,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "7964df3c-55af-4c25-afc5-9e07accb606a",
    "metadata": {},
    "outputs": [
@@ -354,14 +409,14 @@
     {
      "data": {
       "text/plain": [
-       "{'n1': <pyiron_contrib.workflow.node.Node at 0x14f7c6710>,\n",
-       " 'n2': <pyiron_contrib.workflow.node.Node at 0x14ed06d10>,\n",
-       " 'n3': <pyiron_contrib.workflow.node.Node at 0x14ed7b150>,\n",
-       " 'n4': <pyiron_contrib.workflow.node.Node at 0x14f7c7d10>,\n",
-       " 'n5': <pyiron_contrib.workflow.node.Node at 0x14ed08490>}"
+       "{'n1': <pyiron_contrib.workflow.node.Node at 0x14b2e2910>,\n",
+       " 'n2': <pyiron_contrib.workflow.node.Node at 0x14ab96390>,\n",
+       " 'n3': <pyiron_contrib.workflow.node.Node at 0x14b2d6ad0>,\n",
+       " 'n4': <pyiron_contrib.workflow.node.Node at 0x14b2e3e10>,\n",
+       " 'n5': <pyiron_contrib.workflow.node.Node at 0x14ab806d0>}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,12 +438,14 @@
    "id": "2671dc36-42a4-466b-848d-067ef7bd1d1d",
    "metadata": {},
    "source": [
-    "# Example with pre-built nodes"
+    "# Example with pre-built nodes\n",
+    "\n",
+    "Currently we have a handfull of pre-build nodes available for import from the `nodes` package. Let's use these to quickly put together a workflow for looking at some MD data."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "d56c4464-7aa9-4136-83ea-4acce6a0afb1",
    "metadata": {},
    "outputs": [],
@@ -398,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "bf9ef826-fcfe-47ef-8439-f8b9e495122a",
    "metadata": {},
    "outputs": [],
@@ -408,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "ae500d5e-e55b-432c-8b5f-d5892193cdf5",
    "metadata": {},
    "outputs": [

--- a/pyiron_contrib/workflow/nodes.py
+++ b/pyiron_contrib/workflow/nodes.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from functools import partialmethod
-
 import matplotlib.pyplot as plt
 import numpy as np
 from pyiron_atomistics import Project, _StructureFactory
@@ -9,111 +7,93 @@ from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.lammps.lammps import Lammps as LammpsJob
 
-from pyiron_contrib.workflow.node import Node
+from pyiron_contrib.workflow.node import node
 
 
-class BulkStructure(Node):
-    @staticmethod
-    def bulk_structure(
-            element: str = "Fe",
-            cubic: bool = False,
-            repeat: int = 1,
-    ) -> Atoms:
-        return _StructureFactory().bulk(element, cubic=cubic).repeat(repeat)
-
-    __init__ = partialmethod(Node.__init__, bulk_structure, "structure")
+@node("structure")
+def bulk_structure(element: str = "Fe", cubic: bool = False, repeat: int = 1) -> Atoms:
+    return _StructureFactory().bulk(element, cubic=cubic).repeat(repeat)
 
 
-class Lammps(Node):
-    @staticmethod
-    def lammps(structure: Atoms) -> LammpsJob:
-        pr = Project(".")
-        job = pr.atomistics.job.Lammps("NOTAREALNAME")
-        job.structure = structure
-        job.potential = job.list_potentials()[0]
-        return job
-
-    __init__ = partialmethod(Node.__init__, lammps, "job")
+@node("job")
+def lammps(structure: Atoms) -> LammpsJob:
+    pr = Project(".")
+    job = pr.atomistics.job.Lammps("NOTAREALNAME")
+    job.structure = structure
+    job.potential = job.list_potentials()[0]
+    return job
 
 
-class CalcMD(Node):
-    @staticmethod
-    def calc_md(
-            job: AtomisticGenericJob,
-            n_ionic_steps: int = 1000,
-            n_print: int = 100,
-            temperature: int | float = 300.0,
-            pressure: float
-                      | tuple[float, float, float]
-                      | tuple[float, float, float, float, float, float]
-                      | None = None,
-    ):
-        job_name = "JUSTAJOBNAME"
-        pr = Project("WORKFLOWNAMEPROJECT")
-        job = job.copy_to(project=pr, new_job_name=job_name, delete_existing_job=True)
-        job.calc_md(
-            n_ionic_steps=n_ionic_steps,
-            n_print=n_print,
-            temperature=temperature,
-            pressure=pressure
-        )
-        job.run()
-        cells = job.output.cells
-        displacements = job.output.displacements
-        energy_pot = job.output.energy_pot
-        energy_tot = job.output.energy_tot
-        force_max = job.output.force_max
-        forces = job.output.forces
-        indices = job.output.indices
-        positions = job.output.positions
-        pressures = job.output.pressures
-        steps = job.output.steps
-        temperature = job.output.temperature
-        total_displacements = job.output.total_displacements
-        unwrapped_positions = job.output.unwrapped_positions
-        volume = job.output.volume
-        job.remove()
-        pr.remove(enable=True)
-        return (
-            cells,
-            displacements,
-            energy_pot,
-            energy_tot,
-            force_max,
-            forces,
-            indices,
-            positions,
-            pressures,
-            steps,
-            temperature,
-            total_displacements,
-            unwrapped_positions,
-            volume,
-        )
-
-    __init__ = partialmethod(
-        Node.__init__,
-        calc_md,
-        "cells",
-        "displacements",
-        "energy_pot",
-        "energy_tot",
-        "force_max",
-        "forces",
-        "indices",
-        "positions",
-        "pressures",
-        "steps",
-        "temperature",
-        "total_displacements",
-        "unwrapped_positions",
-        "volume",
+@node(
+    "cells",
+    "displacements",
+    "energy_pot",
+    "energy_tot",
+    "force_max",
+    "forces",
+    "indices",
+    "positions",
+    "pressures",
+    "steps",
+    "temperature",
+    "total_displacements",
+    "unwrapped_positions",
+    "volume",
+)
+def calc_md(
+        job: AtomisticGenericJob,
+        n_ionic_steps: int = 1000,
+        n_print: int = 100,
+        temperature: int | float = 300.0,
+        pressure: float
+                  | tuple[float, float, float]
+                  | tuple[float, float, float, float, float, float]
+                  | None = None,
+):
+    job_name = "JUSTAJOBNAME"
+    pr = Project("WORKFLOWNAMEPROJECT")
+    job = job.copy_to(project=pr, new_job_name=job_name, delete_existing_job=True)
+    job.calc_md(
+        n_ionic_steps=n_ionic_steps,
+        n_print=n_print,
+        temperature=temperature,
+        pressure=pressure
+    )
+    job.run()
+    cells = job.output.cells
+    displacements = job.output.displacements
+    energy_pot = job.output.energy_pot
+    energy_tot = job.output.energy_tot
+    force_max = job.output.force_max
+    forces = job.output.forces
+    indices = job.output.indices
+    positions = job.output.positions
+    pressures = job.output.pressures
+    steps = job.output.steps
+    temperature = job.output.temperature
+    total_displacements = job.output.total_displacements
+    unwrapped_positions = job.output.unwrapped_positions
+    volume = job.output.volume
+    job.remove()
+    pr.remove(enable=True)
+    return (
+        cells,
+        displacements,
+        energy_pot,
+        energy_tot,
+        force_max,
+        forces,
+        indices,
+        positions,
+        pressures,
+        steps,
+        temperature,
+        total_displacements,
+        unwrapped_positions,
+        volume,
     )
 
 
-class Scatter(Node):
-    @staticmethod
-    def scatter(x: list | np.ndarray, y: list | np.ndarray):
-        return plt.scatter(x, y)
-
-    __init__ = partialmethod(Node.__init__, scatter, "fig")
+@node("fig")
+def scatter(x: list | np.ndarray, y: list | np.ndarray):
+    return plt.scatter(x, y)


### PR DESCRIPTION
In response to the [discussion in base](https://github.com/pyiron/ironflow/issues/175), this PR adds a new `node` decorator to define new reusable node classes with even more syntactic sugar.

Before:
```python
from functools import partialmethod
from pyiron_contrib.workflow.node import Node

class Adder(Node):
    @staticmethod
    def adder(x: int|float, y: int|float) -> int|float:
        return x + y
    
    __init__ = partialmethod(Node.__init__, adder, "sum")
```

Now:
```python
from pyiron_contrib.workflow.node import node

@node("sum")
def adder(x: int|float, y: int|float) -> int|float:
    return x + y
```

The demo notebook is updated accordingly.