### PR TITLE
Introduce control channels

### DIFF
--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9aa721332f2644d5a30634bf7dfac067",
+       "model_id": "ceee180feeb547a0b959ccacf8aef2ae",
        "version_major": 2,
        "version_minor": 0
       },
@@ -451,6 +451,89 @@
     "Node(plus_minus_one, \"p1\", \"m1\", label=\"n5\", workflow=wf)  # By passing the workflow\n",
     "\n",
     "wf.nodes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b9220b0-833d-4c6a-9929-5dfa60a47d14",
+   "metadata": {},
+   "source": [
+    "# Flow control\n",
+    "\n",
+    "By default, when a node runs and updates its output, this triggers outputs in all downstream connections. This is useful when all your node functions are small and light, but there may come times when you want something other than this simple \"push\" flow.\n",
+    "\n",
+    "In addition to input and output data channels, nodes also have \"signal\" channels available. Input signals are bound to a callback function (typically one of its node's methods), and output signals trigger the callbacks for all the input signal channels they're connected to.\n",
+    "\n",
+    "Standard nodes have a `run` input signal (which is, unsurprisingly, bound to the `run` method), and a `ran` output signal (which, again, hopefully with no great surprise, is triggered at the end of the `run` method.)\n",
+    "\n",
+    "Below is a super simple example of how these signal channels can be used to delay execution and manually control flow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2e418abf-7059-4e1e-9b9f-b3dc0a4b5e35",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 None\n"
+     ]
+    }
+   ],
+   "source": [
+    "@node(\"y\")\n",
+    "def linear(x):\n",
+    "    return x\n",
+    "\n",
+    "@node(\"z\")\n",
+    "def times_two(y):\n",
+    "    return 2 * y\n",
+    "\n",
+    "l = linear(x=1)\n",
+    "t2 = times_two(\n",
+    "    y=l.outputs.y, update_on_instantiation=False, run_automatically=False\n",
+    ")\n",
+    "print(t2.inputs.y, t2.outputs.z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37aa4455-9b98-4be5-a365-363e3c490bb6",
+   "metadata": {},
+   "source": [
+    "Now the input of `t2` got updated when the connection is made, but we told this node not to do any automatic updates, so the output has its uninitialized value of `None`.\n",
+    "\n",
+    "Often, you will probably want to have nodes with data connections to have signal connections, but this is not strictly required. Here, we'll introduce a third node to control the execution of `t2`.\n",
+    "\n",
+    "Note that we have all the same syntacic sugar from data channels when creating connections between signal channels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3310eac4-04f6-421b-9824-19bb2d680be6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "@node(\"void\")\n",
+    "def control():\n",
+    "    return\n",
+    "\n",
+    "c = control()\n",
+    "t2.signals.input.run = c.signals.output.ran\n",
+    "c.run()\n",
+    "print(t2.outputs.z.value)"
    ]
   },
   {

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -62,6 +62,13 @@ class Channel(HasToDict, ABC):
     def __len__(self):
         return len(self.connections)
 
+    def to_dict(self):
+        return {
+            "label": self.label,
+            "connected": self.connected,
+            "connections": [f"{c.node.label}.{c.label}" for c in self.connections]
+        }
+
 
 class DataChannel(Channel, ABC):
     """
@@ -185,13 +192,9 @@ class DataChannel(Channel, ABC):
         return str(self.value)
 
     def to_dict(self):
-        return {
-            "label": self.label,
-            "value": str(self.value),
-            "ready": self.ready,
-            "connected": self.connected,
-            "connections": [f"{c.node.label}.{c.label}" for c in self.connections]
-        }
+        d = super().to_dict()
+        d["value"] = self.value
+        d["ready"] = self.ready
 
 
 class InputData(DataChannel):
@@ -264,16 +267,12 @@ class InputSignal(SignalChannel):
         self.callback()
 
     def __str__(self):
-        return f"{self.label} runs " \
-               f"{[f.__name__ for f in self.callbacks]}"
+        return f"{self.label} runs {self.callback.__name__}"
 
     def to_dict(self):
-        return {
-            "label": self.label,
-            "callbacks": [f.__name__ for f in self.callbacks],
-            "connected": self.connected,
-            "connections": [f"{c.node.label}.{c.label}" for c in self.connections]
-        }
+        d = super().to_dict()
+        d["callback"] = self.callback.__name__
+        return d
 
 
 class OutputSignal(SignalChannel):
@@ -284,10 +283,3 @@ class OutputSignal(SignalChannel):
     def __str__(self):
         return f"{self.label} activates " \
                f"{[f'{c.node.label}.{c.label}' for c in self.connections]}"
-
-    def to_dict(self):
-        return {
-            "label": self.label,
-            "connected": self.connected,
-            "connections": [f"{c.node.label}.{c.label}" for c in self.connections]
-        }

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -60,7 +60,7 @@ class Channel(HasToDict, ABC):
         return len(self.connections)
 
 
-class DataChannel(Channel):
+class DataChannel(Channel, ABC):
     """
     Data channels control the flow of data on the graph.
     They store this data in a `value` attribute.

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -180,7 +180,7 @@ class DataChannel(Channel, ABC):
             return False
 
     def _is_IO_pair(self, other: DataChannel):
-        return isinstance(other, DataChannel) and type(self) != type(other)
+        return isinstance(other, DataChannel) and not isinstance(other, self.__class__)
 
     def _both_typed(self, other: DataChannel):
         return self.type_hint is not None and other.type_hint is not None
@@ -250,7 +250,8 @@ class SignalChannel(Channel, ABC):
         return self._is_IO_pair(other) and not self._already_connected(other)
 
     def _is_IO_pair(self, other) -> bool:
-        return isinstance(other, SignalChannel) and type(self) != type(other)
+        return isinstance(other, SignalChannel) \
+            and not isinstance(other, self.__class__)
 
 
 class InputSignal(SignalChannel):

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
     from pyiron_contrib.workflow.node import Node
 
 
-class Channel(HasToDict):
+class DataChannel(HasToDict):
     """
     Channels control the flow of data on the graph.
     They have a label and belong to a node.
@@ -89,7 +89,7 @@ class Channel(HasToDict):
         else:
             return True
 
-    def connect(self, *others: Channel):
+    def connect(self, *others: DataChannel):
         for other in others:
             if self._valid_connection(other):
                 self.connections.append(other)
@@ -97,7 +97,7 @@ class Channel(HasToDict):
                 out, inp = self._figure_out_who_is_who(other)
                 inp.update(out.value)
             else:
-                if isinstance(other, Channel):
+                if isinstance(other, DataChannel):
                     warn(
                         f"{self.label} ({self.__class__.__name__}) and {other.label} "
                         f"({other.__class__.__name__}) were not a valid connection"
@@ -124,19 +124,19 @@ class Channel(HasToDict):
         else:
             return False
 
-    def _is_IO_pair(self, other: Channel):
-        return isinstance(other, Channel) and type(self) != type(other)
+    def _is_IO_pair(self, other: DataChannel):
+        return isinstance(other, DataChannel) and type(self) != type(other)
 
-    def _already_connected(self, other: Channel):
+    def _already_connected(self, other: DataChannel):
         return other in self.connections
 
-    def _both_typed(self, other: Channel):
+    def _both_typed(self, other: DataChannel):
         return self.type_hint is not None and other.type_hint is not None
 
-    def _figure_out_who_is_who(self, other: Channel) -> (OutputChannel, InputChannel):
-        return (self, other) if isinstance(self, OutputChannel) else (other, self)
+    def _figure_out_who_is_who(self, other: DataChannel) -> (OutputData, InputData):
+        return (self, other) if isinstance(self, OutputData) else (other, self)
 
-    def disconnect(self, *others: Channel):
+    def disconnect(self, *others: DataChannel):
         for other in others:
             if other in self.connections:
                 self.connections.remove(other)
@@ -168,7 +168,7 @@ class Channel(HasToDict):
         }
 
 
-class InputChannel(Channel):
+class InputData(DataChannel):
     def update(self, value):
         self.value = value
         self.node.update()
@@ -180,7 +180,7 @@ class InputChannel(Channel):
         self.strict_connections = False
 
 
-class OutputChannel(Channel):
+class OutputData(DataChannel):
     def update(self, value):
         self.value = value
         for inp in self.connections:

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -125,7 +125,7 @@ class DataChannel(Channel):
         self.value = default
         self.type_hint = type_hint
         self.storage_priority = storage_priority
-        self.strict_connections = True
+        self.strict_connections = strict_connections
 
     @property
     def ready(self):

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 
-from pyiron_contrib.workflow.channels import Channel, InputChannel, OutputChannel
+from pyiron_contrib.workflow.channels import DataChannel, InputData, OutputData
 from pyiron_contrib.workflow.has_to_dict import HasToDict
 from pyiron_contrib.workflow.util import DotDict
 
@@ -32,7 +32,7 @@ class IO(HasToDict):
     is equivalent to
     >>> some_io.some_existing_channel.connect(some_other_channel)
     """
-    def __init__(self, *channels: Channel):
+    def __init__(self, *channels: DataChannel):
         self.channel_dict = DotDict(
             {
                 channel.label: channel for channel in channels
@@ -42,7 +42,7 @@ class IO(HasToDict):
 
     @property
     @abstractmethod
-    def _channel_class(self) -> Channel:
+    def _channel_class(self) -> DataChannel:
         pass
 
     def __getattr__(self, item):
@@ -52,7 +52,7 @@ class IO(HasToDict):
         if key in ["channel_dict", "channel_list"]:
             super().__setattr__(key, value)
         elif key in self.channel_dict.keys():
-            if isinstance(value, Channel):
+            if isinstance(value, DataChannel):
                 self.channel_dict[key].connect(value)
             else:
                 self.channel_dict[key].update(value)
@@ -123,8 +123,8 @@ class IO(HasToDict):
 
 class Inputs(IO):
     @property
-    def _channel_class(self) -> InputChannel:
-        return InputChannel
+    def _channel_class(self) -> InputData:
+        return InputData
 
     def activate_strict_connections(self):
         [c.activate_strict_connections() for c in self]
@@ -135,5 +135,5 @@ class Inputs(IO):
 
 class Outputs(IO):
     @property
-    def _channel_class(self) -> OutputChannel:
-        return OutputChannel
+    def _channel_class(self) -> OutputData:
+        return OutputData

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -188,3 +188,21 @@ class Signals:
     def __init__(self):
         self.input = InputSignals()
         self.output = OutputSignals()
+
+    def disconnect(self):
+        self.input.disconnect()
+        self.output.disconnect()
+
+    @property
+    def connected(self):
+        return self.input.connected or self.output.connected
+
+    @property
+    def fully_connected(self):
+        return self.input.fully_connected and self.output.fully_connected
+
+    def to_dict(self):
+        return {
+            "input": self.input.to_dict(),
+            "output": self.output.to_dict(),
+        }

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -49,6 +49,11 @@ class IO(HasToDict, ABC):
     def _channel_class(self) -> Channel:
         pass
 
+    @property
+    @abstractmethod
+    def label(self) -> str:
+        pass
+
     @abstractmethod
     def _set_existing(self, key, value):
         pass
@@ -105,6 +110,14 @@ class IO(HasToDict, ABC):
     def __dir__(self):
         return set(super().__dir__() + self.labels)
 
+    def to_dict(self):
+        return {
+            "label": self.__class__.__name__,
+            "connected": self.connected,
+            "fully_connected": self.fully_connected,
+            "channels": {l: c.to_dict() for l, c in self.channel_dict.items()}
+        }
+
 
 class DataIO(IO, ABC):
     def _set_existing(self, key, value):
@@ -125,13 +138,9 @@ class DataIO(IO, ABC):
             c.storage_priority = priority
 
     def to_dict(self):
-        return {
-            "label": "inputs",
-            "ready": self.ready,
-            "connected": self.connected,
-            "fully_connected": self.fully_connected,
-            "channels": {l: c.to_dict() for l, c in self.channel_dict.items()}
-        }
+        d = super().to_dict()
+        d["ready"] = self.ready
+        return d
 
 
 class Inputs(DataIO):
@@ -162,14 +171,6 @@ class SignalIO(IO, ABC):
                 f" a {type(self.channel_dict[key])}. Only other signal channels may be "
                 f"connected in this way."
             )
-
-    def to_dict(self):
-        return {
-            "label": "inputs",
-            "connected": self.connected,
-            "fully_connected": self.fully_connected,
-            "channels": {l: c.to_dict() for l, c in self.channel_dict.items()}
-        }
 
 
 class InputSignals(SignalIO):

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -49,7 +49,7 @@ class IO(HasToDict):
         return self.channel_dict[item]
 
     def __setattr__(self, key, value):
-        if key in ["channel_dict", "channel_list"]:
+        if key in ["channel_dict"]:
             super().__setattr__(key, value)
         elif key in self.channel_dict.keys():
             if isinstance(value, DataChannel):

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -49,11 +49,6 @@ class IO(HasToDict, ABC):
     def _channel_class(self) -> Channel:
         pass
 
-    @property
-    @abstractmethod
-    def label(self) -> str:
-        pass
-
     @abstractmethod
     def _set_existing(self, key, value):
         pass

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -4,7 +4,7 @@ import inspect
 from functools import partialmethod
 from typing import get_args, get_type_hints, Optional, TYPE_CHECKING
 
-from pyiron_contrib.workflow.channels import InputChannel, OutputChannel
+from pyiron_contrib.workflow.channels import InputData, OutputData
 from pyiron_contrib.workflow.has_to_dict import HasToDict
 from pyiron_contrib.workflow.io import Inputs, Outputs
 
@@ -246,7 +246,7 @@ class Node(HasToDict):
         self.run_automatically = False
         for k, v in kwargs.items():
             if k in self.inputs.labels:
-                if isinstance(v, OutputChannel):
+                if isinstance(v, OutputData):
                     self.inputs[k] = v
                 else:
                     self.inputs[k].update(v)
@@ -276,7 +276,7 @@ class Node(HasToDict):
             else:
                 default = None
 
-            channels.append(InputChannel(
+            channels.append(InputData(
                 label=label,
                 node=self,
                 default=default,
@@ -318,7 +318,7 @@ class Node(HasToDict):
                 priority = None
 
             channels.append(
-                OutputChannel(
+                OutputData(
                     label=label,
                     node=self,
                     type_hint=hint,

--- a/tests/unit/workflow/test_channels.py
+++ b/tests/unit/workflow/test_channels.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, skipUnless
 from sys import version_info
 
-from pyiron_contrib.workflow.channels import InputChannel, OutputChannel
+from pyiron_contrib.workflow.channels import InputData, OutputData
 
 
 class DummyNode:
@@ -13,12 +13,12 @@ class DummyNode:
 class TestChannels(TestCase):
 
     def setUp(self) -> None:
-        self.ni1 = InputChannel(label="numeric", node=DummyNode(), default=1, type_hint=int | float)
-        self.ni2 = InputChannel(label="numeric", node=DummyNode(), default=1, type_hint=int | float)
-        self.no = OutputChannel(label="numeric", node=DummyNode(), default=0, type_hint=int | float)
+        self.ni1 = InputData(label="numeric", node=DummyNode(), default=1, type_hint=int | float)
+        self.ni2 = InputData(label="numeric", node=DummyNode(), default=1, type_hint=int | float)
+        self.no = OutputData(label="numeric", node=DummyNode(), default=0, type_hint=int | float)
 
-        self.so1 = OutputChannel(label="list", node=DummyNode(), default=["foo"], type_hint=list)
-        self.so2 = OutputChannel(label="list", node=DummyNode(), default=["foo"], type_hint=list)
+        self.so1 = OutputData(label="list", node=DummyNode(), default=["foo"], type_hint=list)
+        self.so2 = OutputData(label="list", node=DummyNode(), default=["foo"], type_hint=list)
 
     def test_mutable_defaults(self):
         self.so1.default.append("bar")

--- a/tests/unit/workflow/test_channels.py
+++ b/tests/unit/workflow/test_channels.py
@@ -1,16 +1,21 @@
 from unittest import TestCase, skipUnless
 from sys import version_info
 
-from pyiron_contrib.workflow.channels import InputData, OutputData
+from pyiron_contrib.workflow.channels import (
+    InputData, OutputData, InputSignal, OutputSignal, SignalChannel
+)
 
 
 class DummyNode:
+    def __init__(self):
+        self.foo = [0]
+
     def update(self):
-        pass
+        self.foo.append(self.foo[-1] + 1)
 
 
 @skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
-class TestChannels(TestCase):
+class TestDataChannels(TestCase):
 
     def setUp(self) -> None:
         self.ni1 = InputData(label="numeric", node=DummyNode(), default=1, type_hint=int | float)
@@ -107,3 +112,38 @@ class TestChannels(TestCase):
                 inp.value,
                 msg="Value should have been passed downstream"
             )
+
+
+class TestSignalChannels(TestCase):
+    def setUp(self) -> None:
+        node = DummyNode()
+        self.inp = InputSignal(label="inp", node=node, callback=node.update)
+        self.out = OutputSignal(label="out", node=DummyNode())
+
+    def test_connections(self):
+        with self.subTest("Good connection"):
+            self.inp.connect(self.out)
+            self.assertEqual(self.inp.connections, [self.out])
+            self.assertEqual(self.out.connections, [self.inp])
+
+        with self.subTest("Ignore repeated connection"):
+            self.out.connect(self.inp)
+            self.assertEqual(len(self.inp), 1)
+            self.assertEqual(len(self.out), 1)
+
+        with self.subTest("Check disconnection"):
+            self.out.disconnect_all()
+            self.assertEqual(len(self.inp), 0)
+            self.assertEqual(len(self.out), 0)
+
+        with self.subTest("No connections to non-SignalChannels"):
+            bad = InputData(label="numeric", node=DummyNode(), default=1, type_hint=int)
+            with self.assertRaises(TypeError):
+                self.inp.connect(bad)
+
+    def test_calls(self):
+        self.out.connect(self.inp)
+        self.out()
+        self.assertListEqual(self.inp.node.foo, [0, 1])
+        self.inp()
+        self.assertListEqual(self.inp.node.foo, [0, 1, 2])

--- a/tests/unit/workflow/test_channels.py
+++ b/tests/unit/workflow/test_channels.py
@@ -2,7 +2,7 @@ from unittest import TestCase, skipUnless
 from sys import version_info
 
 from pyiron_contrib.workflow.channels import (
-    InputData, OutputData, InputSignal, OutputSignal, SignalChannel
+    InputData, OutputData, InputSignal, OutputSignal
 )
 
 

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, skipUnless
 from sys import version_info
 
-from pyiron_contrib.workflow.channels import InputChannel, OutputChannel
+from pyiron_contrib.workflow.channels import InputData, OutputData
 from pyiron_contrib.workflow.io import Inputs, Outputs
 
 
@@ -17,14 +17,14 @@ class TestIO(TestCase):
     def setUp(self) -> None:
         node = DummyNode()
         self.inputs = [
-            InputChannel(label="x", node=node, default=0, type_hint=float),
-            InputChannel(label="y", node=node, default=1, type_hint=float)
+            InputData(label="x", node=node, default=0, type_hint=float),
+            InputData(label="y", node=node, default=1, type_hint=float)
         ]
         outputs = [
-            OutputChannel(label="a", node=node, type_hint=float),
+            OutputData(label="a", node=node, type_hint=float),
         ]
 
-        self.post_facto_output = OutputChannel(label="b", node=node, type_hint=float)
+        self.post_facto_output = OutputData(label="b", node=node, type_hint=float)
 
         self.input = Inputs(*self.inputs)
         self.output = Outputs(*outputs)

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -74,7 +74,7 @@ class TestNode(TestCase):
 
         l = linear(x=1)
         t2 = times_two(
-            y=l.outputs.y, update_on_instantiation=False, run_automatically=False
+            update_on_instantiation=False, run_automatically=False, y=l.outputs.y
         )
         self.assertIsNone(
             t2.outputs.z.value,


### PR DESCRIPTION
Workflow nodes now have a space for signal channels that control callbacks. By default they have a `run` channel (which has the node's `run` method as a callback) and a `ran` channel (which triggers at the end of the `run` method). Adding more is possible, so we should be able to get more complex conditional flow as discussed (among many other things) [here](https://github.com/pyiron/ironflow/issues/188#issuecomment-1504129976) and as seen in [Unity's blueprints scheme](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/Blueprints/UserGuide/FlowControl/). (Edited to add hyperlinks)

Here is the new content of the demo:

# Flow control

By default, when a node runs and updates its output, this triggers outputs in all downstream connections. This is useful when all your node functions are small and light, but there may come times when you want something other than this simple "push" flow.

In addition to input and output data channels, nodes also have "signal" channels available. Input signals are bound to a callback function (typically one of its node's methods), and output signals trigger the callbacks for all the input signal channels they're connected to.

Standard nodes have a `run` input signal (which is, unsurprisingly, bound to the `run` method), and a `ran` output signal (which, again, hopefully with no great surprise, is triggered at the end of the `run` method.)

Below is a super simple example of how these signal channels can be used to delay execution and manually control flow (you will need `from pyiron_contrib.workflow.node import node`):

```python
@node("y")
def linear(x):
    return x

@node("z")
def times_two(y):
    return 2 * y

l = linear(x=1)
t2 = times_two(
    y=l.outputs.y, update_on_instantiation=False, run_automatically=False
)
print(t2.inputs.y, t2.outputs.z)
>>> 1, None
```

Now the input of `t2` got updated when the connection is made, but we told this node not to do any automatic updates, so the output has its uninitialized value of `None`.

Often, you will probably want to have nodes with data connections to have signal connections, but this is not strictly required. Here, we'll introduce a third node to control the execution of `t2`.

Note that we have all the same syntacic sugar from data channels when creating connections between signal channels.

```python
@node("void")
def control():
    return

c = control()
t2.signals.input.run = c.signals.output.ran
c.run()
print(t2.outputs.z.value)
>>> 2
```