### PR TITLE
Make normal nodes slow

### DIFF
--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ceee180feeb547a0b959ccacf8aef2ae",
+       "model_id": "b04ad159923f4d67870f859105813dd9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -47,8 +47,7 @@
     }
    ],
    "source": [
-    "from pyiron_contrib.workflow.node import Node, node\n",
-    "from pyiron_contrib.workflow.workflow import Workflow"
+    "from pyiron_contrib.workflow.node import Node"
    ]
   },
   {
@@ -61,10 +60,11 @@
     "Here we will highlight:\n",
     "- How to instantiate a node\n",
     "- How to make reusable node classes\n",
-    "- A variety of ways to set node channel data\n",
     "- How to connect node inputs and outputs together\n",
-    "- The four ways of adding nodes to a workflow\n",
-    "- How to import and use pre-defined nodes "
+    "- Defining new nodes from special node classes (Fast and SingleValue)\n",
+    "- The five ways of adding nodes to a workflow\n",
+    "- Flow control (i.e. signal channels vs data channels)\n",
+    "- Using pre-defined nodes "
    ]
   },
   {
@@ -82,44 +82,9 @@
    "execution_count": 2,
    "id": "2502bc6b-d961-43d1-b2d9-66b20e2740d7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This won't quite work yet!\n"
-     ]
-    }
-   ],
-   "source": [
-    "def plus_minus_one(x):\n",
-    "    return x+1, x-1\n",
-    "\n",
-    "try:\n",
-    "    pm_node = Node(plus_minus_one, \"p1\", \"m1\")\n",
-    "except TypeError:\n",
-    "    print(\"This won't quite work yet!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "89142b6b-3401-4606-98f9-8dbd5e40f6f0",
-   "metadata": {},
-   "source": [
-    "Unless you specify additional kwargs (i.e. `run_automatically=False`, `update_on_instantiation=False`), your node will try to execute the function immediately! In the example above, this resulted in a `TypeError` (from `None + 1`).\n",
-    "\n",
-    "Instead of just preventing the update by decree, we could (a) provide default values for our function, and/or (b) provide type hints for our function (the node will only run automatically once all the input data has the right type (where specified)).\n",
-    "Let's do both"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "6035d22e-594c-4b3e-9ab0-bb5ece641074",
-   "metadata": {},
    "outputs": [],
    "source": [
-    "def plus_minus_one(x: int | float = 1) -> tuple[int | float, int | float]:\n",
+    "def plus_minus_one(x):\n",
     "    return x+1, x-1\n",
     "\n",
     "pm_node = Node(plus_minus_one, \"p1\", \"m1\")"
@@ -127,16 +92,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f4ff622-4d6b-4aca-9215-4de90e6d83e2",
+   "id": "5d15f0c2-b36d-4960-86b3-40d769f78528",
    "metadata": {},
    "source": [
-    "When we create a node, input and output data channels are constructed automatically from the signature and type hints of the function, and the output labels."
+    "This has automatically created a node with input and output data channels whose labels are gathered by inspecting the function:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "769a6543-6fc8-4004-b97a-6a42584a4f29",
+   "execution_count": 3,
+   "id": "840f4c07-4b21-4bcc-b15c-9847c6c1b048",
    "metadata": {},
    "outputs": [
     {
@@ -152,47 +117,101 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "22ee2a49-47d1-4cec-bb25-8441ea01faf7",
+   "metadata": {},
+   "source": [
+    "The output is still empty because we haven't `run` the node.\n",
+    "If we try that now though, we'll just get a type error because the input is not set!\n",
+    "Let's set the input and run the node:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "1136c118-d035-40a3-a456-2a1c01583d26",
+   "execution_count": 4,
+   "id": "613a90fa-66ed-49f8-ba8c-2f83a54253cd",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "int | float\n"
+      "{'p1': None, 'm1': None}\n",
+      "{'p1': 6, 'm1': 4}\n"
      ]
     }
    ],
    "source": [
-    "print(pm_node.inputs.x.type_hint)"
+    "print(pm_node.outputs.to_value_dict())\n",
+    "pm_node.inputs.x = 5\n",
+    "pm_node.run()\n",
+    "print(pm_node.outputs.to_value_dict())"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b551b4de-6dc4-4d8a-be5e-536e5517f6d9",
+   "id": "df4520d7-856e-4bc8-817f-5b2e22c1ddce",
    "metadata": {},
    "source": [
-    "And now that it could safely update right away, we can look at the output:"
+    "Nodes also have the option to `run_on_updates` -- i.e. to attempt a `run` command whenever _any_ of their input data gets updated -- and to `update_on_instantiation`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ab1ac28a-6e69-491f-882f-da4a43162dd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def adder(x: int, y: int = 1) -> int:\n",
+    "    return x + y\n",
+    "\n",
+    "adder_node = Node(adder, \"sum\", run_on_updates=True, update_on_instantiation=True)\n",
+    "adder_node.inputs.x = 1\n",
+    "adder_node.outputs.sum.value  # We use `value` to see the data the channel holds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0929f222-6073-4201-b5a1-723c31c8998a",
+   "metadata": {},
+   "source": [
+    "We see that now the output got populated automatically when we updated `x`. \n",
+    "We can safely update it back to something silly without causing an error because of our type hints."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "0af9df19-61c3-4b78-9a91-b6f4aaabf591",
+   "id": "ac0fe993-6c82-48c8-a780-cbd0c97fc386",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'p1': 2, 'm1': 0}\n"
-     ]
+     "data": {
+      "text/plain": [
+       "int"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print(pm_node.outputs.to_value_dict())"
+    "adder_node.inputs.x = \"not an integer\"\n",
+    "adder_node.inputs.x.type_hint\n",
+    "# No error because the update doesn't trigger a run"
    ]
   },
   {
@@ -200,7 +219,7 @@
    "id": "263f5b24-113f-45d9-82cc-0475c59da587",
    "metadata": {},
    "source": [
-    "We can assign new data to the input channels with the `update` method, or with `=`:"
+    "Note that assigning data to channels with `=` is actually just syntactic sugar for calling the `update` method of the underlying channel:"
    ]
   },
   {
@@ -210,35 +229,19 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'p1': 3, 'm1': 1}\n"
-     ]
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "pm_node.inputs.x.update(2)\n",
-    "print(pm_node.outputs.to_value_dict())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "26052b2d-cd2c-4073-b3cb-8173b58298c9",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'p1': 4, 'm1': 2}\n"
-     ]
-    }
-   ],
-   "source": [
-    "pm_node.inputs.x = 3\n",
-    "print(pm_node.outputs.to_value_dict())"
+    "adder_node.inputs.x.update(2)\n",
+    "adder_node.outputs.sum.value"
    ]
   },
   {
@@ -250,113 +253,77 @@
     "\n",
     "If we're going to use a node many times, we may want to define a new sub-class of `Node` to handle this.\n",
     "\n",
-    "The can be done directly by inheriting from `Node` and overriding it's `__init__` function so that the core functionality of the node (i.e. the node function and output labels) are set in stone. Here we do this very succinctly using `functools.partialmethod`:"
+    "The can be done directly by inheriting from `Node` and overriding it's `__init__` function so that the core functionality of the node (i.e. the node function and output labels) are set in stone, but even easier is to use the `node` decorator to do this for you!\n",
+    "\n",
+    "The decorator takes the output labels and whatever other class kwargs you want to override, and the function is defined like any other node function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "61b43a9b-8dad-48b7-9194-2045e465793b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyiron_contrib.workflow.node import node"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "aca2ce54-f19a-4d3d-8583-50313d50bf20",
+   "id": "647360a9-c971-4272-995c-aa01e5f5bb83",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "class name = SubtractNode\n",
+      "label = subtract_node\n",
+      "default output = 1\n"
+     ]
+    }
+   ],
    "source": [
-    "from functools import partialmethod\n",
+    "@node(\"diff\", run_on_updates=True, update_on_instantiation=True)\n",
+    "def subtract_node(x: int | float = 2, y: int | float = 1) -> int | float:\n",
+    "    return x - y\n",
     "\n",
-    "class Adder(Node):\n",
-    "    @staticmethod\n",
-    "    def adder(x: int|float, y: int|float) -> int|float:\n",
-    "        return x + y\n",
-    "    \n",
-    "    __init__ = partialmethod(Node.__init__, adder, \"sum\")"
+    "sn = subtract_node()\n",
+    "print(\"class name =\", sn.__class__.__name__)\n",
+    "print(\"label =\", sn.label)\n",
+    "print(\"default output =\", sn.outputs.diff.value)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0d7f1c64-c495-4986-a67d-e46782881731",
+   "id": "7b7133ff-6ef6-49fa-9eb0-7c280de9b1e5",
    "metadata": {},
    "source": [
-    "Note that we only need a single string for `output_labels` when we only return a single value, and that the node's `label` takes (by default) the name of the `node_function`:"
+    "Earlier we saw that we could set input data by function defaults, or by directly setting the `.inputs.*` channel values with an `=` assignement or `.update` method call.\n",
+    "\n",
+    "We can also set the input of a node instance at instantiation by passing the input labels as kwargs!"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "81ab5c0c-a710-49dd-904f-ce6f328b06c8",
+   "id": "8fb0671b-045a-4d71-9d35-f0beadc9cf3a",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "adder\n",
-      "5\n"
-     ]
+     "data": {
+      "text/plain": [
+       "-10"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "add = Adder(x=2, y=3)\n",
-    "print(add.label)\n",
-    "print(add.outputs.sum)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ddaa1e08-464c-41b5-94b1-4fc69970df52",
-   "metadata": {},
-   "source": [
-    "Here we have also shown another way to initialize data -- right at instantiation as a kwarg.\n",
-    "Kwarg values matching the node function signature will be passed from the node initializer to the channels."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fd88faa3-d321-4ab2-93b9-17583ce716b7",
-   "metadata": {},
-   "source": [
-    "We can also define new node classes _even more succinctly_ by using the `@node` decorator! Under the hood it is doing the same stuff we just did above, but here all you need to do is decorate the function you want to have as a node and provide labels for the output:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "7fb1799c-b87b-4e7d-ba92-1b0d2d01028d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@node(\"difference\")\n",
-    "def subtractor(x: int|float, y: int|float) -> int|float:\n",
-    "    return x - y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "4819c6e5-1e52-414d-a39d-9e3940b99725",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "class name = Subtractor\n",
-      "label = subtractor\n",
-      "z = -1\n"
-     ]
-    }
-   ],
-   "source": [
-    "sub = subtractor(x=2, y=3)\n",
-    "print(\"class name =\",sub.__class__.__name__)\n",
-    "print(\"label =\", sub.label)\n",
-    "print(\"z =\", sub.outputs.difference)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c799b0e5-ac4a-4b45-b632-715259630107",
-   "metadata": {},
-   "source": [
-    "Note that the new class uses a CamelCase version of the function name, has the method-resolution-order (i.e. parentage) that we expect."
+    "subtract_node(x=10, y=20).outputs.diff.value"
    ]
   },
   {
@@ -371,33 +338,137 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "594be0e7-c145-4e6f-a2ac-1cb8b34290c2",
+   "execution_count": 11,
+   "id": "5ce91f42-7aec-492c-94fb-2320c971cd79",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 1 1\n",
-      "11 11 11\n"
+      "2 - 4 = -2\n"
      ]
     }
    ],
    "source": [
-    "upstream = Adder(x=0, y=0)\n",
+    "@node(\"sum\", run_on_updates=True, update_on_instantiation=True)\n",
+    "def add_node(x: int | float = 1, y: int | float = 1) -> int | float:\n",
+    "    return x + y\n",
     "\n",
-    "ds1 = Node(plus_minus_one, \"p1\", \"m1\")\n",
-    "ds1.inputs.x.connect(upstream.outputs.sum)\n",
+    "add1 = add_node()\n",
+    "add2 = add_node(x=2, y=2)\n",
+    "sub = subtract_node(x=add1.outputs.sum, y=add2.outputs.sum)\n",
+    "print(\n",
+    "    f\"{add1.outputs.sum.value} - {add2.outputs.sum.value} = {sub.outputs.diff.value}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bea37ae-65f6-4842-b507-9542f17791ca",
+   "metadata": {},
+   "source": [
+    "Because we've set all of our nodes to run automatically on updates, we can change upstream data and see the result propogate downstream immediately:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "20360fe7-b422-4d78-9bd1-de233f28c8df",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "11 - 4 = 7\n"
+     ]
+    }
+   ],
+   "source": [
+    "add1.inputs.x = 10\n",
+    "print(\n",
+    "    f\"{add1.outputs.sum.value} - {add2.outputs.sum.value} = {sub.outputs.diff.value}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5c531a3-77e4-48ad-a189-fed619e79baa",
+   "metadata": {},
+   "source": [
+    "## Special nodes\n",
     "\n",
-    "ds2 = Node(plus_minus_one, \"p1\", \"m1\")\n",
-    "ds2.inputs.x = upstream.outputs.sum\n",
+    "In addition to the basic `Node` class, for the sake of convenience we also offer `FastNode(Node)` -- which enforces that all the node function inputs are type-hinted and have defaults, then sets `run_on_updates=True` and `update_on_instantiation=True` --, and `SingleValueNode(FastNode)` -- which further enforces that there is only a _single_ return value to the node function (i.e. a single output label), and then lets attribute and item access fall back to looking for attributes and items of this single output value. Of course there are decorators available for both of these.\n",
     "\n",
-    "ds3 = Node(plus_minus_one, \"p1\", \"m1\", x=upstream.outputs.sum)\n",
+    "Let's look at a use case:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "1a4e9693-0980-4435-aecc-3331d8b608dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from pyiron_contrib.workflow.node import single_value_node"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "7c4d314b-33bb-4a67-bfb9-ed77fba3949c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'numpy.ndarray'>\n",
+      "[0.02040816 0.04081633 0.06122449]\n",
+      "0.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "@single_value_node(\"linspace\")\n",
+    "def linspace_node(\n",
+    "    start: int | float = 0, stop: int | float = 1, num: int = 50\n",
+    "):\n",
+    "    return np.linspace(start=start, stop=stop, num=num)\n",
     "\n",
-    "print(ds1.outputs.p1, ds2.outputs.p1, ds3.outputs.p1)\n",
-    "upstream.inputs.x = 10\n",
-    "print(ds1.outputs.p1, ds2.outputs.p1, ds3.outputs.p1)"
+    "lin = linspace_node()\n",
+    "\n",
+    "print(type(lin.outputs.linspace.value))  # Output is just what we expect\n",
+    "print(lin[1:4])  # Gets items from the output\n",
+    "print(lin.mean())  # Finds the method on the output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1a9daa5-9c12-4c2f-b8bd-a54a5fc60feb",
+   "metadata": {},
+   "source": [
+    "# Workflows\n",
+    "\n",
+    "Typically, you will have a group of nodes working together with their connections.\n",
+    "We call these groups workflows, and offer a `Workflow` object as a single point of entry -- i.e. most of the time you shouldn't need the node imports used above, because the decorators are available right on the workflow class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1cd000bd-9b24-4c39-9cac-70a3291d0660",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyiron_contrib.workflow.workflow import Workflow\n",
+    "\n",
+    "@Workflow.wrap_as.single_value_node(\"is_greater\")\n",
+    "def greater_than_half(x: int | float | bool = 0) -> bool:\n",
+    "    \"\"\"The functionality doesn't matter here, it's just an example\"\"\"\n",
+    "    return x > 0.5"
    ]
   },
   {
@@ -407,50 +478,46 @@
    "source": [
     "## Adding nodes to a workflow\n",
     "\n",
-    "We use workflows to hold together collections of related and connected nodes.\n",
-    "\n",
     "All five of the following approaches are equivalent ways to add a node to a workflow:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "7964df3c-55af-4c25-afc5-9e07accb606a",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:167: UserWarning: Reassigning the node whatever_n4_gets_used to the label n4 when adding it to the workflow my_wf.\n",
-      "  warn(\n"
+      "n1 n1 <abc.GreaterThanHalf object at 0x147a55850>\n",
+      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14780a7d0>\n",
+      "n3 n3 <abc.GreaterThanHalf object at 0x147d0c1d0>\n",
+      "n4 n4 <abc.GreaterThanHalf object at 0x147d0d310>\n",
+      "n5 n5 <abc.GreaterThanHalf object at 0x147d091d0>\n"
      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "{'n1': <pyiron_contrib.workflow.node.Node at 0x149862b10>,\n",
-       " 'n2': <pyiron_contrib.workflow.node.Node at 0x149860f90>,\n",
-       " 'n3': <pyiron_contrib.workflow.node.Node at 0x149861290>,\n",
-       " 'n4': <pyiron_contrib.workflow.node.Node at 0x1495f1610>,\n",
-       " 'n5': <pyiron_contrib.workflow.node.Node at 0x149868bd0>}"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node will_get_overwritten_with_n4 to the label n4 when adding it to the workflow my_wf.\n",
+      "  warn(\n"
+     ]
     }
    ],
    "source": [
-    "n1 = Node(plus_minus_one, \"p1\", \"m1\", label=\"n1\")\n",
+    "n1 = greater_than_half(label=\"n1\")\n",
     "\n",
     "wf = Workflow(\"my_wf\", n1)  # As args at init\n",
-    "wf.add.Node(plus_minus_one, \"p1\", \"m1\", label=\"n2\")  # Instantiating from the node adder\n",
-    "wf.add(Node(plus_minus_one, \"p1\", \"m1\", label=\"n3\"))  # Instantiating then passing to node adder\n",
-    "wf.n4 = Node(plus_minus_one, \"p1\", \"m1\", label=\"whatever_n4_gets_used\")  # By attribute\n",
-    "Node(plus_minus_one, \"p1\", \"m1\", label=\"n5\", workflow=wf)  # By passing the workflow\n",
+    "wf.add.Node(lambda: x + 1, \"p1\", label=\"n2\")  # Instantiating from the node adder\n",
+    "wf.add(greater_than_half(label=\"n3\"))  # Instantiating then passing to node adder\n",
+    "wf.n4 = greater_than_half(label=\"will_get_overwritten_with_n4\")  # Set attribute to instance\n",
+    "greater_than_half(label=\"n5\", workflow=wf)  # By passing the workflow to the node\n",
     "\n",
-    "wf.nodes"
+    "for k, v in wf.nodes.items():\n",
+    "    print(k, v.label, v)"
    ]
   },
   {
@@ -471,7 +538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 17,
    "id": "2e418abf-7059-4e1e-9b9f-b3dc0a4b5e35",
    "metadata": {},
    "outputs": [
@@ -479,7 +546,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 None\n"
+      "None None\n"
      ]
     }
    ],
