### PR TITLE
Typeguard fix

### DIFF
--- a/pyiron_contrib/workflow/type_hinting.py
+++ b/pyiron_contrib/workflow/type_hinting.py
@@ -17,7 +17,7 @@ def valid_value(value, type_hint) -> bool:
         # Subscripted generics cannot be used with class and instance checks
         try:
             # typeguard handles this case
-            check_type("", value, type_hint)
+            check_type(value, type_hint)
             return True
         except TypeError:
             # typeguard raises an error on a failed check

--- a/pyiron_contrib/workflow/type_hinting.py
+++ b/pyiron_contrib/workflow/type_hinting.py
@@ -7,7 +7,7 @@ import types
 import typing
 from collections.abc import Callable
 
-from typeguard import check_type
+from typeguard import check_type, TypeCheckError
 
 
 def valid_value(value, type_hint) -> bool:
@@ -19,7 +19,7 @@ def valid_value(value, type_hint) -> bool:
             # typeguard handles this case
             check_type(value, type_hint)
             return True
-        except TypeError:
+        except TypeCheckError:
             # typeguard raises an error on a failed check
             return False
 

--- a/tests/unit/workflow/test_type_hinting.py
+++ b/tests/unit/workflow/test_type_hinting.py
@@ -31,8 +31,10 @@ class TestTypeHinting(TestCase):
                 (tuple[int, float], (1, 1.1), ("fo", 0)),
                 (dict[str, int], {'a': 1}, {'a': 'b'}),
         ):
-            self.assertTrue(valid_value(good, hint))
-            self.assertFalse(valid_value(bad, hint))
+            with self.subTest(msg=f"Good {good} vs hint {hint}"):
+                self.assertTrue(valid_value(good, hint))
+            with self.subTest(msg=f"Bad {bad} vs hint {hint}"):
+                self.assertFalse(valid_value(bad, hint))
 
     def test_hint_comparisons(self):
         # Standard types and typing types should be interoperable


### PR DESCRIPTION
Typguard updated the signature and type of error raised by `check_type`. This PR updates our wrapper to that function to accommodate these changes, and also improves the readability of the relevant tests a little bit.