### PR TITLE
Prepare for executors

### DIFF
--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -485,6 +485,18 @@ class Node(HasToDict):
             self.failed = True
             raise e
 
+        self.process_output(function_output)
+
+    def process_output(self, function_output):
+        """
+        Take the results of the node function, and use them to update the node.
+
+        By extracting this as a separate method, we allow the node to pass the actual
+        execution off to another entity and release the python process to do other
+        things. In such a case, this function should be registered as a callback
+        so that the node can finishing "running" and push its data forward when that
+        execution is finished.
+        """
         if len(self.outputs) == 1:
             function_output = (function_output,)
 

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -479,14 +479,20 @@ class Node(HasToDict):
         self.running = True
         self.failed = False
 
-        try:
-            function_output = self.node_function(**self.inputs.to_value_dict())
-        except Exception as e:
-            self.running = False
-            self.failed = True
-            raise e
-
-        self.process_output(function_output)
+        if self.server is None:
+            try:
+                function_output = self.node_function(**self.inputs.to_value_dict())
+            except Exception as e:
+                self.running = False
+                self.failed = True
+                raise e
+            self.process_output(function_output)
+        else:
+            raise NotImplementedError(
+                "We currently only support executing the node functionality right on "
+                "the main python process that the node instance lives on. Come back "
+                "later for cool new features."
+            )
 
     def process_output(self, function_output):
         """

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -328,6 +328,7 @@ class Node(HasToDict):
 
         self.running = False
         self.failed = False
+        self.server = None  # Or "task_manager" or "executor" -- we'll see what's best
         self.node_function = node_function
         self.label = label if label is not None else node_function.__name__
 


### PR DESCRIPTION
Or servers, or task managers, or whatever you want to call them. The point is that the current implementation simply executes nodes using the main python process, but we want to make space for the node to ship the node functionality (callable and arguments) off to some other entity that will handle the actual computation.

@samwaseda, I think for you're demo I think you'll want to do [something like this](https://stackoverflow.com/questions/2231227/python-subprocess-popen-with-a-modified-environment). I don't know exactly how it will pan out, but be aware that `concurrent.futures.ProcessPoolExecutor` has trouble when combined with the interactive interpreter (i.e. notebooks) on everything _except_ linux, cf. #677. So depending how you go here you might bump into that. Getting a not-just-the-same-process executor/server/task manager running is also relatively high priority for me, so I'll try to be highly responsive to your next step(s).