@@ -506,14 +573,14 @@
    "source": [
     "Now the input of `t2` got updated when the connection is made, but we told this node not to do any automatic updates, so the output has its uninitialized value of `None`.\n",
     "\n",
-    "Often, you will probably want to have nodes with data connections to have signal connections, but this is not strictly required. Here, we'll introduce a third node to control the execution of `t2`.\n",
+    "Often, you will probably want to have nodes with data connections to have signal connections, but this is not strictly required. Here, we'll introduce a (not strictly necessary) third node to control starting the workflow, and chain together to signals from our two functional nodes.\n",
     "\n",
     "Note that we have all the same syntacic sugar from data channels when creating connections between signal channels."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 18,
    "id": "3310eac4-04f6-421b-9824-19bb2d680be6",
    "metadata": {},
    "outputs": [
@@ -531,7 +598,8 @@
     "    return\n",
     "\n",
     "c = control()\n",
-    "t2.signals.input.run = c.signals.output.ran\n",
+    "l.signals.input.run = c.signals.output.ran\n",
+    "t2.signals.input.run = l.signals.output.ran\n",
     "c.run()\n",
     "print(t2.outputs.z.value)"
    ]
@@ -543,32 +611,25 @@
    "source": [
     "# Example with pre-built nodes\n",
     "\n",
-    "Currently we have a handfull of pre-build nodes available for import from the `nodes` package. Let's use these to quickly put together a workflow for looking at some MD data."
+    "Currently we have a handfull of pre-build nodes available for import from the `nodes` package. Let's use these to quickly put together a workflow for looking at some MD data.\n",
+    "\n",
+    "The `calc_md`, node is _not_ at `FastNode`, but we happen to know that the calculation we're doing here is very easy, so we'll set `run_on_updates` and `update_at_instantiation` to `True`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "d56c4464-7aa9-4136-83ea-4acce6a0afb1",
+   "execution_count": 19,
+   "id": "8a79aa02-cb49-4bad-b923-8fba32416116",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyiron_contrib.workflow import nodes"
+    "from pyiron_contrib.workflow import nodes\n",
+    "# TODO: Register node libraries directly with the workflow so there is only a single import"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "bf9ef826-fcfe-47ef-8439-f8b9e495122a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wf = Workflow(\"with_prebuilt\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "ae500d5e-e55b-432c-8b5f-d5892193cdf5",
    "metadata": {},
    "outputs": [
@@ -576,9 +637,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:167: UserWarning: Reassigning the node bulk_structure to the label structure when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node bulk_structure to the label structure when adding it to the workflow with_prebuilt.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:167: UserWarning: Reassigning the node lammps to the label engine when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node lammps to the label engine when adding it to the workflow with_prebuilt.\n",
       "  warn(\n"
      ]
     },
@@ -586,16 +647,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The job JUSTAJOBNAME was saved and received the ID: 333\n"
+      "The job JUSTAJOBNAME was saved and received the ID: 7417\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:167: UserWarning: Reassigning the node calc_md to the label calc when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node calc_md to the label calc when adding it to the workflow with_prebuilt.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:167: UserWarning: Reassigning the node scatter to the label plot when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node scatter to the label plot when adding it to the workflow with_prebuilt.\n",
       "  warn(\n"
      ]
     },
