### PR TITLE
Qol workflow reprs

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - coveralls
 - coverage
 - codacy-coverage
+- ipython
 - matplotlib =3.7.1
 - numpy =1.24.3
 - pyiron_base =0.5.36

--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "baec001264424daf8fbb8ca2bb4a7aad",
+       "model_id": "322f7f0435944dd2a35b2e6821f6d2db",
        "version_major": 2,
        "version_minor": 0
       },
@@ -492,7 +492,7 @@
      "output_type": "stream",
      "text": [
       "n1 n1 n1 (GreaterThanHalf) output single-value: False\n",
-      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x14dabb7d0>\n",
+      "n2 n2 <pyiron_contrib.workflow.node.Node object at 0x1441b1990>\n",
       "n3 n3 n3 (GreaterThanHalf) output single-value: False\n",
       "n4 n4 n4 (GreaterThanHalf) output single-value: False\n",
       "n5 n5 n5 (GreaterThanHalf) output single-value: False\n"
@@ -681,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80a9eac6-9953-4105-8c70-c1e14a698564",
+   "id": "cab89cc8-2409-4bdb-8b50-ccdf48e9ec5d",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing
 from abc import ABC, abstractmethod
+from json import dumps
 from warnings import warn
 
 from pyiron_contrib.workflow.has_channel import HasChannel
@@ -198,7 +199,7 @@ class DataChannel(Channel, ABC):
 
     def to_dict(self):
         d = super().to_dict()
-        d["value"] = self.value
+        d["value"] = repr(self.value)
         d["ready"] = self.ready
         return d
 

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -200,6 +200,7 @@ class DataChannel(Channel, ABC):
         d = super().to_dict()
         d["value"] = self.value
         d["ready"] = self.ready
+        return d
 
 
 class InputData(DataChannel):

--- a/pyiron_contrib/workflow/has_to_dict.py
+++ b/pyiron_contrib/workflow/has_to_dict.py
@@ -10,6 +10,5 @@ class HasToDict(ABC):
     def _repr_json_(self):
         return self.to_dict()
 
-    @property
     def info(self):
         print(dumps(self.to_dict(), indent=2))

--- a/pyiron_contrib/workflow/has_to_dict.py
+++ b/pyiron_contrib/workflow/has_to_dict.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from json import dumps
 
+from IPython.display import JSON
+
 
 class HasToDict(ABC):
     @abstractmethod
@@ -12,3 +14,6 @@ class HasToDict(ABC):
 
     def info(self):
         print(dumps(self.to_dict(), indent=2))
+
+    def repr_json(self):
+        return JSON(self.to_dict())

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         ],
         'workflow': [
             'python>=3.10',
+            'ipython',
             'typeguard==3.0.2'
         ]
     },


### PR DESCRIPTION
- Channel values are now stringified before being placed in the `to_dict` dictionary, which avoids errors when trying to view, e.g., channels that hold an `Atoms` object. A different solution will be needed for actual serialization, but this works fine for display purposes.
- `Workflow` and `IO` somehow aren't getting their pretty JSON representation triggered, even though `Node` and `Channel` do and they all just inherit this functionality from `HasToDict`. Until I can figure out why and fix it, I added a method `json_repr()` to force this behaviour.