### PR TITLE
Single import for workflows

### DIFF
--- a/pyiron_contrib/workflow/__init__.py
+++ b/pyiron_contrib/workflow/__init__.py
@@ -1,0 +1,1 @@
+from pyiron_contrib.workflow.workflow import Workflow

--- a/pyiron_contrib/workflow/workflow.py
+++ b/pyiron_contrib/workflow/workflow.py
@@ -4,7 +4,7 @@ from functools import partial
 from warnings import warn
 
 from pyiron_contrib.workflow.has_to_dict import HasToDict
-from pyiron_contrib.workflow.node import Node
+from pyiron_contrib.workflow.node import Node, node
 from pyiron_contrib.workflow.util import DotDict
 
 
@@ -58,6 +58,11 @@ class _NodeAdder:
 
         self._workflow.nodes[node.label] = node
         node.workflow = self._workflow
+
+
+class _NodeDecoratorAccess:
+    """An intermediate container to store node-creating decorators as class methods."""
+    node = node
 
 
 class Workflow(HasToDict):
@@ -129,6 +134,8 @@ class Workflow(HasToDict):
         apply that falls short of a full export, but still guarantees the internal
         integrity of workflows when they're used somewhere else?
     """
+    wrap_as = _NodeDecoratorAccess
+
     def __init__(self, label: str, *nodes: Node, strict_naming=True):
         self.__dict__['label'] = label
         self.__dict__['nodes'] = DotDict()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+from pyiron_contrib.workflow.workflow import Workflow

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,1 +1,0 @@
-from pyiron_contrib.workflow.workflow import Workflow

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -79,3 +79,10 @@ class TestWorkflow(TestCase):
 
         self.assertEqual(len(wf.input), 1)
         self.assertEqual(len(wf.output), 1)
+
+    def test_node_decorators(self):
+        @Workflow.wrap_as.node("y")
+        def plus_one(x: int = 0) -> int:
+            return x + 1
+
+        self.assertEqual(plus_one().outputs.y.value, 1)


### PR DESCRIPTION
Expose the node-creation decorators (right now just `node`) as class attributes on the workflow so that you can work with the workflow infrastructure after _only_ importing `Workflow`.

Eg the following now works:
```python
from pyiron_contrib.workflow.workflow import Workflow

@Workflow.wrap_as.node("y")
def plus_one(x: int = 0) -> int:
    return x + 1

plus_one().outputs.y.value
>>> 1
```