### PR TITLE
More convenient single value nodes

### DIFF
--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b04ad159923f4d67870f859105813dd9",
+       "model_id": "50948e0412a54c9980dbe4d860d7607a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -491,11 +491,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "n1 n1 <abc.GreaterThanHalf object at 0x147a55850>\n",
-      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14780a7d0>\n",
-      "n3 n3 <abc.GreaterThanHalf object at 0x147d0c1d0>\n",
-      "n4 n4 <abc.GreaterThanHalf object at 0x147d0d310>\n",
-      "n5 n5 <abc.GreaterThanHalf object at 0x147d091d0>\n"
+      "n1 n1 n1 (GreaterThanHalf) output single-value: False\n",
+      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14c9cbd50>\n",
+      "n3 n3 n3 (GreaterThanHalf) output single-value: False\n",
+      "n4 n4 n4 (GreaterThanHalf) output single-value: False\n",
+      "n5 n5 n5 (GreaterThanHalf) output single-value: False\n"
      ]
     },
     {
@@ -613,7 +613,9 @@
     "\n",
     "Currently we have a handfull of pre-build nodes available for import from the `nodes` package. Let's use these to quickly put together a workflow for looking at some MD data.\n",
     "\n",
-    "The `calc_md`, node is _not_ at `FastNode`, but we happen to know that the calculation we're doing here is very easy, so we'll set `run_on_updates` and `update_at_instantiation` to `True`."
+    "The `calc_md`, node is _not_ at `FastNode`, but we happen to know that the calculation we're doing here is very easy, so we'll set `run_on_updates` and `update_at_instantiation` to `True`.\n",
+    "\n",
+    "Finally, `SingleValueNode` has one more piece of syntactic sugar: when you're making a connection to the (single!) output channel, you can just pass the node itself!"
    ]
   },
   {
@@ -675,9 +677,9 @@
     "wf = Workflow(\"with_prebuilt\")\n",
     "\n",
     "wf.structure = nodes.bulk_structure(repeat=3, cubic=True, element=\"Al\")\n",
-    "wf.engine = nodes.lammps(structure=wf.structure.outputs.structure)\n",
+    "wf.engine = nodes.lammps(structure=wf.structure)\n",
     "wf.calc = nodes.calc_md(\n",
-    "    job=wf.engine.outputs.job, \n",
+    "    job=wf.engine, \n",
     "    run_on_updates=True, \n",
     "    update_on_instantiation=True\n",
     ")\n",

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -116,8 +116,12 @@ class IO(HasToDict, ABC):
 
 class DataIO(IO, ABC):
     def _set_existing(self, key, value):
+        from pyiron_contrib.workflow.node import SingleValueNode
+
         if isinstance(value, DataChannel):
             self.channel_dict[key].connect(value)
+        elif isinstance(value, SingleValueNode):
+            self.channel_dict[key].connect(list(value.outputs.channel_dict.values())[0])
         else:
             self.channel_dict[key].update(value)
 

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -557,6 +557,9 @@ class SingleValueNode(FastNode):
     def __getattr__(self, item):
         return getattr(self.single_value, item)
 
+    def __repr__(self):
+        return self.single_value.__repr__()
+
 
 def node(*output_labels: str, **node_class_kwargs):
     """

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -560,6 +560,10 @@ class SingleValueNode(FastNode):
     def __repr__(self):
         return self.single_value.__repr__()
 
+    def __str__(self):
+        return f"{self.label} ({self.__class__.__name__}) output single-value: " \
+            + str(self.single_value)
+
 
 def node(*output_labels: str, **node_class_kwargs):
     """

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -328,10 +328,7 @@ class Node(HasToDict):
         self.run_on_updates = False
         for k, v in kwargs.items():
             if k in self.inputs.labels:
-                if isinstance(v, OutputData):
-                    self.inputs[k] = v
-                else:
-                    self.inputs[k].update(v)
+                self.inputs[k] = v
         self.run_on_updates = run_on_updates
 
         if update_on_instantiation:

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -167,3 +167,7 @@ class TestSingleValueNode(TestCase):
             False,
             msg="Should fall back to looking on the single value"
         )