@@ -611,22 +672,20 @@
     }
    ],
    "source": [
+    "wf = Workflow(\"with_prebuilt\")\n",
+    "\n",
     "wf.structure = nodes.bulk_structure(repeat=3, cubic=True, element=\"Al\")\n",
     "wf.engine = nodes.lammps(structure=wf.structure.outputs.structure)\n",
-    "wf.calc = nodes.calc_md(job=wf.engine.outputs.job)\n",
+    "wf.calc = nodes.calc_md(\n",
+    "    job=wf.engine.outputs.job, \n",
+    "    run_on_updates=True, \n",
+    "    update_on_instantiation=True\n",
+    ")\n",
     "wf.plot = nodes.scatter(\n",
     "    x=wf.calc.outputs.steps, \n",
     "    y=wf.calc.outputs.temperature\n",
-    ")"
+    ")\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2de85772-c18f-4a44-a14f-6729a9d3ca2f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -225,8 +225,8 @@ class Node(HasToDict):
             label: Optional[str] = None,
             input_storage_priority: Optional[dict[str, int]] = None,
             output_storage_priority: Optional[dict[str, int]] = None,
-            run_on_updates: bool = True,
-            update_on_instantiation: bool = True,
+            run_on_updates: bool = False,
+            update_on_instantiation: bool = False,
             workflow: Optional[Workflow] = None,
             **kwargs
     ):

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -480,7 +480,7 @@ class SingleValueNode(FastNode):
         return getattr(self.single_value, item)
 
 
