### PR TITLE
Attach node packages to workflow

### DIFF
--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f68cb31497a47258ea429ac23faac87",
+       "model_id": "baec001264424daf8fbb8ca2bb4a7aad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -492,7 +492,7 @@
      "output_type": "stream",
      "text": [
       "n1 n1 n1 (GreaterThanHalf) output single-value: False\n",
-      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14b788110>\n",
+      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14dabb7d0>\n",
       "n3 n3 n3 (GreaterThanHalf) output single-value: False\n",
       "n4 n4 n4 (GreaterThanHalf) output single-value: False\n",
       "n5 n5 n5 (GreaterThanHalf) output single-value: False\n"
@@ -502,7 +502,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node will_get_overwritten_with_n4 to the label n4 when adding it to the workflow my_wf.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:187: UserWarning: Reassigning the node will_get_overwritten_with_n4 to the label n4 when adding it to the workflow my_wf.\n",
       "  warn(\n"
      ]
     }
@@ -621,17 +621,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "8a79aa02-cb49-4bad-b923-8fba32416116",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pyiron_contrib.workflow.node_library import atomistics, standard\n",
-    "# TODO: Register node libraries directly with the workflow so there is only a single import"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
    "id": "ae500d5e-e55b-432c-8b5f-d5892193cdf5",
    "metadata": {},
    "outputs": [
@@ -639,9 +628,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node bulk_structure to the label structure when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:187: UserWarning: Reassigning the node bulk_structure to the label structure when adding it to the workflow with_prebuilt.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node lammps to the label engine when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:187: UserWarning: Reassigning the node lammps to the label engine when adding it to the workflow with_prebuilt.\n",
       "  warn(\n"
      ]
     },
@@ -656,9 +645,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node calc_md to the label calc when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:187: UserWarning: Reassigning the node calc_md to the label calc when adding it to the workflow with_prebuilt.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:176: UserWarning: Reassigning the node scatter to the label plot when adding it to the workflow with_prebuilt.\n",
+      "/Users/huber/work/pyiron/pyiron_contrib/pyiron_contrib/workflow/workflow.py:187: UserWarning: Reassigning the node scatter to the label plot when adding it to the workflow with_prebuilt.\n",
       "  warn(\n"
      ]
     },
