### PR TITLE
Use consistent language for IO

### DIFF
--- a/pyiron_contrib/workflow/workflow.py
+++ b/pyiron_contrib/workflow/workflow.py
@@ -212,7 +212,7 @@ class Workflow(HasToDict):
         return len(self.nodes)
 
     @property
-    def input(self):
+    def inputs(self):
         return DotDict(
             {
                 f"{node.label}_{channel.label}": channel
@@ -223,7 +223,7 @@ class Workflow(HasToDict):
         )
 
     @property
-    def output(self):
+    def outputs(self):
         return DotDict(
             {
                 f"{node.label}_{channel.label}": channel

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -92,15 +92,15 @@ class TestWorkflow(TestCase):
         wf.add.Node(fnc, "y", label="n3")
 
         with self.subTest("Workflow IO should be drawn from its nodes"):
-            self.assertEqual(len(wf.input), 3)
-            self.assertEqual(len(wf.output), 3)
+            self.assertEqual(len(wf.inputs), 3)
+            self.assertEqual(len(wf.outputs), 3)
 
         wf.n3.inputs.x = wf.n2.outputs.y
         wf.n2.inputs.x = wf.n1.outputs.y
 
         with self.subTest("Only unconnected channels should count"):
-            self.assertEqual(len(wf.input), 1)
-            self.assertEqual(len(wf.output), 1)
+            self.assertEqual(len(wf.inputs), 1)
+            self.assertEqual(len(wf.outputs), 1)
 
     def test_node_decorator_access(self):
         @Workflow.wrap_as.fast_node("y")


### PR DESCRIPTION
Nodes had "inputs" and "outputs" while Workflows had "input" and "output". Now they both use the plural.