-def node(*output_labels: str):
+def node(*output_labels: str, **node_class_kwargs):
     """
     A decorator for dynamically creating node classes from functions.
 
@@ -495,13 +495,18 @@ def node(*output_labels: str):
         return type(
             node_function.__name__.title().replace("_", ""),  # fnc_name to CamelCase
             (Node,),  # Define parentage
-            {'__init__': partialmethod(Node.__init__, node_function, *output_labels)}
+            {'__init__': partialmethod(
+                Node.__init__,
+                node_function,
+                *output_labels,
+                **node_class_kwargs,
+            )}
         )
 
     return as_node
 
 
-def fast_node(*output_labels: str):
+def fast_node(*output_labels: str, **node_class_kwargs):
     """
     A decorator for dynamically creating fast node classes from functions.
 
@@ -516,7 +521,8 @@ def fast_node(*output_labels: str):
                 '__init__': partialmethod(
                     FastNode.__init__,
                     node_function,
-                    *output_labels
+                    *output_labels,
+                    **node_class_kwargs
                 )
             }
         )
@@ -524,7 +530,7 @@ def fast_node(*output_labels: str):
     return as_fast_node
 
 
-def single_value_node(*output_labels: str):
+def single_value_node(*output_labels: str, **node_class_kwargs):
     """
     A decorator for dynamically creating fast node classes from functions.
 
@@ -540,7 +546,8 @@ def single_value_node(*output_labels: str):
                 '__init__': partialmethod(
                     SingleValueNode.__init__,
                     node_function,
-                    *output_labels
+                    *output_labels,
+                    **node_class_kwargs
                 )
             }
         )

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -49,7 +49,7 @@ class Node(HasToDict):
         node_function (callable): The function determining the behaviour of the node.
         output_labels (tuple[str]): A name for each return value of the node function.
         label (str): The node's label. (Defaults to the node function's name.)
-        run_automatically (bool): Whether to run when you are updated and all your
+        run_on_updates (bool): Whether to run when you are updated and all your
             input is ready. (Default is True).
         update_on_instantiation (bool): Whether to force an update at the end of instantiation.
             (Default is False.)
@@ -64,7 +64,7 @@ class Node(HasToDict):
         fully_connected (bool): Every IO channel has at least one connection.
 
     Methods:
-        update: If `run_automatically` is true and all your input is ready, will
+        update: If `run_on_updates` is true and all your input is ready, will
             run the engine.
         run: Parse and process the input, execute the engine, process the results and
             update the output.
@@ -100,7 +100,7 @@ class Node(HasToDict):
         type error comes from our `y - 1` term in the function, which is `None - 1`.
 
         There are three ways to resolve this: First, we could set
-        `run_automatically = False`, then the node would not execute until we
+        `run_on_updates = False`, then the node would not execute until we
         manually call the `run()` method.
         This impacts the long-term behaviour of the node though, so let's keep
         searching.
@@ -162,7 +162,7 @@ class Node(HasToDict):
         ...         label: Optional[str] = None,
         ...         input_storage_priority: Optional[dict[str, int]] = None,
         ...         output_storage_priority: Optional[dict[str, int]] = None,
-        ...         run_automatically: bool = True,
+        ...         run_on_updates: bool = True,
         ...         update_on_instantiation: bool = False,
         ...         **kwargs
         ...     ):
@@ -172,7 +172,7 @@ class Node(HasToDict):
         ...             labe=label,
         ...             input_storage_priority=input_storage_priority,
         ...             output_storage_priority=output_storage_priority,
-        ...             run_automatically=run_automatically,
+        ...             run_on_updates=run_on_updates,
         ...             update_on_instantiation=update_on_instantiation,
         ...             **kwargs
         ...         )
@@ -225,7 +225,7 @@ class Node(HasToDict):
             label: Optional[str] = None,
             input_storage_priority: Optional[dict[str, int]] = None,
             output_storage_priority: Optional[dict[str, int]] = None,
-            run_automatically: bool = True,
+            run_on_updates: bool = True,
             update_on_instantiation: bool = True,
             workflow: Optional[Workflow] = None,
             **kwargs
@@ -247,14 +247,14 @@ class Node(HasToDict):
 
         self.signals = self._build_signal_channels()
 
-        self.run_automatically = False
+        self.run_on_updates = False
         for k, v in kwargs.items():
             if k in self.inputs.labels:
                 if isinstance(v, OutputData):
                     self.inputs[k] = v
                 else:
                     self.inputs[k].update(v)
-        self.run_automatically = run_automatically
+        self.run_on_updates = run_on_updates
 
         if update_on_instantiation:
             self.update()
@@ -339,7 +339,7 @@ class Node(HasToDict):
         return signals
 
     def update(self) -> None:
-        if self.run_automatically and self.ready:
+        if self.run_on_updates and self.ready:
             self.run()
 
     def run(self) -> None:
@@ -414,7 +414,7 @@ class FastNode(Node):
             label=label,
             input_storage_priority=input_storage_priority,
             output_storage_priority=output_storage_priority,
-            run_automatically=True,
+            run_on_updates=True,
             update_on_instantiation=True,
             workflow=workflow,
             ** kwargs

--- a/pyiron_contrib/workflow/nodes.py
+++ b/pyiron_contrib/workflow/nodes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import matplotlib.pyplot as plt
 import numpy as np
 from pyiron_atomistics import Project, _StructureFactory
@@ -15,11 +17,11 @@ def bulk_structure(element: str = "Fe", cubic: bool = False, repeat: int = 1) ->
     return _StructureFactory().bulk(element, cubic=cubic).repeat(repeat)
 
 
-@node("job")
-def lammps(structure: Atoms) -> LammpsJob:
+@single_value_node("job")
+def lammps(structure: Optional[Atoms] = None) -> LammpsJob:
     pr = Project(".")
     job = pr.atomistics.job.Lammps("NOTAREALNAME")
-    job.structure = structure
+    job.structure = structure if structure is not None else _StructureFactory().bulk()
     job.potential = job.list_potentials()[0]
     return job
 
@@ -94,6 +96,8 @@ def calc_md(
     )
 
 
-@node("fig")
-def scatter(x: list | np.ndarray, y: list | np.ndarray):
+@single_value_node("fig")
+def scatter(
+        x: Optional[list | np.ndarray] = None, y: Optional[list | np.ndarray] = None
+):
     return plt.scatter(x, y)


### PR DESCRIPTION
I.e. they should default `runs_on_updates` and `updates_on_instantiation` both to `False`.

All the documentation and examples are updated accordingly, and the library of nodes makes as many as possible `SingleValueNodes`.