@@ -676,18 +665,26 @@
    "source": [
     "wf = Workflow(\"with_prebuilt\")\n",
     "\n",
-    "wf.structure = atomistics.bulk_structure(repeat=3, cubic=True, element=\"Al\")\n",
-    "wf.engine = atomistics.lammps(structure=wf.structure)\n",
-    "wf.calc = atomistics.calc_md(\n",
+    "wf.structure = wf.add.atomistics.BulkStructure(repeat=3, cubic=True, element=\"Al\")\n",
+    "wf.engine = wf.add.atomistics.Lammps(structure=wf.structure)\n",
+    "wf.calc = wf.add.atomistics.CalcMd(\n",
     "    job=wf.engine, \n",
     "    run_on_updates=True, \n",
     "    update_on_instantiation=True\n",
     ")\n",
-    "wf.plot = standard.scatter(\n",
+    "wf.plot = wf.add.standard.Scatter(\n",
     "    x=wf.calc.outputs.steps, \n",
     "    y=wf.calc.outputs.temperature\n",
-    ")\n"
+    ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80a9eac6-9953-4105-8c70-c1e14a698564",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -470,7 +470,8 @@ class Node(HasToDict):
 class FastNode(Node):
     """
     Like a regular node, but _all_ input channels _must_ have default values provided,
-    and the initialization signature forces `` and `` to be `True`.
+    and the initialization signature forces `run_on_updates` and
+    `update_on_instantiation` to be `True`.
     """
 
     def __init__(

--- a/pyiron_contrib/workflow/node_library/atomistics.py
+++ b/pyiron_contrib/workflow/node_library/atomistics.py
@@ -92,3 +92,10 @@ def calc_md(
         unwrapped_positions,
         volume,
     )
+
+
+nodes = [
+    bulk_structure,
+    calc_md,
+    lammps,
+]

--- a/pyiron_contrib/workflow/node_library/package.py
+++ b/pyiron_contrib/workflow/node_library/package.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING
+
+from pyiron_contrib.workflow.node import Node
+from pyiron_contrib.workflow.util import DotDict
+
+if TYPE_CHECKING:
+    from pyiron_contrib.workflow.workflow import Workflow
+
+
+class NodePackage(DotDict):
+    """
+    A collection of node classes that, when instantiated, will have their workflow
+    automatically set.
+
+    Node classes are accessible by their _class name_ by item or attribute access.
+
+    Can be extended by adding node classes to new names with an item or attribute set,
+    but to update an existing node the `update` method must be used.
+    """
+
+    def __init__(self, workflow: Workflow, *node_classes: Node):
+        super().__init__()
+        self.__dict__['_workflow'] = workflow  # Avoid the __setattr__ override
+        for node in node_classes:
+            self[node.__name__] = node
+
+    def __setitem__(self, key, value):
+        if key in self.keys():
+            raise KeyError(f"The name {key} is already a stored node class.")
+        elif key in self.__dir__():
+            raise KeyError(
+                f"The name {key} is already an attribute of this "
+                f"{self.__class__.__name__} instance."
+            )
+        if not isinstance(value, type) or not issubclass(value, Node):
+            raise TypeError(
+                f"Can only set members that are (sub)classes of  {Node.__name__}, but "
+                f"got {type(value)}"
+            )
+        super().__setitem__(key, value)
+
+    def __getitem__(self, item):
+        value = super().__getitem__(item)
+        if issubclass(value, Node):
+            return partial(value, workflow=self._workflow)
+        else:
+            return value
+
+    def update(self, *node_classes):
+        replacing = set(self.keys()).intersection([n.__name__ for n in node_classes])
+        for name in replacing:
+            del self[name]
+
+        for node in node_classes:
+            self[node.__name__] = node

--- a/pyiron_contrib/workflow/node_library/standard.py
+++ b/pyiron_contrib/workflow/node_library/standard.py
@@ -13,3 +13,8 @@ def scatter(
         x: Optional[list | np.ndarray] = None, y: Optional[list | np.ndarray] = None
 ):
     return plt.scatter(x, y)
+
+
+nodes = [
+    scatter,
+]

--- a/tests/unit/workflow/test_node_package.py
+++ b/tests/unit/workflow/test_node_package.py
@@ -1,0 +1,71 @@
+from unittest import TestCase, skipUnless
+from sys import version_info
+
+from pyiron_contrib.workflow.node_library.package import NodePackage
+from pyiron_contrib.workflow.workflow import Workflow
+
+
+@Workflow.wrap_as.fast_node("x")
+def dummy(x: int = 0):
+    return x
+
+
+@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+class TestNodePackage(TestCase):
+    def setUp(self) -> None:
+        self.wf = Workflow("test_workflow")
+        self.package = NodePackage(self.wf, dummy)
+
+    def test_init(self):
+        self.assertTrue(
+            hasattr(self.package, dummy.__name__),
+            msg="Classes should be added at instantiation"
+        )
+
+    def test_access(self):
+        node = self.package.Dummy()
+        self.assertIsInstance(node, dummy)
+        self.assertIs(
+            node.workflow,
+            self.package._workflow,
+            msg="Package workflow should get assigned to node instances"
+        )
+
+    def test_update(self):
+        with self.assertRaises(KeyError):
+            self.package.Dummy = "This is already a node class name"
+
+        with self.assertRaises(KeyError):
+            self.package.update = "This is already a method"
+
+        with self.assertRaises(TypeError):
+            self.package.available_name = "But we can still only assign node classes"
+
+        @Workflow.wrap_as.node("y")
+        def add(x: int = 0):
+            return x + 1
+
+        self.package.node_class_and_free_key = add  # Should work!
+
+        with self.assertRaises(KeyError):
+            # This is already occupied by another node class
+            self.package.Dummy = add
+
+        old_dummy_instance = self.package.Dummy(label="old_dummy_instance")
+
+        @Workflow.wrap_as.fast_node("y")
+        def dummy(x: int = 0):
+            return x + 1
+
+        self.package.update(dummy)
+
+        self.assertEqual(len(self.package), 2, msg="Update should replace, not extend")
+
+        new_dummy_instance = self.package.Dummy(label="new_dummy_instance")
+
+        self.assertEqual(
+            old_dummy_instance.outputs.x.value, 0, msg="Should have old functionality"
+        )
+        self.assertEqual(
+            new_dummy_instance.outputs.y.value, 1, msg="Should have new functionality"
+        )

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -50,6 +50,21 @@ class TestWorkflow(TestCase):
         with self.assertRaises(AttributeError):
             Node(fnc, "x", label="boa", workflow=wf)
 
+    def test_node_packages(self):
+        wf = Workflow("my_workflow")
+
+        # Test invocation
+        wf.add.atomistics.BulkStructure(repeat=3, cubic=True, element="Al")
+        # Test invocation with attribute assignment
+        wf.engine = wf.add.atomistics.Lammps(structure=wf.bulk_structure)
+
+        self.assertSetEqual(
+            set(wf.nodes.keys()),
+            set(["bulk_structure", "engine"]),
+            msg=f"Expected one node label generated automatically from the class and "
+                f"the other from the attribute assignment, but got {wf.nodes.keys()}"
+        )
+
     def test_double_workfloage_and_node_removal(self):
         wf1 = Workflow("one")
         wf1.add.Node(fnc, "y", label="node1")

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -26,13 +26,18 @@ class TestWorkflow(TestCase):
         # Validate name incrementation
         wf.add(Node(fnc, "x", label="foo"))
         wf.add.Node(fnc, "y", label="bar")
-        wf.baz = Node(fnc, "y", label="whatever_baz_gets_used")
+        with self.assertRaises(AttributeError):
+            wf.baz = Node(
+                fnc,
+                "y",
+                label="even_without_strict_you_still_cant_override_by_assignment"
+            )
         Node(fnc, "x", label="boa", workflow=wf)
         self.assertListEqual(
             list(wf.nodes.keys()),
             [
                 "foo", "bar", "baz", "boa",
-                "foo0", "bar0", "baz0", "boa0",
+                "foo0", "bar0", "boa0",
             ]
         )
 


### PR DESCRIPTION
Here I introduce a new `NodePackage` class, which takes lists of node classes and makes them both item- and attribute-accessible, where the returned objects are wrapped to use a particular project. 
These node packages are then attached to the `Workflow` (well, to the `_NodeAdder`). 
**With this, we now really have a single point of import, `Workflow`**, which lets you access pre-build nodes with `wf.add.some_namespace.SomeNodeClass`, define new nodes with the `@Workflow.wrap_as.node` decorators, and add any new local nodes with `wf.add(some_node_instance)` or `wf.node_name = some_node_instance`.

The final workflow example now reads

```python
wf = Workflow("with_prebuilt")

wf.structure = wf.add.atomistics.BulkStructure(repeat=3, cubic=True, element="Al")
wf.engine = wf.add.atomistics.Lammps(structure=wf.structure)
wf.calc = wf.add.atomistics.CalcMd(
    job=wf.engine, 
    run_on_updates=True, 
    update_on_instantiation=True
)
wf.plot = wf.add.standard.Scatter(
    x=wf.calc.outputs.steps, 
    y=wf.calc.outputs.temperature
)
```

Not in the scope of this PR: registration methods so that the available node packages on a given workflow can be extended. This is planned though, and necessary for the eventual goal of workflow serialization.