### PR TITLE
Introduce `DirectoryObject` and `FileObject`

### DIFF
--- a/pyiron_contrib/workflow/files.py
+++ b/pyiron_contrib/workflow/files.py
@@ -14,7 +14,7 @@ def delete_files_and_directories_recursively(path):
     
 class DirectoryObject:
     def __init__(self, directory):
-        self.path = Path(path)
+        self.path = Path(directory)
         self.create()
 
     def create(self):
@@ -36,6 +36,9 @@ class DirectoryObject:
         path = self.path / Path(file_name)
         with path.open(mode=mode) as f:
             f.write(content)
+
+    def create_subdirectory(self, path):
+        return DirectoryObject(self.path / path)
 
 
 class FileObject:

--- a/pyiron_contrib/workflow/files.py
+++ b/pyiron_contrib/workflow/files.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+
+def delete_files_and_directories_recursively(path):
+    if not path.exists():
+        return
+    for item in path.rglob('*'):
+        if item.is_file():
+            item.unlink()
+        else:
+            delete_files_and_directories_recursively(item)
+    path.rmdir()
+    
+    
+class DirectoryObject:
+    def __init__(self, directory):
+        self.path = Path(path)
+        self.create()
+
+    def create(self):
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def delete(self):
+        delete_files_and_directories_recursively(self.path)
+
+    def list_files(self):
+        return list(self.path.glob('*'))
+
+    def __len__(self):
+        return len(self.list_files())
+
+    def __repr__(self):
+        return f"DirectoryObject(directory='{self.path}' with {len(self)} files)"
+
+    def write(self, file_name, content, mode="w"):
+        path = self.path / Path(file_name)
+        with path.open(mode=mode) as f:
+            f.write(content)
+
+
+class FileObject:
+    def __init__(self, file_name: str, directory: DirectoryObject):
+        self.directory = directory
+        self._file_name = file_name
+
+    @property
+    def file_name(self):
+        return self._file_name
+
+    @property
+    def path(self):
+        return self.directory.path / Path(self._file_name)
+
+    def write(self, content, mode='w'):
+        self.directory.write(file_name=self.file_name, content=content, mode=mode)
+
+    def delete(self):
+        self.path.unlink()

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -14,6 +14,7 @@ from pyiron_contrib.workflow.channels import (
 from pyiron_contrib.workflow.has_channel import HasChannel
 from pyiron_contrib.workflow.has_to_dict import HasToDict
 from pyiron_contrib.workflow.io import Inputs, Outputs, Signals
+from pyiron_contrib.workflow.files import FileObject
 
 if TYPE_CHECKING:
     from pyiron_contrib.workflow.workflow import Workflow
@@ -364,6 +365,8 @@ class Node(HasToDict):
         if update_on_instantiation:
             self.update()
 
+        self._working_directory = None
+
     @property
     def _input_args(self):
         return inspect.signature(self.node_function).parameters
@@ -571,6 +574,22 @@ class Node(HasToDict):
             "outputs": self.outputs.to_dict(),
             "signals": self.signals.to_dict(),
         }
+
+    @property
+    def working_directory(self):
+        if self._working_directory is None:
+            if self.workflow is None:
+                raise ValueError(
+                    "working directory is available only if the node is"
+                    " attached to a workflow"
+                )
+            self._working_directory = self.workflow.working_directory.create_subdirectory(
+                self.label
+            )
+        return self._working_directory
+
+    def create_file(self, file_name):
+        return FileObject(file_name, self.working_directory)
 
 
 class FastNode(Node):

--- a/pyiron_contrib/workflow/workflow.py
+++ b/pyiron_contrib/workflow/workflow.py
@@ -7,6 +7,7 @@ from pyiron_contrib.workflow.has_to_dict import HasToDict
 from pyiron_contrib.workflow.node import Node, node, fast_node, single_value_node
 from pyiron_contrib.workflow.node_library import atomistics, package, standard
 from pyiron_contrib.workflow.util import DotDict
+from pyiron_contrib.workflow.files import DirectoryObject
 
 
 class _NodeAdder:
@@ -153,10 +154,17 @@ class Workflow(HasToDict):
         self.__dict__["nodes"] = DotDict()
         self.__dict__["add"] = _NodeAdder(self)
         self.__dict__["strict_naming"] = strict_naming
+        self.__dict__["working_directory"] = None
         # We directly assign using __dict__ because we override the setattr later
 
         for node in nodes:
             self.add_node(node)
+
+    @property
+    def working_directory(self):
+        if self.__dict__["working_directory"] is None:
+            self.__dict__["working_directory"] = DirectoryObject(self.label)
+        return self.__dict__["working_directory"]
 
     def add_node(self, node: Node, label: str = None) -> None:
         """


### PR DESCRIPTION
This PR allows for working files which some softwares require.

- `FileObject` handles only the file and has no information of address i.e. it must be attached to a `DirectoryObject`
- The central path is known to `Workflow` -> a `Node` cannot create a directory if it is not attached to a `Workflow`
- The directory is created only if `workflow.working_directory` is called.
- Path: `workflow_name/function_name/file_name`

Example I:

```python
from pyiron_contrib.workflow import Workflow
from pyiron_contrib.workflow.node import Node

def f(x):
    return x

wf = Workflow("TEST")
n_f = Node(f, "f")
wf.add(n_f)
my_file = n_f.create_file('new_file')  # Creates all directories
my_file.write('something')

with open(my_file.path, 'r') as f:
    print(f.read())

wf.working_directory.delete()  # deletes everything
```

Output:

```
TEST/f/new_file
something
```

Example II

```python
def f(x):
    return x

n_f = Node(f, "f")
my_file = n_f.create_file('new_file')  # Error, because not attached to a workflow
```


Closes #702