### PR TITLE
Node status

### DIFF
--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -149,8 +149,12 @@ class DataChannel(Channel, ABC):
             return True
 
     def update(self, value):
+        self._before_update()
         self.value = value
         self._after_update()
+
+    def _before_update(self):
+        pass
 
     def _after_update(self):
         pass
@@ -245,6 +249,13 @@ class InputData(DataChannel):
     @property
     def ready(self):
         return not self.waiting_for_update and super().ready
+
+    def _before_update(self):
+        if self.node.running:
+            raise RuntimeError(
+                f"Parent node {self.node.label} of {self.label} is running, so value "
+                f"cannot be updated."
+            )
 
     def _after_update(self):
         self.waiting_for_update = False

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -317,6 +317,8 @@ class Node(HasToDict):
             workflow: Optional[Workflow] = None,
             **kwargs
     ):
+        self.running = False
+        self.failed = False
         self.node_function = node_function
         self.label = label if label is not None else node_function.__name__
 
@@ -457,6 +459,9 @@ class Node(HasToDict):
             self.run()
 
     def run(self) -> None:
+        self.running = True
+        self.failed = False
+
         function_output = self.node_function(**self.inputs.to_value_dict())
 
         if len(self.outputs) == 1:
@@ -469,6 +474,8 @@ class Node(HasToDict):
 
         for channel_name in self.channels_requiring_update_after_run:
             self.inputs[channel_name].wait_for_update()
+
+        self.running = False
 
     def __call__(self) -> None:
         self.run()

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -487,7 +487,7 @@ class Node(HasToDict):
 
     @property
     def ready(self) -> bool:
-        return self.inputs.ready
+        return not (self.running or self.failed) and self.inputs.ready
 
     @property
     def connected(self) -> bool:

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -459,6 +459,9 @@ class Node(HasToDict):
             self.run()
 
     def run(self) -> None:
+        if self.running:
+            raise RuntimeError(f"{self.label} is already running")
+
         self.running = True
         self.failed = False
 

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -465,7 +465,12 @@ class Node(HasToDict):
         self.running = True
         self.failed = False
 
-        function_output = self.node_function(**self.inputs.to_value_dict())
+        try:
+            function_output = self.node_function(**self.inputs.to_value_dict())
+        except Exception as e:
+            self.running = False
+            self.failed = True
+            raise e
 
         if len(self.outputs) == 1:
             function_output = (function_output,)

--- a/tests/unit/workflow/test_channels.py
+++ b/tests/unit/workflow/test_channels.py
@@ -9,6 +9,8 @@ from pyiron_contrib.workflow.channels import (
 class DummyNode:
     def __init__(self):
         self.foo = [0]
+        self.running = False
+        self.label = "node_label"
 
     def update(self):
         self.foo.append(self.foo[-1] + 1)
@@ -121,6 +123,10 @@ class TestDataChannels(TestCase):
                 inp.value,
                 msg="Value should have been passed downstream"
             )
+
+        self.ni1.node.running = True
+        with self.assertRaises(RuntimeError):
+            self.no.update(42)
 
 
 class TestSignalChannels(TestCase):

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -6,6 +6,10 @@ from pyiron_contrib.workflow.io import Inputs, Outputs
 
 
 class DummyNode:
+    def __init__(self):
+        self.running = False
+        self.label = "node_label"
+
     def update(self):
         pass
 

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -110,6 +110,38 @@ class TestNode(TestCase):
             msg="Running the upstream node should trigger a run here"
         )
 
+    def test_statuses(self):
+        n = Node(plus_one, "p1")
+        self.assertTrue(n.ready)
+        self.assertFalse(n.running)
+        # Can't really test "running" until we have a background executor
+        self.assertFalse(n.failed)
+
+        n.inputs.x = "Can't be added together with an int"
+        with self.assertRaises(TypeError):
+            # The function error should get passed up
+            n.run()
+        self.assertFalse(n.ready)
+        # self.assertFalse(n.running)
+        self.assertTrue(n.failed)
+
+        n.inputs.x = 1
+        n.update()
+        self.assertFalse(
+            n.ready,
+            msg="Update _checks_ for ready, so should still have failed status"
+        )
+        # self.assertFalse(n.running)
+        self.assertTrue(n.failed)
+
+        n.run()
+        self.assertTrue(
+            n.ready,
+            msg="A manual run() call bypasses checks, so readiness should reset"
+        )
+        self.assertTrue(n.ready)
+        # self.assertFalse(n.running)
+        self.assertFalse(n.failed, msg="Re-running should reset failed status")
 
 @skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
 class TestFastNode(TestCase):

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -143,6 +143,7 @@ class TestNode(TestCase):
         # self.assertFalse(n.running)
         self.assertFalse(n.failed, msg="Re-running should reset failed status")
 
+
 @skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
 class TestFastNode(TestCase):
     def test_instantiation(self):
@@ -150,6 +151,7 @@ class TestFastNode(TestCase):
 
         with self.assertRaises(ValueError):
             missing_defaults_should_fail = FastNode(no_default, "z")
+
 
 @skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
 class TestSingleValueNode(TestCase):


### PR DESCRIPTION
Adds new `running` and `failed` flags to `Node`.

`running` is turned on then off inside the `run` method; `failed` gets set when the node function raises an error. Nodes that are running or failed are not `ready`. Nodes that are running cannot be `run`, nor will their input data channels `update`.

For now, none of this is useful, but node status will be necessary once we introduce executors and the workflow is able to do other things while a node runs (either in the background or remotely).