### PR TITLE
Move pre-built node files

### DIFF
--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "50948e0412a54c9980dbe4d860d7607a",
+       "model_id": "1f68cb31497a47258ea429ac23faac87",
        "version_major": 2,
        "version_minor": 0
       },
@@ -492,7 +492,7 @@
      "output_type": "stream",
      "text": [
       "n1 n1 n1 (GreaterThanHalf) output single-value: False\n",
-      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14c9cbd50>\n",
+      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14b788110>\n",
       "n3 n3 n3 (GreaterThanHalf) output single-value: False\n",
       "n4 n4 n4 (GreaterThanHalf) output single-value: False\n",
       "n5 n5 n5 (GreaterThanHalf) output single-value: False\n"
@@ -625,7 +625,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyiron_contrib.workflow import nodes\n",
+    "from pyiron_contrib.workflow.node_library import atomistics, standard\n",
     "# TODO: Register node libraries directly with the workflow so there is only a single import"
    ]
   },
@@ -649,7 +649,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The job JUSTAJOBNAME was saved and received the ID: 7417\n"
+      "The job JUSTAJOBNAME was saved and received the ID: 7418\n"
      ]
     },
     {
@@ -676,14 +676,14 @@
    "source": [
     "wf = Workflow(\"with_prebuilt\")\n",
     "\n",
-    "wf.structure = nodes.bulk_structure(repeat=3, cubic=True, element=\"Al\")\n",
-    "wf.engine = nodes.lammps(structure=wf.structure)\n",
-    "wf.calc = nodes.calc_md(\n",
+    "wf.structure = atomistics.bulk_structure(repeat=3, cubic=True, element=\"Al\")\n",
+    "wf.engine = atomistics.lammps(structure=wf.structure)\n",
+    "wf.calc = atomistics.calc_md(\n",
     "    job=wf.engine, \n",
     "    run_on_updates=True, \n",
     "    update_on_instantiation=True\n",
     ")\n",
-    "wf.plot = nodes.scatter(\n",
+    "wf.plot = standard.scatter(\n",
     "    x=wf.calc.outputs.steps, \n",
     "    y=wf.calc.outputs.temperature\n",
     ")\n"

--- a/pyiron_contrib/workflow/node_library/atomistics.py
+++ b/pyiron_contrib/workflow/node_library/atomistics.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-import matplotlib.pyplot as plt
-import numpy as np
 from pyiron_atomistics import Project, _StructureFactory
 from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
@@ -94,10 +92,3 @@ def calc_md(
         unwrapped_positions,
         volume,
     )
-
-
-@single_value_node("fig")
-def scatter(
-        x: Optional[list | np.ndarray] = None, y: Optional[list | np.ndarray] = None
-):
-    return plt.scatter(x, y)

--- a/pyiron_contrib/workflow/node_library/standard.py
+++ b/pyiron_contrib/workflow/node_library/standard.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+from pyiron_contrib.workflow.node import single_value_node
+
+
+@single_value_node("fig")
+def scatter(
+        x: Optional[list | np.ndarray] = None, y: Optional[list | np.ndarray] = None
+):
+    return plt.scatter(x, y)

--- a/pyiron_contrib/workflow/workflow.py
+++ b/pyiron_contrib/workflow/workflow.py
@@ -111,14 +111,14 @@ class Workflow(HasToDict):
         0, 1, 2
 
         We can also use pre-built nodes, e.g.
-        >>> from pyiron_contrib.workflow import nodes
+        >>> from pyiron_contrib.workflow.node_library import atomistics, standard
         >>>
         >>> wf = Workflow("with_prebuilt")
         >>>
-        >>> wf.structure = nodes.BulkStructure(repeat=3, cubic=True, element="Al")
-        >>> wf.engine = nodes.Lammps(structure=wf.structure.outputs.structure)
-        >>> wf.calc = nodes.CalcMD(job=wf.engine.outputs.job)
-        >>> wf.plot = nodes.Scatter(
+        >>> wf.structure = atomistics.BulkStructure(repeat=3, cubic=True, element="Al")
+        >>> wf.engine = atomistics.Lammps(structure=wf.structure)
+        >>> wf.calc = atomistics.CalcMD(job=wf.engine)
+        >>> wf.plot = standard.Scatter(
         ...     x=wf.calc.outputs.steps,
         ...     y=wf.calc.outputs.temperature
         ... )


### PR DESCRIPTION
And split them into two categories: "atomistics" and "standard" (which is right now just the plotting node).

This is a precursor to having these node packages available directly on the workflow object.