### PR TITLE
Fail earlier without output labels

### DIFF
--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -26,7 +26,7 @@ class Node(HasToDict):
 
     An "update" is gentle and will only trigger the node to run if its run-on-update
     flag is set to true and if its input is all ready -- i.e. having values matching
-    the type hints.
+    the type hints, and if it is not either already running or already failed.
 
     They also have input and output signal channels -- a run input and a ran output,
     although these are extensible in child classes. Calling the run input signal
@@ -81,7 +81,9 @@ class Node(HasToDict):
         inputs (Inputs): A collection of input data channels.
         outputs (Outputs): A collection of output data channels.
         signals (Signals): A holder for input and output collections of signal channels.
-        ready (bool): All input reports ready.
+        ready (bool): All input reports ready, not running or failed.
+        running (bool): Currently running.
+        failed (bool): An exception was thrown when executing the node function.
         connected (bool): Any IO channel has at least one connection.
         fully_connected (bool): Every IO channel has at least one connection.
 

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -317,6 +317,9 @@ class Node(HasToDict):
             workflow: Optional[Workflow] = None,
             **kwargs
     ):
+        if len(output_labels) == 0:
+            raise ValueError("Nodes must have at least one output label.")
+
         self.running = False
         self.failed = False
         self.node_function = node_function

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -24,6 +24,13 @@ class TestNode(TestCase):
     def test_defaults(self):
         node = Node(plus_one, "y")
 
+    def test_failure_without_output_labels(self):
+        with self.assertRaises(
+                ValueError,
+                msg="Instantiated nodes should demand at least one output label"
+        ):
+            Node(plus_one)
+
     def test_instantiation_update(self):
         no_update = Node(
             plus_one,

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -22,7 +22,7 @@ def no_default(x, y):
 @skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
 class TestNode(TestCase):
     def test_defaults(self):
-        node = Node(plus_one, "y")
+        Node(plus_one, "y")
 
     def test_failure_without_output_labels(self):
         with self.assertRaises(

--- a/tests/unit/workflow/test_node.py
+++ b/tests/unit/workflow/test_node.py
@@ -82,7 +82,7 @@ class TestNode(TestCase):
         self.assertEqual(4, node2.outputs.y.value, msg="Initialize from connection")
 
     def test_automatic_updates(self):
-        node = Node(throw_error, run_on_updates=True)
+        node = Node(throw_error, "no_return", run_on_updates=True)
 
         with self.subTest("Shouldn't run for invalid input on update"):
             node.inputs.x.update("not an int")


### PR DESCRIPTION
We demand that output be labeled, so throw a clear and explicit error if a node gets instantiated with no output labels. (Note that one label is totally sufficient, as the user may be intentionally trying to return data of type `tuple` for a function that returns multiple values.)