### PR TITLE
Pin scikit-image to 0.19.3

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - pyparsing =3.0.9
 - scipy =1.10.1
 - seaborn =0.12.2
-- scikit-image =0.20.0
+- scikit-image =0.19.3
 - randspg =0.0.1
 - boto3 =1.26.118
 - moto =4.1.8

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             'fenics==2019.1.0',
             'mshr==2019.1.0',
         ],
-        'image': ['scikit-image==0.20.0'],
+        'image': ['scikit-image==0.19.3'],
         'generic': [
             'boto3==1.26.118', 
             'moto==4.1.8'


### PR DESCRIPTION
To avoid a dependency conflict that 0.20.0 introduces with pyiron_atomistics for their mutual scipy dependency.

Closes #651. (As long as it works and doesn't introduce any new dependency conflicts). If this is merged, we'll need a new issue for un-pinning scikit-image once 0.21.0 gets released.