### PR TITLE
Workflow: Refactor io

### DIFF
--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -56,7 +56,7 @@ class IO(HasToDict, ABC):
 
     @property
     @abstractmethod
-    def _channel_class(self) -> Channel:
+    def _channel_class(self) -> type(Channel):
         pass
 
     @abstractmethod
@@ -152,7 +152,7 @@ class DataIO(IO, ABC):
 
 class Inputs(DataIO):
     @property
-    def _channel_class(self) -> InputData:
+    def _channel_class(self) -> type(InputData):
         return InputData
 
     def activate_strict_connections(self):
@@ -164,7 +164,7 @@ class Inputs(DataIO):
 
 class Outputs(DataIO):
     @property
-    def _channel_class(self) -> OutputData:
+    def _channel_class(self) -> type(OutputData):
         return OutputData
 
 
@@ -181,13 +181,13 @@ class SignalIO(IO, ABC):
 
 class InputSignals(SignalIO):
     @property
-    def _channel_class(self) -> InputSignal:
+    def _channel_class(self) -> type(InputSignal):
         return InputSignal
 
 
 class OutputSignals(SignalIO):
     @property
-    def _channel_class(self) -> OutputSignal:
+    def _channel_class(self) -> type(OutputSignal):
         return OutputSignal
 
 

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -58,7 +58,8 @@ class IO(HasToDict, ABC):
         pass
 
     @abstractmethod
-    def _set_existing(self, key, value):
+    def _assign_value_to_channel(self, key, value):
+        """What to do when some non-channel value gets assigned to a channel"""
         pass
 
     def __getattr__(self, item) -> Channel:
@@ -66,8 +67,13 @@ class IO(HasToDict, ABC):
 
     def __setattr__(self, key, value):
         if key in self.channel_dict.keys():
-            self._set_existing(key, value)
+            # Assignment to an existing channel
+            if isinstance(value, HasChannel):
+                self.channel_dict[key].connect(value.channel)
+            else:
+                self._assign_value_to_channel(key, value)
         elif isinstance(value, self._channel_class):
+            # Assigning a channel of the correct type to an unused key
             if key != value.label:
                 raise ValueError(
                     f"Channels can only be assigned to attributes matching their label,"
@@ -121,11 +127,8 @@ class IO(HasToDict, ABC):
 
 
 class DataIO(IO, ABC):
-    def _set_existing(self, key, value):
-        if isinstance(value, HasChannel):
-            self.channel_dict[key].connect(value.channel)
-        else:
-            self.channel_dict[key].update(value)
+    def _assign_value_to_channel(self, key, value):
+        self.channel_dict[key].update(value)
 
     def to_value_dict(self):
         return {label: channel.value for label, channel in self.channel_dict.items()}
@@ -163,15 +166,12 @@ class Outputs(DataIO):
 
 
 class SignalIO(IO, ABC):
-    def _set_existing(self, key, value):
-        if isinstance(value, HasChannel):
-            self.channel_dict[key].connect(value.channel)
-        else:
-            raise TypeError(
-                f"Tried to assign {value} ({type(value)} to the {key}, which is already"
-                f" a {type(self.channel_dict[key])}. Only other signal channels may be "
-                f"connected in this way."
-            )
+    def _assign_value_to_channel(self, key, value):
+        raise TypeError(
+            f"Tried to assign {value} ({type(value)} to the {key}, which is already"
+            f" a {type(self.channel_dict[key])}. Only other signal channels may be "
+            f"connected in this way."
+        )
 
 
 class InputSignals(SignalIO):

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -44,7 +44,7 @@ class IO(HasToDict, ABC):
     """
 
     def __init__(self, *channels: Channel):
-        self.channel_dict = DotDict(
+        self.__dict__["channel_dict"] = DotDict(
             {
                 channel.label: channel
                 for channel in channels
@@ -65,9 +65,7 @@ class IO(HasToDict, ABC):
         return self.channel_dict[item]
 
     def __setattr__(self, key, value):
-        if key in ["channel_dict"]:
-            super().__setattr__(key, value)
-        elif key in self.channel_dict.keys():
+        if key in self.channel_dict.keys():
             self._set_existing(key, value)
         elif isinstance(value, self._channel_class):
             if key != value.label:

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -25,6 +25,9 @@ class IO(HasToDict, ABC):
     attribute name matches the channel's label and type (i.e. `OutputChannel` for
     `Outputs` and `InputChannel` for `Inputs`).
 
+    New channels can also be added using the `add` method, which must be implemented in
+    child classes to add channels of the correct type.
+
     When assigning something to an attribute holding an existing channel, if the
     assigned object is a `Channel`, then it is treated like a `connection`, otherwise
     it is treated like a value `update`. I.e.

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -169,9 +169,7 @@ class Outputs(DataIO):
 
 
 class SignalIO(IO, ABC):
-    def _assign_a_non_channel_value(
-            self, channel: SignalChannel, value
-    ) -> None:
+    def _assign_a_non_channel_value(self, channel: SignalChannel, value) -> None:
         raise TypeError(
             f"Tried to assign {value} ({type(value)} to the {channel.label}, which is "
             f"already a {type(channel)}. Only other signal channels may be connected "


### PR DESCRIPTION
I had originally hoped to get it so that you don't need to import channel classes to add to an IO panel, e.g. `self.signals.input.add("run", self.run)` instead of `self.signals.input.run = InputSignal("run", self, self.run)`. I didn't manage to get that working, but nonetheless like the refactoring that happened along the way.