### PR TITLE
Check whether all variables are defined inside the node function

### DIFF
--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -4,6 +4,7 @@ import inspect
 import warnings
 from functools import partialmethod
 from typing import get_args, get_type_hints, Optional, TYPE_CHECKING
+import dis
 
 from pyiron_contrib.workflow.channels import (
     InputData,
@@ -366,7 +367,7 @@ class Node(HasToDict):
 
     @staticmethod
     def _check_node_ready_to_run(func):
-        undefined_variables = set(list(check_func_variables(func))
+        undefined_variables = set(list(check_func_variables(func)))
         if len(undefined_variables) == 0:
             return True
         else:
@@ -554,7 +555,7 @@ class Node(HasToDict):
 def check_func_variables(func):
     for ins in dis.get_instructions(func):
         if inspect.iscode(ins.argval):  # inner function
-            yield from check_node_variables(ins.argval)
+            yield from check_func_variables(ins.argval)
         elif ins.opname == "LOAD_GLOBAL":  # global variable
             yield ins.argval
 


### PR DESCRIPTION
This change gives a warning, if not all variables are defined within the node.

```python
def add1(a):
    return np.sum(a)

wf.add.Node(add1, "output")
```

Output: `np`

```python
def add2(a):
    import numpy as np
    return np.sum(a)

wf.add.Node(add2, "output")
```

Output: None

```python
b = 3

def add3(a):
    return a + b

wf.add.Node(add3, "output")
```

Output: `b`

```python
def add4(a, b=3):
    return a + b

wf.add.Node(add4, "output")
```

Output: None


```python
x = 0
y = 1
z = 2

def complex_func():
    p = 0
    print(f"{x}")
    def inner1(t):
        q = y
        return lambda s: x + add3(z)
    return inner1(2)

wf.add.Node(complex_func, "output")
```

Output: `y, x, z, add3`