+
+    def test_repr(self):
+        svn = SingleValueNode(plus_one, "y")
+        self.assertEqual(svn.__repr__(), svn.outputs.y.value.__repr__())

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -177,8 +177,8 @@ class TestSingleValueNode(TestCase):
 
     def test_str(self):
         svn = SingleValueNode(plus_one, "y")
-        self.assertIn(
-            str(svn.outputs.y.value), str(svn),
+        self.assertTrue(
+            str(svn).endswith(str(svn.single_value)),
             msg="SingleValueNodes should have their output as a string in their string "
                 "representation (e.g., perhaps with a reminder note that this is "
                 "actually still a Node and not just the value you're seeing.)"

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -191,7 +191,7 @@ class TestSingleValueNode(TestCase):
         regular.inputs.x = svn
 
         self.assertIn(
-            svn, regular.inputs.x.connections,
+            svn.outputs.y, regular.inputs.x.connections,
             msg="SingleValueNodes should be able to make connections between their "
                 "output and another node's input by passing themselves"
         )

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -171,3 +171,12 @@ class TestSingleValueNode(TestCase):
     def test_repr(self):
         svn = SingleValueNode(plus_one, "y")
         self.assertEqual(svn.__repr__(), svn.outputs.y.value.__repr__())
+
+    def test_str(self):
+        svn = SingleValueNode(plus_one, "y")
+        self.assertTrue(
+            str(svn.outputs.y.value) in str(svn),
+            msg="SingleValueNodes should have their output as a string in their string "
+                "representation (e.g., perhaps with a reminder note that this is "
+                "actually still a Node and not just the value you're seeing.)"
+        )

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -108,58 +108,62 @@ class TestNode(TestCase):
             msg="Running the upstream node should trigger a run here"
         )
 
-    def test_fast_node(self):
+
+@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+class TestFastNode(TestCase):
+    def test_instantiation(self):
         has_defaults_is_ok = FastNode(plus_one, "y")
 
         with self.assertRaises(ValueError):
             missing_defaults_should_fail = FastNode(no_default, "z")
 
-    def test_single_value_node(self):
-        with self.subTest("Test creation"):
-            has_defaults_and_one_return = SingleValueNode(plus_one, "y")
+@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+class TestSingleValueNode(TestCase):
+    def test_instantiation(self):
+        has_defaults_and_one_return = SingleValueNode(plus_one, "y")
 
-            with self.assertRaises(ValueError):
-                too_many_labels = SingleValueNode(plus_one, "z", "excess_label")
+        with self.assertRaises(ValueError):
+            too_many_labels = SingleValueNode(plus_one, "z", "excess_label")
 
-        with self.subTest("Test output attribute access as a fallback"):
-            class Foo:
-                some_attribute = "exists"
-                connected = True  # Overlaps with an attribute of the node
+    def test_item_and_attribute_access(self):
+        class Foo:
+            some_attribute = "exists"
+            connected = True  # Overlaps with an attribute of the node
 
-                def __getitem__(self, item):
-                    if item == 0:
-                        return True
-                    else:
-                        return False
+            def __getitem__(self, item):
+                if item == 0:
+                    return True
+                else:
+                    return False
 
-            def returns_foo() -> Foo:
-                return Foo()
+        def returns_foo() -> Foo:
+            return Foo()
 
-            svn = SingleValueNode(returns_foo, "foo")
+        svn = SingleValueNode(returns_foo, "foo")
 
-            self.assertEqual(
-                svn.some_attribute,
-                "exists",
-                msg="Should fall back to looking on the single value"
-            )
+        self.assertEqual(
+            svn.some_attribute,
+            "exists",
+            msg="Should fall back to looking on the single value"
+        )
 
-            self.assertEqual(
-                svn.connected,
-                False,
-                msg="Should return the _node_ attribute, not the single value attribute"
-            )
+        self.assertEqual(
+            svn.connected,
+            False,
+            msg="Should return the _node_ attribute, not the single value attribute"
+        )
 
-            with self.assertRaises(AttributeError):
-                svn.doesnt_exists_anywhere
+        with self.assertRaises(AttributeError):
+            svn.doesnt_exists_anywhere
 
-            self.assertEqual(
-                svn[0],
-                True,
-                msg="Should fall back to looking on the single value"
-            )
+        self.assertEqual(
+            svn[0],
+            True,
+            msg="Should fall back to looking on the single value"
+        )
 
-            self.assertEqual(
-                svn["some other key"],
-                False,
-                msg="Should fall back to looking on the single value"
-            )
+        self.assertEqual(
+            svn["some other key"],
+            False,
+            msg="Should fall back to looking on the single value"
+        )

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -183,3 +183,22 @@ class TestSingleValueNode(TestCase):
                 "representation (e.g., perhaps with a reminder note that this is "
                 "actually still a Node and not just the value you're seeing.)"
         )
