### PR TITLE
Use the new workflow that swaps 3.8 for 3.11

### DIFF
--- a/.github/workflows/push-pull-main.yml
+++ b/.github/workflows/push-pull-main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull-main.yml@main
+    uses: pyiron/actions/.github/workflows/push-pull-main.yml@drop_38
     secrets: inherit
     with:
       notebooks-env-files: .ci_support/environment.yml .ci_support/environment-notebooks.yml


### PR DESCRIPTION
I'm sure there must be a way to automate this sort of test, but for this exact moment let's just be quick and dirty and manually swap the branch target in a PR on this repo. There is no intention to actually merge this commit to main.