### PR TITLE
Refactor the two ways of adding into a single method

### DIFF
--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -26,18 +26,17 @@ class TestWorkflow(TestCase):
         # Validate name incrementation
         wf.add(Node(fnc, "x", label="foo"))
         wf.add.Node(fnc, "y", label="bar")
-        with self.assertRaises(AttributeError):
-            wf.baz = Node(
-                fnc,
-                "y",
-                label="even_without_strict_you_still_cant_override_by_assignment"
-            )
+        wf.baz = Node(
+            fnc,
+            "y",
+            label="without_strict_you_can_override_by_assignment"
+        )
         Node(fnc, "x", label="boa", workflow=wf)
         self.assertListEqual(
             list(wf.nodes.keys()),
             [
                 "foo", "bar", "baz", "boa",
-                "foo0", "bar0", "boa0",
+                "foo0", "bar0", "baz0", "boa0",
             ]
         )
 


### PR DESCRIPTION
Which is itself refactored so the checks are a bit more readable. There was _one_ behaviour change here, and that is that we now allow iterating on labels even during node-addition-by-attribute-assignment (of course, still only when strict_naming is deactivated). I.e.

```python
from pyiron_contrib.workflow.workflow import Workflow

@Workflow.wrap_as.node("y")
def fnc(x=0): return x + 1

wf = Workflow("my_workflow")
wf.deactivate_strict_naming()

wf.baz = fnc(label="base")
wf.baz = fnc(label="zeroth")
wf.baz = fnc(label="first")

print(wf.nodes.keys())
>>> dict_keys(['baz', 'baz0', 'baz1'])
```

Test is updated accordingly.