+
+    def test_easy_output_connection(self):
+        svn = SingleValueNode(plus_one, "y")
+        regular = Node(plus_one, "y")
+
+        regular.inputs.x = svn
+
+        self.assertIn(
+            svn, regular.inputs.x.connections,
+            msg="SingleValueNodes should be able to make connections between their "
+                "output and another node's input by passing themselves"
+        )
+
+        regular.run()
+        self.assertEqual(
+            regular.outputs.y.value, 3,
+            msg="SingleValueNode connections should pass data just like usual; in this "
+                "case default->plus_one->plus_one = 1 + 1 +1 = 3"
+        )

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -202,3 +202,10 @@ class TestSingleValueNode(TestCase):
             msg="SingleValueNode connections should pass data just like usual; in this "
                 "case default->plus_one->plus_one = 1 + 1 +1 = 3"
         )
+
+        at_instantiation = Node(plus_one, "y", x=svn)
+        self.assertIn(
+            svn.outputs.y, at_instantiation.inputs.x.connections,
+            msg="The parsing of SingleValueNode output as a connection should also work"
+                "from assignment at instantiation"
+        )

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -170,7 +170,10 @@ class TestSingleValueNode(TestCase):
 
     def test_repr(self):
         svn = SingleValueNode(plus_one, "y")
-        self.assertEqual(svn.__repr__(), svn.outputs.y.value.__repr__())
+        self.assertEqual(
+            svn.__repr__(), svn.outputs.y.value.__repr__(),
+            msg="SingleValueNodes should have their output as their representation"
+        )
 
     def test_str(self):
         svn = SingleValueNode(plus_one, "y")

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -177,8 +177,8 @@ class TestSingleValueNode(TestCase):
 
     def test_str(self):
         svn = SingleValueNode(plus_one, "y")
-        self.assertTrue(
-            str(svn.outputs.y.value) in str(svn),
+        self.assertIn(
+            str(svn.outputs.y.value), str(svn),
             msg="SingleValueNodes should have their output as a string in their string "
                 "representation (e.g., perhaps with a reminder note that this is "
                 "actually still a Node and not just the value you're seeing.)"


### PR DESCRIPTION
Gives better `__repr__` (_not_ `_repr_json`) and `__str__` methods for `SingleValueNode`, and makes it easier to connect them, per [ironflow #194](https://github.com/pyiron/ironflow/issues/194#issuecomment-1529974794).

The final example is now further streamlined, note how the entire `SingleValueNode` instance can be passed when making connections:

```python
from pyiron_contrib.workflow import nodes, Workflow

wf = Workflow("with_prebuilt")

wf.structure = nodes.bulk_structure(repeat=3, cubic=True, element="Al")
wf.engine = nodes.lammps(structure=wf.structure)
wf.calc = nodes.calc_md(
    job=wf.engine, 
    run_on_updates=True, 
    update_on_instantiation=True
)
wf.plot = nodes.scatter(
    x=wf.calc.outputs.steps, 
    y=wf.calc.outputs.temperature
)
```

Right now the implementation uses a local import to avoid circular imports, but I have an idea for a mixin to resolve this in the next PR.