### PR TITLE
Tinybase: Add creators for UX

### DIFF
--- a/notebooks/tinybase/TinyJob.ipynb
+++ b/notebooks/tinybase/TinyJob.ipynb
@@ -86,52 +86,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "id": "e31baebd-b2c8-4343-90ad-92d9128d1496",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d365d332f5f44babad1dc4f275dc3284",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "j = pr.create.job.AseMD('md')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "id": "18e6de26-308c-46ae-9672-b2db43447ea5",
    "metadata": {
     "tags": []
@@ -144,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 18,
    "id": "72848cd2-fd51-4ad8-b56e-ca686074bb26",
    "metadata": {
     "tags": []
@@ -159,18 +126,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 19,
    "id": "56c0e73a-c42b-4814-a25a-e6974fea3d00",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:Job already finished!\n"
-     ]
+     "data": {
+      "text/plain": [
+       "<pyiron_contrib.tinybase.executor.ExecutionContext at 0x7fc186581b40>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/notebooks/tinybase/TinyJob.ipynb
+++ b/notebooks/tinybase/TinyJob.ipynb
@@ -86,19 +86,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "e31baebd-b2c8-4343-90ad-92d9128d1496",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d9d50a24c6348aa986d0949a2750f6f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "j = pr.create.job.AseMD('md')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "id": "18e6de26-308c-46ae-9672-b2db43447ea5",
    "metadata": {
     "tags": []
@@ -111,7 +144,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
+   "id": "652989f1-6a38-4901-9c21-4302c85bb0d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from math import inf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "72848cd2-fd51-4ad8-b56e-ca686074bb26",
    "metadata": {
     "tags": []
@@ -126,21 +171,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "id": "56c0e73a-c42b-4814-a25a-e6974fea3d00",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<pyiron_contrib.tinybase.executor.ExecutionContext at 0x7fc186581b40>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:Job already finished!\n"
+     ]
     }
    ],
    "source": [
@@ -149,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "49ccfe01-7b7e-4615-bf43-21c1bbffec66",
    "metadata": {
     "tags": []
@@ -158,7 +200,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1945295762b54d49809da2f8840cf80d",
+       "model_id": "6a7d186114ee445abf94c0ab53aa0e90",
        "version_major": 2,
        "version_minor": 0
       },
@@ -184,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "7b807119-da8d-475c-9aa8-c8e8c9afa115",
    "metadata": {
     "tags": []
@@ -196,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "3a8cda32-df2e-4884-8cfd-84e438c5be69",
    "metadata": {
     "tags": []
@@ -214,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "d4b81c3f-4667-4b99-a2b3-08c7ee7e2c82",
    "metadata": {
     "tags": []
@@ -229,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "id": "e7494fee-d565-45e3-a819-c77ab0d2c7f6",
    "metadata": {
     "scrolled": true,
@@ -237,24 +279,66 @@
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:root:Job already finished!\n"
+      "       Step     Time          Energy         fmax\n",
+      "LBFGS:    0 12:07:57       11.288146      189.5231\n",
+      "LBFGS:    1 12:07:57        1.168671       43.6957\n",
+      "LBFGS:    2 12:07:57        0.860403       38.6924\n",
+      "LBFGS:    3 12:07:57        0.362400       30.3554\n",
+      "LBFGS:    4 12:07:57        0.004806       24.0865\n",
+      "LBFGS:    5 12:07:57       -0.267437       19.0615\n",
+      "LBFGS:    6 12:07:57       -0.471646       15.0628\n",
+      "LBFGS:    7 12:07:57       -0.623506       11.8810\n",
+      "LBFGS:    8 12:07:57       -0.735237        9.3518\n",
+      "LBFGS:    9 12:07:57       -0.816458        7.3435\n",
+      "LBFGS:   10 12:07:57       -0.874705        5.7512\n",
+      "LBFGS:   11 12:07:57       -0.915849        4.4909\n",
+      "LBFGS:   12 12:07:57       -0.944435        3.4955\n",
+      "LBFGS:   13 12:07:57       -0.963943        2.7113\n",
+      "LBFGS:   14 12:07:57       -0.977006        2.0956\n",
+      "LBFGS:   15 12:07:57       -0.985585        1.6137\n",
+      "LBFGS:   16 12:07:57       -0.991109        1.2382\n",
+      "LBFGS:   17 12:07:57       -0.994598        0.9468\n",
+      "LBFGS:   18 12:07:57       -0.996763        0.7216\n",
+      "LBFGS:   19 12:07:57       -0.998083        0.5484\n",
+      "LBFGS:   20 12:07:57       -0.998876        0.4157\n",
+      "LBFGS:   21 12:07:57       -0.999347        0.3144\n",
+      "LBFGS:   22 12:07:57       -0.999623        0.2374\n",
+      "LBFGS:   23 12:07:57       -0.999784        0.1790\n",
+      "LBFGS:   24 12:07:57       -0.999877        0.1348\n",
+      "LBFGS:   25 12:07:57       -0.999930        0.1014\n",
+      "LBFGS:   26 12:07:57       -0.999960        0.0762\n",
+      "LBFGS:   27 12:07:57       -0.999977        0.0573\n",
+      "LBFGS:   28 12:07:57       -0.999987        0.0430\n",
+      "LBFGS:   29 12:07:57       -0.999993        0.0323\n",
+      "LBFGS:   30 12:07:57       -0.999996        0.0242\n",
+      "LBFGS:   31 12:07:57       -0.999998        0.0182\n",
+      "LBFGS:   32 12:07:57       -0.999999        0.0136\n",
+      "LBFGS:   33 12:07:57       -0.999999        0.0102\n",
+      "LBFGS:   34 12:07:57       -1.000000        0.0077\n",
+      "LBFGS:   35 12:07:57       -1.000000        0.0058\n",
+      "LBFGS:   36 12:07:57       -1.000000        0.0043\n",
+      "LBFGS:   37 12:07:57       -1.000000        0.0032\n",
+      "LBFGS:   38 12:07:57       -1.000000        0.0024\n",
+      "LBFGS:   39 12:07:57       -1.000000        0.0018\n",
+      "LBFGS:   40 12:07:57       -1.000000        0.0014\n",
+      "LBFGS:   41 12:07:57       -1.000000        0.0010\n",
+      "LBFGS:   42 12:07:57       -1.000000        0.0008\n"
      ]
     }
    ],
    "source": [
-    "exe = j.run(\n",
+    "j.run(\n",
     "    executor=pr.create.executor.process(4)\n",
     ")\n",
-    "if exe is not None:\n",
-    "    exe.wait()"
+    "j.wait()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "id": "7c16a615-0913-4880-9694-2c125285babc",
    "metadata": {
     "tags": []
@@ -295,30 +379,6 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>4</td>\n",
-       "      <td>pyiron</td>\n",
-       "      <td>md</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>8</td>\n",
-       "      <td>/home/poul/pyiron/contrib/notebooks/tinybase/t...</td>\n",
-       "      <td>finished</td>\n",
-       "      <td>AseMDTask</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>5</td>\n",
-       "      <td>pyiron</td>\n",
-       "      <td>min</td>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>9</td>\n",
-       "      <td>/home/poul/pyiron/contrib/notebooks/tinybase/t...</td>\n",
-       "      <td>finished</td>\n",
-       "      <td>AseMinimizeTask</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
        "      <td>6</td>\n",
        "      <td>pyiron</td>\n",
        "      <td>murn</td>\n",
@@ -329,15 +389,39 @@
        "      <td>finished</td>\n",
        "      <td>MurnaghanTask</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7</td>\n",
+       "      <td>pyiron</td>\n",
+       "      <td>md</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>13</td>\n",
+       "      <td>/home/poul/pyiron/contrib/notebooks/tinybase/t...</td>\n",
+       "      <td>finished</td>\n",
+       "      <td>AseMDTask</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>8</td>\n",
+       "      <td>pyiron</td>\n",
+       "      <td>min</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>14</td>\n",
+       "      <td>/home/poul/pyiron/contrib/notebooks/tinybase/t...</td>\n",
+       "      <td>finished</td>\n",
+       "      <td>AseMinimizeTask</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "   id username  name  jobtype_id  project_id  status_id  \\\n",
-       "0   4   pyiron    md           1           1          8   \n",
-       "1   5   pyiron   min           3           1          9   \n",
-       "2   6   pyiron  murn           2           1         11   \n",
+       "0   6   pyiron  murn           2           1         11   \n",
+       "1   7   pyiron    md           1           1         13   \n",
+       "2   8   pyiron   min           3           1         14   \n",
        "\n",
        "                                            location    status  \\\n",
        "0  /home/poul/pyiron/contrib/notebooks/tinybase/t...  finished   \n",
@@ -345,12 +429,12 @@
        "2  /home/poul/pyiron/contrib/notebooks/tinybase/t...  finished   \n",
        "\n",
        "              type  \n",
-       "0        AseMDTask  \n",
-       "1  AseMinimizeTask  \n",
-       "2    MurnaghanTask  "
+       "0    MurnaghanTask  \n",
+       "1        AseMDTask  \n",
+       "2  AseMinimizeTask  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 26,
    "id": "654ce992-b73f-42e3-a32e-2e0dafa7c952",
    "metadata": {
     "tags": []
@@ -515,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 27,
    "id": "253237f0-b338-470c-bc54-3c7400a757b7",
    "metadata": {},
    "outputs": [],
@@ -526,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 28,
    "id": "c801093b-499e-48a7-8444-77602ed88a96",
    "metadata": {},
    "outputs": [],
@@ -536,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 29,
    "id": "1e30b36e-11e6-47d1-836e-cffea7b73cdd",
    "metadata": {},
    "outputs": [],
@@ -546,44 +630,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 30,
    "id": "18b5305a-8950-44af-bc2e-c9734b059713",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:Job already finished!\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.5 ms, sys: 727 µs, total: 2.23 ms\n",
-      "Wall time: 2.08 ms\n"
+      "CPU times: user 1.41 s, sys: 1.23 s, total: 2.64 s\n",
+      "Wall time: 10.7 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "exe = murn.run(\n",
-    "    executor=pr.create.executor.process(4)\n",
-    ")\n",
-    "if exe is not None:\n",
-    "    exe.wait()"
+    "murn.run(executor='process')\n",
+    "murn.wait()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 31,
    "id": "836bb2ec-4295-4a3c-b976-7a35d04aad36",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiIAAAGdCAYAAAAvwBgXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA5/ElEQVR4nO3dd3Tc1Z3//9eojXrvXa5yL3IvYMAYA6EmYHozBC8QQtjdJIRkgWw2/p5A+OUkBBISajCmG0gwYAdww90W7l29N0ujXj+/PyQNFm6SrZnPSPN8nDNn48/MeN7ej/G8dO/73msxDMMQAACACTzMLgAAALgvgggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDReZhdwJh0dHSoqKlJQUJAsFovZ5QAAgF4wDEO1tbWKj4+Xh8eZxzxcOogUFRUpKSnJ7DIAAMA5yM/PV2Ji4hlf49JBJCgoSFLnHyQ4ONjkagAAQG/YbDYlJSXZv8fPxKWDSPd0THBwMEEEAIABpjdtFTSrAgAA0xBEAACAaQgiAADANAQRAABgGoIIAAAwDUEEAACYhiACAABMQxABAACmIYgAAADTEEQAAIBpCCIAAMA0BBEAAGAalz70zlEOldTq/Z0FCvP30X/MG2p2OQAAuC23HBEprmnUi+uy9NE3hWaXAgCAW3PLIJIQ6idJKqpuNLkSAADcm1sGkbiuIGJralNdc5vJ1QAA4L7cMogEWr0U7NvZHlPMqAgAAKZxyyAiSfFdoyKFBBEAAEzj9kGkqLrJ5EoAAHBfbhxEfCV1rqABAADmcOMgwtQMAABmc98gEtIZRIqZmgEAwDTuG0S6e0SYmgEAwDRuG0TiQrp6RKqb1NFhmFwNAADuyW2DSGyIrywWqaW9Q5X1LWaXAwCAW3LbIOLt6aGYoM5REbZ6BwDAHG4bRCQpjiW8AACYyq2DyLdLeFk5AwCAGdw6iHAKLwAA5nLrIGJfOcPUDAAApnDrIMLUDAAA5nLrIMLUDAAA5nLrINI9NVNe26zmtnaTqwEAwP04LYgsXbpUFotFjzzyiLM+8qzCA3xk9er8f0FpTbPJ1QAA4H6cEkS2bdumF198UePHj3fGx/WaxWL5dnqGhlUAAJzO4UGkrq5Ot956q/72t78pLCzM0R/XZ92bmtEnAgCA8zk8iDz44IO68sorNX/+/LO+trm5WTabrcfD0eJDaFgFAMAsXo78zd966y3t3LlT27Zt69Xrly5dqqeeesqRJZ0kzj41wxJeAACczWEjIvn5+frxj3+sN954Q76+vr16z2OPPaaamhr7Iz8/31Hl2SUwNQMAgGkcNiKyY8cOlZWVKSMjw36tvb1d69at03PPPafm5mZ5enr2eI/VapXVanVUSacUz14iAACYxmFB5JJLLtGePXt6XLv77ruVnp6un/3sZyeFELN8G0SaZBiGLBaLyRUBAOA+HBZEgoKCNHbs2B7XAgICFBERcdJ1M3Uv361rblNNY6tC/X1MrggAAPfh1jurSpKvt6eigjqngwqOMz0DAIAzOXTVzHetWbPGmR/Xa4lhfiqvbVbB8QaNTQgxuxwAANyG24+ISFJimL8kRkQAAHA2gog6R0QkgggAAM5GENGJQaTB5EoAAHAvBBF9u3KGEREAAJyLIKKePSKGYZhcDQAA7oMgom+nZuqa22RrbDO5GgAA3AdBRJ17iUQGdu4lkk+fCAAATkMQ6cLKGQAAnI8g0oWVMwAAOB9BpAubmgEA4HwEkS5MzQAA4HwEkS4JTM0AAOB0BJEuSV1BpJC9RAAAcBqCSJeE0M4ekVr2EgEAwGkIIl38fDwVGegjib1EAABwFoLICRK6Vs4UVtOwCgCAMxBETsDKGQAAnIsgcgI2NQMAwLkIIidgUzMAAJyLIHKCxFCmZgAAcCaCyAnsUzNVDewlAgCAExBETtA9NVPb3KaaxlaTqwEAYPAjiJzAz8dT0UFWSVJuJQ2rAAA4GkHkO1IiOkdF8qoIIgAAOBpB5DuSwgkiAAA4C0HkO5K7gwhTMwAAOBxB5DuYmgEAwHkIIt+RzNQMAABOQxD5ju4ekeKaRrW0dZhcDQAAgxtB5DuiAq3y8/ZUh8EpvAAAOBpB5DssFgvTMwAAOAlB5BTsS3gr602uBACAwY0gcgqsnAEAwDkIIqfA1AwAAM5BEDmF7iDCeTMAADgWQeQUkrumZvKrGmQYhsnVAAAweBFETiEh1E8Wi1Tf0q6q+hazywEAYNAiiJyCr7enYoN9JUm59IkAAOAwBJHT6O4TySeIAADgMASR0+AUXgAAHI8gchr2lTOMiAAA4DAEkdNIZlMzAAAcjiByGvSIAADgeASR0+gOIsU1TWpqbTe5GgAABieCyGmEB/goyNdLEtMzAAA4CkHkNCwWi9IiAyRJ2RWcwgsAgCMQRM4gNaIziOQQRAAAcAiCyBmkdo2I5FQSRAAAcASHBpGlS5dq6tSpCgoKUnR0tK699lodOnTIkR/Zr1K7lvAyNQMAgGM4NIisXbtWDz74oDZv3qzVq1erra1NCxYsUH39wPhit4+IVNCsCgCAI3g58jf/7LPPevz6lVdeUXR0tHbs2KELLrjAkR/dL9K6ekRKbE1qbGmXn4+nyRUBADC4OLVHpKamRpIUHh5+yuebm5tls9l6PMwUFuCjED9vSfSJAADgCE4LIoZh6NFHH9WcOXM0duzYU75m6dKlCgkJsT+SkpKcVd5pfTs9QxABAKC/OS2IPPTQQ9q9e7eWL19+2tc89thjqqmpsT/y8/OdVd5ppXU3rDIiAgBAv3Noj0i3H/3oR/r444+1bt06JSYmnvZ1VqtVVqvVGSX1GiMiAAA4jkODiGEY+tGPfqQVK1ZozZo1SktLc+THOUQaK2cAAHAYhwaRBx98UG+++aY++ugjBQUFqaSkRJIUEhIiPz8/R350v+neXZWpGQAA+p9De0ReeOEF1dTUaN68eYqLi7M/3n77bUd+bL/qnpopr21WXXObydUAADC4OHxqZqAL8fNWeICPqupblFNRr7EJIWaXBADAoMFZM72Q0rVyhr1EAADoXwSRXkjjFF4AAByCINIL3X0i2aycAQCgXxFEeqE7iOQyNQMAQL8iiPSCfWqGIAIAQL8iiPRCamRns2pFXYtsTa0mVwMAwOBBEOmFIF9vRQV1bj2fVc6oCAAA/YUg0ktDozqnZ7LK60yuBACAwYMg0ktDowIlSccIIgAA9BuCSC8N6Q4iZUzNAADQXwgivWSfmqlgRAQAgP5CEOml7qmZnIoGtbV3mFwNAACDA0GklxJC/WT18lBLe4cKjjeaXQ4AAIMCQaSXPDws3/aJ0LAKAEC/IIj0wRD7El4aVgEA6A8EkT5gCS8AAP2LINIH3StnCCIAAPQPgkgffDsiwtQMAAD9gSDSB909IlX1LTpe32JyNQAADHwEkT7w9/FSfIivJDY2AwCgPxBE+mhoNFu9AwDQXwgifWTvE2FEBACA80YQ6SP7yhlGRAAAOG8EkT7q3l01iyW8AACcN4JIH3VPzeRWNailjcPvAAA4HwSRPooJtirQ6qX2DkO5lUzPAABwPggifWSxWOwrZ46UMT0DAMD5IIicgxFdQeRwaa3JlQAAMLARRM7BiJggSdKRUkZEAAA4HwSRczAshhERAAD6A0HkHHSPiGRX1Ku1nZUzAACcK4LIOYgP8VWg1UttHYZyKlg5AwDAuSKInAOLxaJh9oZV+kQAADhXBJFzNJyVMwAAnDeCyDmyr5wpI4gAAHCuCCLnaHjXyhmW8AIAcO4IIufoxJUznDkDAMC5IYico7gTV85w5gwAAOeEIHKOeq6coU8EAIBzQRA5DyNiWMILAMD5IIich2/PnGFEBACAc0EQOQ/D7Ut4GREBAOBcEETOQ/emZjmsnAEA4JwQRM5DXIivgrpWzmRz5gwAAH1GEDkPFotFI2I7p2cOlthMrgYAgIGHIHKe0u1BhIZVAAD6iiByntLjgiVJB4sZEQEAoK8IIudpVNeIyIFiRkQAAOgrpwSR559/XmlpafL19VVGRobWr1/vjI91iu4ekRJbk47Xt5hcDQAAA4vDg8jbb7+tRx55RI8//rgyMzM1d+5cXX755crLy3P0RztFsK+3EsP8JNEnAgBAXzk8iDz77LNavHix7r33Xo0aNUp/+MMflJSUpBdeeMHRH+00o7r7RFg5AwBAnzg0iLS0tGjHjh1asGBBj+sLFizQxo0bT3p9c3OzbDZbj8dA0N0ncpA+EQAA+sShQaSiokLt7e2KiYnpcT0mJkYlJSUnvX7p0qUKCQmxP5KSkhxZXr9JZ0QEAIBz4pRmVYvF0uPXhmGcdE2SHnvsMdXU1Ngf+fn5zijvvHXvJXKotFbtHYbJ1QAAMHB4OfI3j4yMlKen50mjH2VlZSeNkkiS1WqV1Wp1ZEkOkRIRIF9vDzW1dii3sl5DogLNLgkAgAHBoSMiPj4+ysjI0OrVq3tcX716tWbNmuXIj3YqTw+LRsawwyoAAH3l8KmZRx99VH//+9/18ssv68CBA/rJT36ivLw8LVmyxNEf7VTpseywCgBAXzl0akaSFi1apMrKSv36179WcXGxxo4dq5UrVyolJcXRH+1U6XFdO6wyIgIAQK85PIhI0gMPPKAHHnjAGR9lGvYSAQCg7zhrpp90r5zJr2pUbVOrydUAADAwEET6Sai/j+JCfCVJh5ieAQCgVwgi/ah7emZfEdMzAAD0BkGkH42N7w4iNSZXAgDAwEAQ6UdjEkIkSXsLGREBAKA3CCL9aEzXiMjh0lo1t7WbXA0AAK6PINKPEkL9FOrvrbYOQ4dL6swuBwAAl0cQ6UcWi0Vj4zunZ+gTAQDg7Agi/ax7emYvQQQAgLMiiPQzGlYBAOg9gkg/617Ce7DEprb2DpOrAQDAtRFE+llqRIACfDzV1NqhrIp6s8sBAMClEUT6mYeHRaO7+0QK6RMBAOBMCCIOMMa+coY+EQAAzoQg4gBjGBEBAKBXCCIOMLZr5cz+Ips6OgyTqwEAwHURRBxgWHSgfLw8VNvcpvzjDWaXAwCAyyKIOIC3p4dGxQZJkvYwPQMAwGkRRBxkXGLn9MzuAoIIAACnQxBxkPGJoZKkXfnVptYBAIArI4g4yMSkUEmdUzPtNKwCAHBKBBEHGRoVKH8fTzW0tOtYeZ3Z5QAA4JIIIg7i6WHRuK5lvN8wPQMAwCkRRBxoQtf0zO6CalPrAADAVRFEHGiCvWGVlTMAAJwKQcSBxnct4T1YYlNTa7vJ1QAA4HoIIg6UGOaniAAftbYbOlDMAXgAAHwXQcSBLBaLfVSEjc0AADgZQcTBuhtW2dgMAICTEUQczN6wysoZAABOQhBxsO6pmWPl9bI1tZpcDQAAroUg4mARgVYlhvlJkvbSJwIAQA8EESfo7hPJpE8EAIAeCCJOMDk5TJK0M/e4yZUAAOBaCCJOkJHSFUTyjsswOIkXAIBuBBEnGB0XLKuXh443tCq7ot7scgAAcBkEESfw8fKwr57ZwfQMAAB2BBEnmXzC9AwAAOhEEHGSjK6GVUZEAAD4FkHESbpHRI6U1ammkY3NAACQCCJOExloVUqEvwxD+ob9RAAAkEQQcSqmZwAA6Ikg4kTd0zOZNKwCACCJIOJU3TusZuZVq72Djc0AACCIONHI2CAF+HiqrrlNh0trzS4HAADTEUScyNPDokn0iQAAYEcQcbLuc2e25VSZXAkAAOYjiDjZ9LRwSdKWrCoOwAMAuD2HBZGcnBwtXrxYaWlp8vPz09ChQ/XEE0+opaXFUR85IExKDpOXh0UltiYVHG80uxwAAEzl5ajf+ODBg+ro6NBf//pXDRs2THv37tV9992n+vp6PfPMM476WJfn5+Op8Ykh2plXrS3ZVUoK9ze7JAAATOOwILJw4UItXLjQ/ushQ4bo0KFDeuGFF9w6iEjS9CERnUEkq1I/yEg0uxwAAEzj1B6RmpoahYeHn/b55uZm2Wy2Ho/BaFpXn8hWGlYBAG7OaUHk2LFj+tOf/qQlS5ac9jVLly5VSEiI/ZGUlOSs8pwqIyVMHhYpt7JBJTVNZpcDAIBp+hxEnnzySVksljM+tm/f3uM9RUVFWrhwoW644Qbde++9p/29H3vsMdXU1Ngf+fn5ff8TDQDBvt4aHR8siVERAIB763OPyEMPPaSbbrrpjK9JTU21/++ioiJddNFFmjlzpl588cUzvs9qtcpqtfa1pAFpelqE9hbatDW7UldPiDe7HAAATNHnIBIZGanIyMhevbawsFAXXXSRMjIy9Morr8jDg21Luk1LC9dLG7K1JYsREQCA+3LYqpmioiLNmzdPycnJeuaZZ1ReXm5/LjY21lEfO2BMTe1sWD1SVqfKumZFBLrHSBAAACdyWBBZtWqVjh49qqNHjyoxsecSVXYUlcIDfDQiJlCHS+u0Lee4Fo4lnAEA3I/D5kruuusuGYZxygc6dS/j3ZxVaXIlAACYg6YNE80a2tlrs/FYhcmVAABgDoKIiWYOiZDFIh0urVNZLfuJAADcD0HERGEBPhod17mfyKZjTM8AANwPQcRks4d1Ts98fZTpGQCA+yGImGzW0AhJ0tdHK2nkBQC4HYKIyaalhcvb06LC6kblVjaYXQ4AAE5FEDGZv4+XJiWFSZK+ZvUMAMDNEERcQHefyMajNKwCANwLQcQFzB7W2Sey8ViFOjroEwEAuA+CiAuYkBSqAB9PHW9o1YESm9nlAADgNAQRF+Dt6WHf7p1lvAAAd0IQcRHdfSLrjxBEAADugyDiIuaNjJIkbcmuUmNLu8nVAADgHAQRFzE0KlAJoX5qaevgNF4AgNsgiLgIi8WiC7tGRdYcKjO5GgAAnIMg4kIuHNEVRA6Xm1wJAGAwq2tu0xcHSvW//9qv5VvzTK3Fy9RPRw+zh0XKy8Oi3MoG5VTUKzUywOySAACDQHNbu3bmVmvjsQp9fbRCuwpq1N61b9XU1DDdPC3ZtNoIIi4k0OqlKalh2pxVpTWHynRXZJrZJQEABiDDMHS4tE7rj5Rrw9EKbcmqUmNrz4UQKRH+mjU0UhcMjzSpyk4EERczb2S0NmdVae3hct01myACAOidstomfX20QusPV2jD0QqV1Tb3eD4y0KrZwyI0e2ikZg2LUGKYv0mV9kQQcTEXjojS//v0oDZlVaqptV2+3p5mlwQAcEGNLe3akl2pDUc6g8fBktoez/t6e2haWoTmDovUnOGRSo8NksViMana0yOIuJj02CDFBvuqxNakrdlVuqCrgRUA4N46OgztK7Jp/dFybThSoe05x9XS3mF/3mKRxsQHa86wKF0wPFKTU8IGxA+zBBEXY7FYdOGIKL29PV9rDpUTRADAjVXVt2jd4XKtOVSmdUcqVFXf0uP5hFA/zeka8Zg9LFLhAT4mVXruCCIuaN7IziDyxcFS/ep7o1xyKA0A0P/aOwztLqjWmkPlWnO4XLsLqmWccCh7oNVLM4ZEaO7wzvAxJDJgwH9HEERc0NwRUfLx9FBuZYOOltVpeEyQ2SUBAByksq5Z646Ua82hcq07XK7jDa09nk+PDdK8kdGaNzJKGSlh8vYcXFuAEURcUKDVS7OGRWjNoXKtPlBKEAGAQaS9w9CurlGPtYfKtLuwpseoR5DVS3OGR2reyChdOCJasSG+5hXrBAQRFzV/VExnENlfqgfmDTO7HADAeahpaNWaw2X68mDZKUc9RsUFa97IKM0bEaXJg3DU40wIIi5q/qgY/fLDvfomv1pltU2KDhrciRgABpus8jp9caBM/z5Qqu25x+07mUpSkK+X5g6P1LwR0bpwZJRigt3333iCiIuKDfHV+MQQ7S6o0VcHy7Roqnnb7wIAzq6tvUPbco7ry4Ol+uJAmbIq6ns8PyImUBenx+ji9GhNSg51q1GPMyGIuLD5o2K0u6BGq/eXEkQAwAV1T7l8caBMaw6VydbUZn/O29Oi6WkRumRUtC5Jj1FyhGvsZOpqCCIu7NLRMXp29WGtP1KhxpZ2+fm4/sY0ADDYnWnKJczfWxeldwaPC0ZEKsjX28RKBwaCiAtLjw1SQqifCqsbteFohS4dHWN2SQDgdgzD0O6CGq3aX6LP95XqaFldj+eHRwfqklExmj8qWpOSw+TpMbD39XA2gogLs1gsunR0jF7dmKPV+0sIIgDgJG3tHdqaXaXP95Vo1f5SFdc02Z/z8rBoxhCmXPoLQcTFLbAHkVK1tnfQ3AQADtLY0q51R8r1+b4SfXmwTNUnLLH19/HUvJFRumxMrOaNjFaIH1Mu/YUg4uKmpYUrPMBHVfUt2pJVpTnDI80uCQAGjeqGFn1xoEyf7yvRuiPlamr99hC58AAfzR8VrcvGxGr2sMgBcYDcQEQQcXFenh66bEyslm/N0yd7igkiAHCeymxN+mxfiT7fV6LNWVU9mk0TQv102ZhYXTYmRhkpYfJiFNrhCCIDwJXj4rR8a54+31ei/71mDP9hAEAfldQ06dO9xVq5p1jbc4/32FI9PTZIC8bEasHoGI2JDx7wh8gNNASRAWDGkHCF+Xt3Ts9kV2n2MEZFAOBsimsa9emeEnv4ONHk5FAtHBurBaNjlRoZYFKFkAgiA0L39Mxb2/K1ck8xQQQATqOoulEr93SOfOzMq+7xXEZKmK4YF6fLx8YqPtTPnAJxEoLIAHHFuDi9tS1fn+8r0a+vGcs6dQDoUljdqE/3FOuTPcXKPCF8WCzSFHv4iBv0p9gOVASRAWLm0AiF+nuroq5FW7IrNWsooyIA3FdRdaM+2V2sf+0p1q78avt1i0WamhKuK8bF6vJxcW59mNxAQRAZILw9PbRgdIze2V6glXuKCSIA3E5lXbNW7inWP3cVa2tOlf26xSJNSw3XlePjtHBMrKIJHwMKQWQAuWJcnN7ZXqBP95ToiavGsLkZgEHP1tSqVftK9fGuIn19tKLHUttpaeG6anycLhsbq+ggwsdARRAZQOYMi1REgI8q61u04WiFLhoZbXZJANDvmlrb9cWBMn28q1BfHSpXS9u3m4yNSwjR1RPi9b0JcYoLoeF0MCCIDCBenh66akK8Xt2Yow8zCwkiAAaN1vYObThSoY93FWnVvhLVt7TbnxsWHdgZPsbHaUhUoIlVwhEIIgPMtZMS9OrGHK3aV6r65jYFWLmFAAamjg5DW3Oq9NE3Rfp0b3GPs10SQv101YR4XT0hXqPigthkbBDjW2yAmZAYorTIAGVX1GvV/hJdNynR7JIAoE+OltXqg52F+uibIhVWN9qvRwb66Mpxcbp6YrwmJ4cRPtwEQWSAsVgsumZivP7w7yNakVlEEAEwIFTUNevjb4q0IrNQewpr7NeDrF5aODZW10xM0Iwh4Rxh4YYIIgPQtRMT9Id/H9GGI+Uqq22iWxyAS2pqbdeq/aVasbNA6458u+LFy8OiC0dE6brJCZo/KoZTbd2cU4JIc3Ozpk+frl27dikzM1MTJ050xscOWqmRAZqUHKrMvGr9c1exFs9JM7skAJDU2fexObtSK3YW6tO9JaprbrM/NyExRNdNStBVE+IVEWg1sUq4EqcEkZ/+9KeKj4/Xrl27nPFxbuHaiQnKzKvWiswCgggA0x0prdUHmYX6KLNQRTVN9usJoX66blKCrp2UoGHRrHjByRweRD799FOtWrVK77//vj799FNHf5zbuGpCvH7zyX7tLbRpf5FNo+ODzS4JgJupbmjRx7uK9N6OAu0uOKHvw9dLV46L03WTEjQ1NVwenI2FM3BoECktLdV9992nDz/8UP7+/md9fXNzs5qbm+2/ttlsjixvQAsP8NGlo2O0ck+J3tmeryevHmN2SQDcQHuHoQ1HK/TO9nyt3leqlvbOzca8PCyaNzJK101K1CWjoun7QK85LIgYhqG77rpLS5Ys0ZQpU5STk3PW9yxdulRPPfWUo0oadBZNTdbKPSVakVmon1+ezn/4ABwmu6Je7+3I1wc7C1V8wtRLemyQbpySpGsm0veBc9PnIPLkk0+eNSxs27ZNGzdulM1m02OPPdbr3/uxxx7To48+av+1zWZTUlJSX0t0G3OGRSo+xFdFNU36fF+JrpmYYHZJAAaRuuY2rdxdrHd35GtbznH79VB/b10zIV43TEnSmPhg9vvAebEYhmGc/WXfqqioUEVFxRlfk5qaqptuukn//Oc/e/wFbW9vl6enp2699Va99tprZ/0sm82mkJAQ1dTUKDiYHohTeXb1Yf3xiyOaPSxCy+6dYXY5AAY4wzC0JbtK724v0Kd7i9XQtdW6h0W6YESUbshI0vzR0bJ6MQKL0+vL93efg0hv5eXl9ejxKCoq0mWXXab33ntP06dPV2Li2TfiIoicXX5Vgy54+isZhrT+pxcpKfzsvTgA8F1F1Y16f0eB3t1RoLyqBvv1IZEB+sGURF0/KVGxIexZhN7py/e3w3pEkpOTe/w6MLBz2dbQoUN7FULQO0nh/pozLFLrj3Q2j/3ngpFmlwRggGht79CXB8v01tY8rTlcru4fSwN8PHXVhHjdMCWRrdbhcOysOggsmpqk9Ucq9O72Av34kuFskQzgjHIr6/X2tny9u6NA5bXfrlScnhauG6ck6fJxsfL34esBzuG0v2mpqaly0CyQ27t0dIwiAnxUYmvSvw+UauHYOLNLAuBimtvatWpfqd7alqevj1bar0cG+ugHGUlaNDVJaZEBJlYId0XkHQSsXp66eVqynvvqqF7bmEsQAWB3tKxOb23N0weZhaqqb5EkWSzS3OFRunlqki4ZFSMfL0ZRYR6CyCBxy/RkPb/mqDZlVepwaa1GxASZXRIAkzS1tmvlnmIt35rXY9ltbLCvbpySqBumJNHYDpdBEBkk4kP9tGB0rD7bV6LXN+XoN9eOM7skAE52oNimt7bmaUVmoWxNnYfNeXpYdNHIaN08LUkXjoiihwwuhyAyiNwxK0Wf7SvRBzsL9dOF6Qr29Ta7JAAO1j368cbmXO3Mq7ZfTwzz001Tk3TDlCTFBLPsFq6LIDKIzBwSoeHRgTpSVqf3dxTo7tmcygsMVrmV9Vq2JU/vbs/X8YZWSZ3nvSwYE6ObpyVr9tBIDpvDgEAQGUQsFovumJmiX320T69vytWdM1P5hwgYRNraO/TFwTK9sTlX6498u8N1Qqifbp6WpBunJik6iNEPDCwEkUHmusmJ+t1nh5RdUa8vDpbp0tExZpcE4DyV2pr01tZ8vbUtz37gnMUiXTgiSrdNT9FF6dHy5IcODFAEkUEm0OqlW2Yk669rs/TiumMEEWCAMgxDG49V6o3NuVq9v1RtHZ37MIUH+OjGKUm6ZVqykiNY+YKBjyAyCN0zO00vb8jWtpzj2pl3XJOTw8wuCUAv1TS06t0d+XpzS56yKurt16emhum2GSlaODaWA+cwqBBEBqGYYF9dMzFB7+0o0Itrs/SX2zPMLgnAWewpqNHrm3L0z91FamrtkNR55sv1kxN164xkpcdy8CcGJ4LIIPXDC4bovR0F+nx/ibIr6tm6GXBBLW0d+nRvsV7dmKPME5bepscG6bYZKbp2UoICrfwzjcGNv+GD1IiYIF2cHq0vD5bp7+uz9H/XscEZ4CrKbE1atiVPb27Nsx865+1p0RXj4nTHzBROvIVbIYgMYj+8YIi+PFim93YU6Mfzh7OsDzCRYRjamVet1zbmaOWeYnvzaXSQVbdOT9HN01l6C/dEEBnEpqeFa1JyqDLzqvXi2iz98nujzS4JcDtNre36564ivbYpR3sLbfbrU1LCdOesVF02JpZD5+DWCCKDmMVi0Y8vGa67XtmmN7bk6v4LhyoqyGp2WYBbKKpu1Bubc/XWtnz7qbc+Xh66ZkK87pyVqrEJISZXCLgGgsggd+GIKE1ICtWu/Gr9bX2WfnHFKLNLAgYtwzC0OatKr2/K0ar9pWrvmn5JCPXTbTNStGhqksIDfEyuEnAtBJFBzmKx6JFLhuvuV7fpH5ty9cMLhigykFERoD81tLTpw8wivb4pRwdLau3XZw6J0J2zUjV/VDSn3gKnQRBxA/NGRmlCYoh2FdTob+uy9BijIkC/KKxu1Osbc7R8a55sTW2SJD9vT10/OUF3zEzVyNggkysEXB9BxA1YLBb9eP5w3fPqdr2+KVf3zh1CrwhwHnbmHddLG7L12d4S+/RLSoS/bp+RohumJCnEz9vkCoGBgyDiJi4aGW0fFfnTl0f062vGml0SMKC0tXfos30lemlDdo/Nx2YNjdA9s9N0cXo0p10D54Ag4iYsFot+dnm6bvnbFr25JU93z05jt1WgF2oaW/XW1jy9tjFHRV0n3/p4eujqifG6Z3aaRsez9TpwPggibmTW0EjNGxmlNYfK9cyqQ/rzLZPNLglwWTkV9Xrl62y9u6NADS3tkqSIAB/dNiNFt81IYXoT6CcEETfzs4XpWnu4XJ/sLtYP51ZrQlKo2SUBLqN7+e1LG7L1xcFSGZ3tHxoZE6TFc9J09cR4+Xpz8i3QnwgibmZUXLCun5So93cWaOmnB7T8vhmcaQG319zWrn/uKtbLG7K1v/jb3U8vGhmlxXOGaPawCP47ARyEIOKGHl0wQv/cXaTNWVVavb9UC8bEml0SYIrKumYt25Knf2zOtR8+5+vtoR9kJOru2WkaGhVocoXA4EcQcUMJoX66d06anl9zTP/7yX5dMCKK4Wa4lUMltXp5Q7ZWfFOolrYOSVJssK/umJWiW6YlK9Sf3U8BZyGIuKkHLxqmD3YWKr+qUS+uy9LDlww3uyTAoTo6DK09Uq6XN2Rr/ZEK+/UJiSG6Z06arhgXJ292PwWcjiDipgKsXvrFlaP08PJM/fmro7p+coISw/zNLgvod40t7Xp/Z4Fe+Tpbx8rrJUkeFumyMbFaPCdNGSlh9H8AJiKIuLGrxsdp2eZcbcmu0v99ckAv3JZhdklAvympadLrm3L05tY8VTe0SpKCrF5aNDVJd85KVVI4wRtwBQQRN2axWPTk1WP0vT9t0Kd7S7TmUJnmjYw2uyzgvOwuqNbLG7L1r93Fauvafj0p3E93z0rTDVMSFeTL9uuAKyGIuLlRccG6c2aqXv46W4+v2KtVP7lAAVb+WmBgae8wtHp/5/br23KO269PSw3XPXPSdOnoGHmy/TrgkvjGgf5zwQh9vq9EhdWNevrzQ3ry6jFmlwT0Sm1Tq97ZXqBXN2Yrv6pRkuTlYdFVEzq3Xx+XGGJyhQDOhiACBVi9tPT6cbrj5a16bVOOrpoQr4yUMLPLAk4rv6pBr27M0dvb8lXX3CZJCvX31q3Tk3XHzFTFBPuaXCGA3iKIQJJ0wYgofX9y546rP3t/tz55eI6sXuwtAtdhGIa25x7XS+uztWp/ibraPzQ0KkD3zEnT9ZMS5efD31lgoCGIwO5X3xultYfLdLSsTs+uOqzHrhhldkmAWts7tHJPsV7akK3dBTX263OHR2rxnDRdMDxKHvR/AAMWQQR2of4++u114/TDf+zQi+uzdOHIKM0aGml2WXBTx+tb9ObWPL2+KUelts7t1328PHT9pATdMydNI2KCTK4QQH8giKCHBWNidfO0JC3fmq//fGeXPvvxBQrxZ7kjnOdoWa1e/jpHH+wsUFNr5/brkYFW3TkzRbdMT1ZEoNXkCgH0J4IITvKr743W5qwqZVfU6xcf7tFzN09i50k4lGEYWn+kQi9tyNbaw+X262Pig7V4TpquHB9HzxIwSBFEcBJ/Hy/9YdFEff+Fjfpkd7EuGB6pRVOTzS4Lg1BTa7tWZBbq5Q3ZOlJWJ0myWKRLR8Vo8Zw0TUsLJwQDgxxBBKc0ISlUjy4Yod99dki/+mifxsSHaGwCezKgf5TZmvT6plwt25Kr413brwf4eOrGqUm6e1aakiPYfh1wFwQRnNaSC4ZqZ+5x/ftAmZa8sUP/+tEcjkfHedlbWKOXNmTrX7uL1Nreuf42McxPd81K1Y1TkxTM9uuA2yGI4LQ8PCz6/Q0TddVzG5RX1aBH3v5GL985laWS6JPO7ddL9fLX2dqaXWW/PjU1TIvnpGn+qBh5eXqYWCEAMxFEcEYh/t564bbJuv75jVpzqFzPrDqkny5MN7ssDACn2379e+PjdM+cNI1PDDW3QAAugSCCsxoTH6LfXjdO//nuLj2/5phSIwN045Qks8uCi8oqr9Prm3L13o4Ctl8HcFYEEfTK9zMSlV1Rr+e+OqpffLBHiWF+bHYGu44OQ2sPl+vVjTk9lt8Oiw7UPbPTdN2kBLZfB3BKBBH02qOXjlBOZb3+tbtYS/6xQx88MEvDotnd0p3VNLbq3e35+sfmXOVWNkjqXH578cho3TkrVXOHR7L8FsAZEUTQax4eFj1zwwQV1zRpR+5x3f7SVr1z/0wlhbPU0t0cLq3VaxtztCKzUA0t7ZKkYF8vLZqapNtnpLL8FkCvWQzDMMwu4nRsNptCQkJUU1Oj4OBgs8tBl6r6Fi366yYdKatTSoS/3r1/pqKZ9x/02jsM/ftAqV7bmKONxyrt10fGBOnOWam6dlK8/H342QZA376/Hb5m7pNPPtH06dPl5+enyMhIXX/99Y7+SDhYeICP3rh3upLD/ZVb2aDbXtqiqvoWs8uCg1TVt+gva4/pgt99pfv/sUMbj1XKwyItHBOr5ffN0GePzNUt05MJIQDOiUP/5Xj//fd133336be//a0uvvhiGYahPXv2OPIj4SQxwb5adu90/eAvG3W4tE63/G2z/rF4uqKCOJBsMDAMQ9tyjuvNLblauadELe2dh8+F+XvrpmnJum1GihJC/UyuEsBg4LCpmba2NqWmpuqpp57S4sWLz+n3YGrG9R0t6wwhZbXNGhIZoGX3TVdcCF9QA1VNY6tW7CzQsi159rNfJGlcQohun5miqyfEy9eb1S8Azqwv398OGxHZuXOnCgsL5eHhoUmTJqmkpEQTJ07UM888ozFjxpzyPc3NzWpubrb/2mazOao89JNh0YF65/6ZuvXvW5RVUa8b/rJJy+6drpSIALNLQy8ZhqHdBTVatiVXH+8qUlNr5+iHn7enrpkYr1umJ7P5GACHcdiIyFtvvaWbb75ZycnJevbZZ5Wamqrf//73WrVqlQ4fPqzw8PCT3vPkk0/qqaeeOuk6IyKur7C6Ubf+bbNyKhsUEeCjF++YooyUMLPLwhnUN7fp411FWrYlV3sLvw39I2OCdOuMZF07KYGzXwCck76MiPQ5iJwuLJxo27ZtOnz4sG699Vb99a9/1Q9/+ENJnSMeiYmJ+s1vfqP777//pPedakQkKSmJIDJAlNmadPer27SvyCYfLw89e+MEfW98vNll4QSGYWhn3nG9s61A/9pdpPqupbc+Xh66clycbp2erIyUMPb+AHBeHDo189BDD+mmm24642tSU1NVW1srSRo9erT9utVq1ZAhQ5SXl3fK91mtVlmtNDsOVNHBvnrn/pn68VuZ+veBMj30ZqaOltXp4YuHc1CeycpsTfogs1DvbM9XVnm9/XpaZIBumZas72ckKjyAk5UBOF+fg0hkZKQiI8++tXdGRoasVqsOHTqkOXPmSJJaW1uVk5OjlJSUvleKASHA6qW/3j5F//fJAb38dbb+8O8jysyr1v+3aCJfdE7W2t6hLw+W6d3t+frqULnaOzoHP/28PXXl+DjdOCVJU1MZ/QBgLoc1qwYHB2vJkiV64oknlJSUpJSUFD399NOSpBtuuMFRHwsX4Olh0f9cNVqj4oL0q4/2au3hcn3vj+v1p1sm0zfiYIZhaG+hTR9+U6gPMwtVecL+LhkpYbpxSqKuHB+vQCt7fgBwDQ791+jpp5+Wl5eXbr/9djU2Nmr69On68ssvFRbGl5E7uGFKksYlhug/3tip7Ip63fCXjfqPeUP18CXDZfViCWh/yqts6Awf3xT2mHqJCrLq+skJuiEjScOiA02sEABOjS3e4XC1Ta361Yd79eE3RZKk9NggPXPDBI1NCDG5soGtsq5Z/9pdrA+/KVRmXrX9utXLQ/NHx+i6iQmaNzJKXp4O30AZAHpw6KoZZyKIDC6f7S3W4yv2qrK+RZ4eFt0+I0U/uXSEQvxYItpbVfUtWr2/RCv3lGjD0Qp734eHRZo9LFLXTEzQZWNiFMSyWwAmIojAZVXUNeuJj/fpk93FkqSIAB/97PJ0fX9yojxZWXNKZbVN+nxfqT7bW6zNWVX28CF17nh67aQEXTU+joMHAbgMgghc3oYjFXri47061tXPMDw6UI9eOkKXjYllqa+k3Mp6fXGgTJ/tLdG23Cqd+F/pmPhgXT42VpePi9PQKPo+ALgegggGhJa2Dr22MUfPfXVUNY2tkjq/ZP9j3lAtHBPrVr0NLW0d2pZTpS8Plumrg2XKqqjv8fzEpNDO8DE2TskR/iZVCQC9QxDBgGJratXf12fr5Q3ZqmtukyQlhPrpzlkpWjQlWSH+g6/fwTAM5VY2aOOxSq07XK4NRyvsf3ZJ8vKwaGpquOaPjtHlY2MVz0m3AAYQgggGpOP1LXplY46Wbc6173/h4+WhS0fH6AeTEzV3eOSAHiUpqm7UxmOV2nSsUpuOVaiopqnH85GBVl00MkoXp0drzvBIGk4BDFgEEQxoTa3t+uibQr3ydY4OltTar0cG+uiS9BjNHx2jOcMi5efjunuRNLe1a3+RTZl51crMr1Zm3nEVHG/s8RpvT4smJYdp9tBIXZQepbHxIfTHABgUCCIYFAzD0L4im97bUaCPdxWp6oRdQq1eHpqWFq6pqZ2PScmh8vU2J5jUNLbqUEmtDpbYdKC4VgeKbdpfZFNLe0eP13lYpPGJoZo1NEKzhkYqIyXMpcMUAJwrgggGnZa2Dm3JrtQXB8q0en+pCqt7ji54eVg0NCpQI2ODlB4XpGFRgUoI81NiqL+C/bzO6zyVtvYOVdW3qNTWrLyqhq5HvfKqGpRdXn/SFEu38AAfTUoK1aTkUE1KDtP4xBCmWwC4BYIIBjXDMHS4tE5bsiu1NbtKW7OrVFbbfNrXB1q9FBVkVbCft4J9vRTi5y0/b095eljk4WGRh0UyDKmptUONrW1qbGlXQ0u7qupbVFHXrOMNrWetKSHUT+ldIWhkbLAmJoYqKdyPA+UAuCWCCNyKYRgqqmnSoa6pkYMltcqpqFdhdWOP6Zzz4WGRwgOsSg73U3K4v5IjApQc7q/UCH8Njwlid1gAOEFfvr85ghMDnsViUUKonxJC/XRxekyP5xpb2lVY3ajKumbZmtpka2xVTWOrmtra1dFhqL1Dau/K4v4+nvLz9pRf1/8ND/BRRKCPIgOtCvP3YedXAHAAgggGNT8fTw2LDuTkWQBwUQN3UwYAADDgEUQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqCCAAAMI1Ln75rdB3PbrPZTK4EAAD0Vvf3dvf3+Jm4dBCpra2VJCUlJZlcCQAA6Kva2lqFhISc8TUWozdxxSQdHR0qKipSUFCQLBaL/brNZlNSUpLy8/MVHBxsYoU4Fe6P6+MeuTbuj+vjHp2ZYRiqra1VfHy8PDzO3AXi0iMiHh4eSkxMPO3zwcHB/AVwYdwf18c9cm3cH9fHPTq9s42EdKNZFQAAmIYgAgAATDMgg4jVatUTTzwhq9Vqdik4Be6P6+MeuTbuj+vjHvUfl25WBQAAg9uAHBEBAACDA0EEAACYhiACAABMQxABAACmcdkg8vzzzystLU2+vr7KyMjQ+vXre/W+r7/+Wl5eXpo4caJjC3Rzfb0/zc3Nevzxx5WSkiKr1aqhQ4fq5ZdfdlK17qmv92jZsmWaMGGC/P39FRcXp7vvvluVlZVOqta9rFu3TldddZXi4+NlsVj04YcfnvU9a9euVUZGhnx9fTVkyBD95S9/cXyhbqqv9+eDDz7QpZdeqqioKAUHB2vmzJn6/PPPnVPsIOCSQeTtt9/WI488oscff1yZmZmaO3euLr/8cuXl5Z3xfTU1Nbrjjjt0ySWXOKlS93Qu9+fGG2/UF198oZdeekmHDh3S8uXLlZ6e7sSq3Utf79GGDRt0xx13aPHixdq3b5/effddbdu2Tffee6+TK3cP9fX1mjBhgp577rlevT47O1tXXHGF5s6dq8zMTP3iF7/Qww8/rPfff9/Blbqnvt6fdevW6dJLL9XKlSu1Y8cOXXTRRbrqqquUmZnp4EoHCcMFTZs2zViyZEmPa+np6cbPf/7zM75v0aJFxi9/+UvjiSeeMCZMmODACt1bX+/Pp59+aoSEhBiVlZXOKA9G3+/R008/bQwZMqTHtT/+8Y9GYmKiw2pEJ0nGihUrzvian/70p0Z6enqPa/fff78xY8YMB1YGw+jd/TmV0aNHG0899VT/FzQIudyISEtLi3bs2KEFCxb0uL5gwQJt3LjxtO975ZVXdOzYMT3xxBOOLtGtncv9+fjjjzVlyhT97ne/U0JCgkaMGKH/+q//UmNjozNKdjvnco9mzZqlgoICrVy5UoZhqLS0VO+9956uvPJKZ5SMs9i0adNJ9/Oyyy7T9u3b1draalJVOJ2Ojg7V1tYqPDzc7FIGBJc79K6iokLt7e2KiYnpcT0mJkYlJSWnfM+RI0f085//XOvXr5eXl8v9kQaVc7k/WVlZ2rBhg3x9fbVixQpVVFTogQceUFVVFX0iDnAu92jWrFlatmyZFi1apKamJrW1tenqq6/Wn/70J2eUjLMoKSk55f1sa2tTRUWF4uLiTKoMp/L73/9e9fX1uvHGG80uZUBwuRGRbhaLpcevDcM46Zoktbe365ZbbtFTTz2lESNGOKs8t9fb+yN1/nRgsVi0bNkyTZs2TVdccYWeffZZvfrqq4yKOFBf7tH+/fv18MMP63/+53+0Y8cOffbZZ8rOztaSJUucUSp64VT381TXYa7ly5frySef1Ntvv63o6GizyxkQXG74IDIyUp6enif95FZWVnbSTwSSVFtbq+3btyszM1MPPfSQpM4vPsMw5OXlpVWrVuniiy92Su3uoK/3R5Li4uKUkJDQ40joUaNGyTAMFRQUaPjw4Q6t2d2cyz1aunSpZs+erf/+7/+WJI0fP14BAQGaO3eufvOb3/ATt8liY2NPeT+9vLwUERFhUlX4rrfffluLFy/Wu+++q/nz55tdzoDhciMiPj4+ysjI0OrVq3tcX716tWbNmnXS64ODg7Vnzx5988039seSJUs0cuRIffPNN5o+fbqzSncLfb0/kjR79mwVFRWprq7Ofu3w4cPy8PBQYmKiQ+t1R+dyjxoaGuTh0fOfA09PT0nf/uQN88ycOfOk+7lq1SpNmTJF3t7eJlWFEy1fvlx33XWX3nzzTXqr+sq8PtnTe+uttwxvb2/jpZdeMvbv32888sgjRkBAgJGTk2MYhmH8/Oc/N26//fbTvp9VM47V1/tTW1trJCYmGj/4wQ+Mffv2GWvXrjWGDx9u3HvvvWb9EQa9vt6jV155xfDy8jKef/5549ixY8aGDRuMKVOmGNOmTTPrjzCo1dbWGpmZmUZmZqYhyXj22WeNzMxMIzc31zCMk+9PVlaW4e/vb/zkJz8x9u/fb7z00kuGt7e38d5775n1RxjU+np/3nzzTcPLy8v485//bBQXF9sf1dXVZv0RBhSXDCKGYRh//vOfjZSUFMPHx8eYPHmysXbtWvtzd955p3HhhRee9r0EEcfr6/05cOCAMX/+fMPPz89ITEw0Hn30UaOhocHJVbuXvt6jP/7xj8bo0aMNPz8/Iy4uzrj11luNgoICJ1ftHr766itD0kmPO++80zCMU9+fNWvWGJMmTTJ8fHyM1NRU44UXXnB+4W6ir/fnwgsvPOPrcWYWw2DcFQAAmMPlekQAAID7IIgAAADTEEQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDT/P8DwUliUNgrHAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiIAAAGdCAYAAAAvwBgXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA5+UlEQVR4nO3dd3hc9bnu/XtGXbJ6b5ZkuchVtmVs3ABTTDVJCC34UA3BG0hCeJPsEPa7gZ3s7fMGwsmBBAKJKUls42A6odgB3HCX5V5kW5LVexlZvaz3DxVbuEm2ZtaM5vu5rrmC1sxoPcqyPbd+5VkWwzAMAQAAmMBqdgEAAMB9EUQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKbxNLuAc+ns7FRxcbECAwNlsVjMLgcAAPSDYRiqr69XXFycrNZzj3k4dRApLi5WYmKi2WUAAIALUFBQoISEhHO+xqmDSGBgoKSuHyQoKMjkagAAQH/YbDYlJib2fo6fi1MHkZ7pmKCgIIIIAAAupj/LKlisCgAATEMQAQAApiGIAAAA0xBEAACAaQgiAADANAQRAABgGoIIAAAwDUEEAACYhiACAABMQxABAACmIYgAAADTEEQAAIBpnPqmd/ZyuLRe7+4sVKi/t/7tilSzywEAwG255YhISV2TXlufow93FZldCgAAbs0tg0h8iJ8kqbi2yeRKAABwb24ZRGK7g4ituV31zW0mVwMAgPtyyyAyzMdTQb5dy2NK6ppNrgYAAPfllkFEkuKYngEAwHRuG0ROrhNhRAQAALO4bRCJDfGV1LWDBgAAmMNtg0jP1EwRUzMAAJjGbYMIW3gBADCf2waR2OCuIMKuGQAAzOO2QSSuZ41IbbM6Ow2TqwEAwD25bRCJDvKV1SK1dnSqsqHF7HIAAHBLbhtEvDysigo8OSoCAAAcz22DiHRyeoYFqwAAmMPNgwhbeAEAMBNBROycAQDALO4dRIKZmgEAwEzuHURoagYAgKkIIpKKmZoBAMAUBBFJFfUtamnvMLkaAADcj8OCyJIlS2SxWPT444876pTnFervJV+vrv8LShkVAQDA4RwSRLZv367XXntNkyZNcsTp+s1isSguuGedCEEEAABHs3sQOXHihBYuXKg///nPCg0NtffpBowFqwAAmMfuQeTRRx/VjTfeqKuvvvq8r21paZHNZuvzsDe6qwIAYB5Pe37zt99+Wzt37tT27dv79folS5bo2WeftWdJp4kNZucMAABmsduISEFBgX7yk5/o73//u3x9ffv1nieffFJ1dXW9j4KCAnuV1yueqRkAAExjtxGRzMxMlZeXKyMjo/dYR0eH1q9frz/84Q9qaWmRh4dHn/f4+PjIx8fHXiWdEWtEAAAwj92CyFVXXaW9e/f2OXb//fcrLS1N//7v/35aCDFL7ClrRAzDkMViMbkiAADch92CSGBgoCZMmNDnWEBAgMLDw087bqaeqZmG1g7VNbUpxN/b5IoAAHAfbt1ZVZJ8vTwUGdg1HVRYw/QMAACOZNddM9+2du1aR56u3xJC/VRR36LCmkZNiA82uxwAANyG24+ISFJCqL8kRkQAAHA0goi6RkQkgggAAI5GENGpQaTR5EoAAHAvBBExNQMAgFkIIuo7NWMYhsnVAADgPggiOtlL5ERLu+qa2kyuBgAA90EQEb1EAAAwC0GkGwtWAQBwPIJINxasAgDgeASRbvQSAQDA8Qgi3ZiaAQDA8Qgi3ZiaAQDA8Qgi3eglAgCA4xFEutFLBAAAxyOIdKOXCAAAjkcQOQULVgEAcCyCyClYsAoAgGMRRE5BLxEAAByLIHIKpmYAAHAsgsgpmJoBAMCxCCKnoJcIAACORRA5xam9RGob6SUCAIC9EUROcWovkQLWiQAAYHcEkW9JCutaJ5JfTRABAMDeCCLfMrw7iByvIogAAGBvBJFvGR7eFUQKGBEBAMDuCCLfwogIAACOQxD5lqRw1ogAAOAoBJFvSeweESmpa1Jre6fJ1QAAMLQRRL4lcpiP/Lw81GlIRbV0WAUAwJ4IIt9isVhOWSfSYHI1AAAMbQSRM2DnDAAAjkEQOQN2zgAA4BgEkTNg5wwAAI5BEDmDRNq8AwDgEASRMzj1fjOGYZhcDQAAQxdB5AziQ/1ksUiNrR2qPNFqdjkAAAxZBJEz8PH0UFywnySmZwAAsCeCyFkkhvUEEXqJAABgLwSRs0gKC5Ak5VfRXRUAAHshiJxFT1Oz44yIAABgNwSRs+hpakZ3VQAA7IcgchZ0VwUAwP4IImfR0121vL5FTa0dJlcDAMDQRBA5i2A/LwX6ekqSCmoYFQEAwB4IImdhsVh6R0WYngEAwD4IIueQFN61hTevkp0zAADYA0HkHEZEdAWR3CqCCAAA9mDXILJkyRJdcsklCgwMVFRUlL773e/q8OHD9jzloEpmRAQAALuyaxBZt26dHn30UW3ZskVr1qxRe3u75s+fr4YG1/hgT+4ZESGIAABgF572/Oaff/55n6/feOMNRUVFKTMzU5dddpk9Tz0oUrqDSElds5paO+Tn7WFyRQAADC12DSLfVldXJ0kKCws74/MtLS1qaWnp/dpmszmkrrMJ9fdSkK+nbM3tOl7doLSYIFPrAQBgqHHYYlXDMPTEE09ozpw5mjBhwhlfs2TJEgUHB/c+EhMTHVXeGVksFqVEDpPEOhEAAOzBYUHkscce0549e7RixYqzvubJJ59UXV1d76OgoMBR5Z1VSncvkRyCCAAAg84hUzM/+tGP9NFHH2n9+vVKSEg46+t8fHzk4+PjiJL6rWfBKiMiAAAMPrsGEcMw9KMf/Ujvv/++1q5dq5SUFHuezi5SeoMI3VUBABhsdg0ijz76qJYvX64PP/xQgYGBKi0tlSQFBwfLz8/PnqceND29RGhqBgDA4LPrGpFXXnlFdXV1uuKKKxQbG9v7WLlypT1PO6h6pmYq6ltU39xmcjUAAAwtdp+acXXBfl4KD/BWVUOrjlc1akJ8sNklAQAwZHCvmX6gwyoAAPZBEOkH7jkDAIB9EET6YUQkIyIAANgDQaQf2DkDAIB9EET6ITmiq7sqUzMAAAwugkg/9IyI1DS2qbax1eRqAAAYOggi/RDg46mowK7W86wTAQBg8BBE+qm31TvrRAAAGDQEkX7q2TmTU0EQAQBgsBBE+ik1cpgkgggAAIOJINJPPUHkaPkJkysBAGDoIIj0U08Qya1sUEen699DBwAAZ0AQ6af4UD95e1rV2tGpwppGs8sBAGBIIIj0k4fVohHdO2eOVTA9AwDAYCCIDEBqVNf0zLFyFqwCADAYCCID0LNOhBERAAAGB0FkAFIjmZoBAGAwEUQGgC28AAAMLoLIAPR0V61pbFN1Aze/AwDgYhFEBsDf21PxIX6SmJ4BAGAwEEQG6OTOGYIIAAAXiyAyQCxYBQBg8BBEBujkFl56iQAAcLEIIgNELxEAAAYPQWSARnavESmoblRzW4fJ1QAA4NoIIgMUMcxbQb6e6jSkvCqmZwAAuBgEkQGyWCzccwYAgEFCELkArBMBAGBwEEQuQM86kSP0EgEA4KIQRC7AqJ4gUlZvciUAALg2gsgFGB0dKEnKqWhQe0enydUAAOC6CCIXID7ET/7eHmrt6FReVaPZ5QAA4LIIIhfAarX0Ts9kMz0DAMAFI4hcoJ7pGYIIAAAXjiBygXqCyJEyds4AAHChCCIXaFR019TMYUZEAAC4YASRCzQmpmtEJK+yQa3t7JwBAOBCEEQuUEyQrwJ9PNXeaSi3klbvAABcCILIBbJYLEzPAABwkQgiF6FneoYOqwAAXBiCyEUYFcUWXgAALgZB5CKc7CXCFl4AAC4EQeQijO5eI3K8qkHNbR0mVwMAgOshiFyEyEAfhfh7qdOQjlUwKgIAwEARRC6CxWLR6Cg6rAIAcKEIIheJLbwAAFw4gshF6tnCm11KEAEAYKAIIhepZ+fMIYIIAAAD5pAg8vLLLyslJUW+vr7KyMjQhg0bHHFahxgbEyRJKqptUl1Tm8nVAADgWuweRFauXKnHH39cTz31lLKysjR37lxdf/31ys/Pt/epHSLY30vxIX6SpMOMigAAMCB2DyIvvPCCFi1apAcffFBjx47V73//eyUmJuqVV16x96kdJq17ncjBEpvJlQAA4FrsGkRaW1uVmZmp+fPn9zk+f/58bdq06bTXt7S0yGaz9Xm4grGxXdMzBBEAAAbGrkGksrJSHR0dio6O7nM8OjpapaWlp71+yZIlCg4O7n0kJibas7xBQxABAODCOGSxqsVi6fO1YRinHZOkJ598UnV1db2PgoICR5R30cbGdk3NHC6rV0enYXI1AAC4Dk97fvOIiAh5eHicNvpRXl5+2iiJJPn4+MjHx8eeJdlFUniAfL2sam7rVF5Vg1Ijh5ldEgAALsGuIyLe3t7KyMjQmjVr+hxfs2aNZs2aZc9TO5SH1aIxMUzPAAAwUHafmnniiSf0l7/8Ra+//roOHjyon/70p8rPz9fixYvtfWqHGhfLzhkAAAbKrlMzknTHHXeoqqpK//Vf/6WSkhJNmDBBn376qZKSkux9aoc6uWCVXiIAAPSX3YOIJD3yyCN65JFHHHEq06R1T80cYkQEAIB+414zgySte2qmuK5ZtY2tJlcDAIBrIIgMkiBfLyWEdrV6Z3oGAID+IYgMIhqbAQAwMASRQTS2+54zh0oJIgAA9AdBZBCxcwYAgIEhiAyicXFdQeRwWb3aOjpNrgYAAOdHEBlEw8P8Fejrqdb2Th0pO2F2OQAAOD2CyCCyWCwa3z0qsq+4zuRqAABwfgSRQTYxPliStK+IIAIAwPkQRAbZBIIIAAD9RhAZZD1B5ECJTe0sWAUA4JwIIoMsJTxAAd4eam7rVE5lg9nlAADg1Agig8xqtWh8XNeoyN5CpmcAADgXgogdjI9n5wwAAP1BELEDds4AANA/BBE76Fmwur/Yps5Ow+RqAABwXgQRO0iNHCZfL6saWztYsAoAwDkQROzAw2rRuO4b4O1nnQgAAGdFELGTnnUi7JwBAODsCCJ2Mr5nwSojIgAAnBVBxE56RkT2F7FgFQCAsyGI2MnIqGHy8bSqvqVdeVUsWAUA4EwIInbi5WHt3ca7u7DW3GIAAHBSBBE7mpwYIknalV9rah0AADgrgogdpfcEkYJaU+sAAMBZEUTsaEp3EDlQYlNLe4e5xQAA4IQIInaUEOqnsABvtXUYOlBsM7scAACcDkHEjiwWS+86kd1MzwAAcBqCiJ2lJ4RIYp0IAABnQhCxs8nDQyRJu2n1DgDAaQgidpae0NVLJLeyQbWNrSZXAwCAcyGI2FmIv7dSIgIkMSoCAMC3EUQcgMZmAACcGUHEAXqmZ3YV1JhcCQAAzoUg4gCTh4dK6pqaMQzuxAsAQA+CiAOMjQ2Ut4dV1Q2tKqhuMrscAACcBkHEAXw8PTQuLkiStDOf6RkAAHoQRBxkWlLX9MyO49UmVwIAgPMgiDhIRk8QyWNEBACAHgQRB8lI7goih8vqZWtuM7kaAACcA0HEQaICfTU8zF+GIWXRTwQAAEkEEYfqWSeSmcc6EQAAJIKIQ/VMz+w4zjoRAAAkgohDTUsKkyTtKqhVe0enydUAAGA+gogDjYoapiBfTzW2duhgSb3Z5QAAYDqCiANZrRZNpZ8IAAC9CCIOdrKxGetEAAAgiDhYRvc6kcy8Gm6ABwBwe3YLInl5eVq0aJFSUlLk5+en1NRUPf3002ptbbXXKV3C5MQQeVotKrU1q6iWG+ABANybp72+8aFDh9TZ2alXX31VI0eO1L59+/TQQw+poaFBzz//vL1O6/T8vD00Pi5IuwvrlHm8Rgmh/maXBACAaewWRK677jpdd911vV+PGDFChw8f1iuvvOLWQUSSLkkO0+7COm3NrdZ3JsebXQ4AAKZx6BqRuro6hYWFnfX5lpYW2Wy2Po+h6NIR4ZKkLTlVJlcCAIC5HBZEjh07ppdeekmLFy8+62uWLFmi4ODg3kdiYqKjynOoS1LCZLFIORUNKrc1m10OAACmGXAQeeaZZ2SxWM752LFjR5/3FBcX67rrrtNtt92mBx988Kzf+8knn1RdXV3vo6CgYOA/kQsI9vPS+LggSdKWXPqJAADc14DXiDz22GO68847z/ma5OTk3v8uLi7WvHnzNHPmTL322mvnfJ+Pj498fHwGWpJLmpESrn1FNm3JqdLN6XFmlwMAgCkGHEQiIiIUERHRr9cWFRVp3rx5ysjI0BtvvCGrlbYlPS4dEa6lG3O1lXUiAAA3ZrddM8XFxbriiis0fPhwPf/886qoqOh9LiYmxl6ndRnTk7vWiRyraFB5fbOiAn3NLgkAAIezWxBZvXq1jh49qqNHjyohIaHPc3QUlYL9vTQ2JkgHSmzamlOtBUzPAADckN3mSu677z4ZhnHGB7qwjRcA4O5YtGGiS0d09VTZys4ZAICbIoiYaHp3P5Gj5SdUUd9idjkAADgcQcREIf7eSovp6ieyNZfpGQCA+yGImKxnembTMYIIAMD9EERMNju1qyfLN0crTa4EAADHI4iY7NLUcHlaLTpe1aiC6kazywEAwKEIIiYb5uOpKcNDJEkbjjAqAgBwLwQRJzBnZKQkaePRivO8EgCAoYUg4gTmjOpZJ1Kljk4avgEA3AdBxAmkJwQr0NdTdU1t2ldUZ3Y5AAA4DEHECXh6WDWzu937RnbPAADcCEHEScztnp7ZcIR1IgAA90EQcRJzRnUtWM08XqPG1naTqwEAwDEIIk4iOdxf8SF+auswuAkeAMBtEESchMVi6Z2e2Ug/EQCAmyCIOJG53dMz67NZJwIAsJ/65jZ9ebBMv/7kgFZsyze1Fk9Tz44+5oyKkIfVoiPlJ1RQ3ajEMH+zSwIADAFtHZ3Kyq/VxqOV2nikQrsL63r7Vk1PDtMPpg83rTaCiBMJ9vNSRlKotuVW6+vD5bpnZrLZJQEAXJBhGDpafkIbjlRq49FKbc2pUkNrR5/XJIf7a2ZqhC4fHWFSlV0IIk7myrQobcut1leHCCIAgP4rtzXrm2OV2nCkUt8crVSZraXP82EB3po9MkJzR0Zo1shwJYQ6x6g7QcTJzBsTpf/92SFtPlalptYO+Xl7mF0SAMAJNba2a2tOdfd0S6UOl9X3ed7H06rpKWGaMzJCc0ZFaGxMkKxWi0nVnh1BxMmMjh6m+BA/FdU2aXNOpa5Miza7JACAE+jsNHSgxKZ12RVan12hnfk1aus4eX8yi0UaHxekOSMjNXdUhDKSQuXr5fy/zBJEnIzFYtEVYyK1bGu+vjpUThABADdW09CqDUcrtfZwudZnV6ryRN/plvgQP80d1TXiMSs1QmEB3iZVeuEIIk7oyrQoLduar68PVcgwDFkszjeUBgAYfB2dhvYU1mpddoXWHq7Q7sJaGafclN3f20OzuheYzhkVqeRwf5f/jCCIOKFZqRHy9rSqqLZJR8pPaHR0oNklAQDspKK+RRuOdAWPDUcqVNPY1uf5MdGBumJMpC4fHamM5FD5eDr/dMtAEESckJ+3h2aOCNe67Ap9daicIAIAQ0hHp6Gs/BqtPVyhddkV2ltU1+f5QB9PzRkVoctHR+ryMZGKDfYzqVLHIIg4qSvTonqDyOLLU80uBwBwEWzNbVqfXaGvDpbr68Plp416jI8L6h71iNKU4SHy8nCfxucEESd1ZVqUnv5ov3bkVau6odUlFyABgDvLrWzQlwfL9OXBcm3Pq1Z758nFHsF+Xpo7KkJXjInSZaMjFBXoa2Kl5iKIOKnEMH+NjQ3SwRKb/nWwTLdPSzS7JADAObR1dGpHXo2+OtQVPnIqG/o8nxoZoKvHRuvKtChlJIXK041GPc6FIOLErh0frYMlNq3eX0oQAQAnVNPQqnXZFfrXwTKty65QfXN773NeHhbNSAnXlWlRujItSskRASZW6rwIIk7s2vEx+v2/jmj9kUo1tLQrwIfLBQBmO17VoNX7y7T6QKkyj9folBkXhQV4a96YKF01NkpzR0Uo0NfLvEJdBJ9sTiwtJlDDw/yVX92o9dkVun5irNklAYDbMQxD+4tt+mJ/qVbvLzutlXpaTKCuGhulK9OiNTkxRB5O2EbdmRFEnJjFYtH8cdH6y8ZcfbG/lCACAA7S3tGpbbnVWn2gTKv3l6q4rrn3OU+rRZeOCNc146J11dgop7l5nKsiiDi5ayfE6C8bc/XloXK1tnfK25PFTQBgD02tHVqXXaHVB0r11aFy1Z6yxdbPy0NXjInU/PHRunJMtIL9mXIZLAQRJzd1eKgihnmr8kSrtuRU6bLRkWaXBABDRnVDq748WKbVB8q04UiFmts6e58LC/DW1WOjNH9cjOaMinCJG8i5IoKIk/OwWnTNuGit2FagL/aXEkQA4CJV1Lfoi/2l+mxfibbkVKvjlNWmCaF+unZ8jOaPi9a05DDWezgAQcQFzB8foxXbCrT6QJl+/Z0JsvIXAwAGpNzWrM/3l+rTvSXallvdZ6fL2NggXTs+WvPHxWhsbKDL30TO1RBEXMCs1HAF+nqqor5FO47XaHpKmNklAYDTK6lr0md7u0Y+dhyv6XMX2/SEYF0/MVbXT4hRUjj9PcxEEHEBPp4eunZ8jFZlFurj3cUEEQA4i8KaRn2+r2vkY2d+bZ/npgwP0Y0TY3Xt+BglhrHTxVkQRFzETZNitSqzUJ/uLdHTC8bRGhgAuhVUN+rTvSX6dF+pdhfU9h63WKRpSaG6fkKsrpsQo7iQoX0XW1dFEHERs0dGKNTfS1UNrdqSU605oyLMLgkATFNa16xP9hTr4z0lp4WP6clhumFiV/iIDnLfm8m5CoKIi/DysOr6ibFavjVfH+8uJogAcDvVDa36dG+JPt5drG151b1rPqwWaUZKuG6YFKtrx0e79Z1sXRFBxIUsmBSn5Vvz9dm+Ev36uxNobgZgyLM1t2n1/jJ9vLtYG49W9tlqOy0pVAvS43TDxFhFBvqYWCUuBkHEhUxPCVNkoI8q6lu08WiFrkyLNrskABh0Ta0d+vJQV/j4+nCFWttPNhmbEB+kBZPidFN6nOJZ8zEkEERciIfVohsnxurNTXn6eHcJQQTAkNHa3qn12RX6eE+x1hwoU2NrR+9zqZEBujk9XgvSYzUicpiJVcIeCCIuZkF6nN7clKfV+0vV3NZBy2EALsswDO04XqP3s4r0zz0lqms6eW+XhFA/LUiP083pcUqLocnYUEYQcTFTh4coPsRPRbVN+tfBMt00Kc7skgBgQI5VnNAHWUV6P6tIhTVNvcejAn1046RY3Zwep8mJIYQPN0EQcTEWi0XfmxKvP3x9VKsyCwkiAFxC5YkWfbK7WO9nFWl3YV3v8QBvD10/MVbfmxKvS0eEc28XN0QQcUG3TO0KIuuzK1Rua1YU++QBOKGm1g6tOVimD7KKtC67onfHi4fVostGReh7UxN0zdho+XkzxezOHBJEWlpaNGPGDO3evVtZWVmaPHmyI047ZI2IHKaMpFBlHq/RB7uK9MPLUs0uCQAkSR2dhrbmVOm9rCJ9vq9UJ1rae59LTwjW96bE66b0OEUMY7stujgkiPziF79QXFycdu/e7YjTuYXvT01Q5vEarcos1ENzRzCXCsBUR8vr9U5moT7MKlaprbn3eEKon743JV7fnRKvVHa84AzsHkQ+++wzrV69Wu+++64+++wze5/Obdw4KVbPfLxf2WUntK/IpokJwWaXBMDN1DW16ePdxVqVWahdp7RZD/bz0o2TutZ9TEsK5RclnJNdg0hZWZkeeughffDBB/L3P/+dDltaWtTS0tL7tc1ms2d5Li3Yz0vzx0Xrkz0lendnIUEEgEN0dBr65mil3sks1Bf7S3ubjXlYLZo3Jkq3ZsRrXlqUfDxZ94H+sVsQMQxD9913nxYvXqxp06YpLy/vvO9ZsmSJnn32WXuVNOR8PyNBn+wp0Ye7ivSrG8bS8h2A3eRUnNC7Owv13s4ildSdnHoZEx2o26Yl6DuT42mzjgsy4CDyzDPPnDcsbN++XZs2bZLNZtOTTz7Z7+/95JNP6oknnuj92mazKTExcaAluo25IyMUFeij8voWfXmwTNdPjDW7JABDSH1zm/65p0SrMgu143hN7/FgPy99Z3KcbstI1IT4IKZecFEshmEY53/ZSZWVlaqsrDzna5KTk3XnnXfq448/7vMHtKOjQx4eHlq4cKHeeuut857LZrMpODhYdXV1CgoKGkiZbuP/+/yQXll7THNHRehvi2aYXQ4AF9fZaWhLTpXeySzUZ/tK1NzWNfVitUiXj47UrRmJunocUy84t4F8fg84iPRXfn5+nzUexcXFuvbaa7Vq1SrNmDFDCQkJ5/0eBJHzy69q1GXPfS1JWv/zeRoefv61OADwbSV1TVq1o1ArdxT06XaaGhmgWzMSdcvUeEXTswj9NJDPb7utERk+fHifr4cN69q2lZqa2q8Qgv4ZHu6vy0ZHan12hZZvy9cvr08zuyQALqK9o1NfHSrXyu0F+vpwubr7jSnQx1MLJsfp1owETaHVOuyMzqpDwF3Th2t9doVWZRboiWtGs2gVwDkdr2rQP3YU6J0dhSqvP7lTcXpymO6cnqjrJ8TS7RQO47AgkpycLDvNArm9q8ZGKTrIR2W2Fq0+UMr9ZwCcpqW9Q1/sL9PK7fn65mhV7/HwAG99PyNBd1ySSMMxmIIRkSHAy8OqO6Yl6sWvjmrZlnyCCIBeR8rq9fb2Ar23s1A1jW2SJItFmjsqUndekqirx0YzigpTEUSGiDumD9cfvj6qzTlVyqk4oRH8ZgO4rcbWdn2yp0Qrtxco85RttzFBvrp9WoJum5aoxDAWtsM5EESGiPgQP80bE6UvD5Xrb1uO6+kF480uCYCDHS6t17Ktx/X+ziLVd99szsNq0VVpUbpzeqIuHx0lDysLT+FcCCJDyD2zkvXloXK9s6NQT1wzWoG+XmaXBMDOWto79NneUv19y/E+TceSwv11xyWJunVqgqLYdgsnRhAZQi4bFaGRUcN0tPyE/rGjUIvmpJhdEgA7OV7VoOVb8/VOZqGqG1oldY1+zB8XrYUzkjQrNVxWRj/gAggiQ4jFYtEDs1P0q/f36s1NubpvVjLDsMAQ0t7RqS8PlWvZ1nytz67oPR4b7Ks7LxmuO6cn0nQMLocgMsTcMjVez31xSAXVTVpzoFTXTeD+M4CrK61r1tvb8/X2tgKV2rpuOGexSJeNitTCGcN1ZVqUPD3Y+QLXRBAZYny9PHTXjOH649fHtHRjLkEEcFGdnYa+OVapZVvyteZgmTq6256GBXjr9mmJumv6cG7pgCGBIDIE3TMzWa+uy9H2vBrtKazVpIQQs0sC0E81Da1alVmoZVuPK6+qsff49OQwLbx0uK6bEMMN5zCkEESGoOggX900KVYf7CrWXzbk6sUfTDG7JADnsb+4Tn/ddFwf7CpSS3vXHW8DfTx1y9R43TUjSWNiAk2uELAPgsgQ9eDcEfpgV7E+2VOsJ64ZreSIALNLAvAtbR2d+nxfqd7alNdn6+242CDdMzNJC9LjFODDP9MY2vgTPkRNiA/WFWMitfZwhf607pj+9/cnmV0SgG7l9c1avjVfy7fm9950ztNq0fUTY3XfrCRNHR7KHW/hNggiQ9hj80Zq7eEKvbuzUD+5epRig/3MLglwW4ZhaGd+rd7alKfP9pWoraNr8WlkoI/umj5cC2cMp/EY3BJBZAiblhym6Slh2pZbrdfW59D2HTBBc1uHPtpdrL9uztO+Ilvv8YykUN0zM0nXT4jlpnNwawSRIe6xeSN1T+42rdiWr0fnjVTEMB+zSwLcQmFNo/6+JV8rt+f33vXW29Oq76TH6d5ZyZoQH2xyhYBzIIgMcXNHRWhSQrD2FNbp9Y25+sV1aWaXBAxZhmFo07EqvbUpT/86WKbu1h+KD/HT/7o0SXdckqiwAG9ziwScDEFkiLNYLHp03kg9/LdMvbUpTw/OHcE/hMAga27r0Hs7i/TGN7k6Un6i9/jskeG6d2ayrhobze0WgLMgiLiBa8ZGa0J8kPYV2fTK2qN66sZxZpcEDAlltmb9dXOelm89Of3i7+2h709N0D0zkzQqmt4fwPkQRNyA1WrR/zN/jO5/Y7ve2nxci+aMUEwwq/OBC7W3sE6vf5OrT/YU9+5+SQj1032zknX7JYkK8vUyuULAdRBE3MQVoyN1SXKotufV6KWvjui/vzfR7JIAl9LRaWjNgTK9vjFX2/Kqe49fkhyqRXNSdM24GKZfgAtAEHETFotFP782Tbe/ulkrtxfoh5eNUFI43VaB86lvbtM/dhTqzU25KqhuktTVfOymSbF6YE4K93ICLhJBxI1MTwnT5aMjtS67Qv9nTbZ+fyf3oAHOpqC6UW9uytPK7QU60dIuSQrx99Jd04frnpnJTG8Cg4Qg4mZ+Nn+M1mVX6MPdxVo0Z4QmJtDLAOhhGIZ2HK/R0g25Wn2gtHf7bWpkgB6Yk6JbpiTIz5s73wKDiSDiZiYmBOu7k+P0wa5i/fqTA1r58KXc0wJur7W9U5/uLdHr3+RqT2Fd7/G5oyL0wJwUXT4qUlbWfwB2QRBxQ7+4Lk2f7y/Vtrxqfbq3VDdOijW7JMAUNQ2tWr4tX3/dnKcyW9fN57w9rbplSrwemJOi0Wy/BeyOIOKG4kL89PBlqfq/Xx7R/3x6UFeNjZKvF8PNcB9Hy0/o9W9y9d7OQjW3dUqSIob56J6ZSVo4Y7jCuRUC4DAEETe1+PJU/WNHgYpqm7R0Y64enTfS7JIAuzIMQxuPVmrpxlytPVzRe3xcbJAWzUnRTemx8vEkkAOORhBxU37eHvr369L0+Mpd+uPXR3XL1HjFBvuZXRYw6JrbOvRBVpFe/yZX2WVd7dctFunqsdF6YHaKLh0RxjopwEQEETd2c3qc/ro5Tzvza/XsRwf0p7szzC4JGDTl9c36++bj+vvWfFU3tErqar9++7RE3TcrWckR9NEBnAFBxI1ZrRb99/cmasFLG/X5/lKtOVCma8ZFm10WcFH2F9dp6cZcfbz7ZPv1+JCT7deD/Wi/DjgTgoibGxsbpAfnjtCf1h3T0x/u06zUcAX48McCrqWj09CXB8v0+je52pJzsv16RlKoHpidomvHR8vTw2pihQDOhk8c6CdXjdI/9xaroLpJL6zJ1v97E3fnhWtoaGnXOzsK9MamPB2vapQkeVgtumFirBbNSdHkxBBzCwRwXgQRyM/bQ7/+zgTd98Z2vfFNrr4zOY77Z8CpFdY06q1NeXp7e4Hqm7varwf5euquGUm6Z2aS4kJYeA24CoIIJElXjInSzelx+mh3sZ74x2598qM59BaBUzEMQzvza/T6xjx9vr9UHd3910dEBOj+2cn6fkaC/L35Jw1wNfytRa9nbx6vzTlVOlp+Qs99cZgpGjiFto5OfbavVEs35mp3QW3v8dkjw7VoToquGB1F+3XAhRFE0Cs0wFu//f4k3f/mdi3dmKurxkZpVmqE2WXBTdU1tvW2Xy+pa5YkeXtY9Z3JcXpgTorGxgaZXCGAwUAQQR/z0qL0g+nDtWJbvn7+zh59/vhcBfqy3RGOc6zihN78Jk+rMgvV1NYhSYoY5q3/dWmSFs5IUmQg7deBoYQggtP8x41j9c3RSuVXN+rJ9/bqpR9MofMk7Kqn/frrG3P19Snt19NiAvXAnBTdnB7HmiVgiCKI4DQBPp76P3dM1h2vbtYne0o0Y0S47r40yeyyMASdrf36VWlRemB2imamhhOCgSGOIIIzykgK1b9fl6b//vSgfv3xAU1JDNGE+GCzy8IQUWZr1t82H9eyrcdV09gm6WT79XtnJSuF9uuA2yCI4KwenJuibXnVWnOgTI8s26mPfzSH9ti4KHsL67R0Y44+2VOi9s6T7dfvn52s26bRfh1wRwQRnJXFYtHzt6brxpc2KL+6UU+s3KXX7pkmD7ZKYgDaOzq15kBX+/XteTW9xy9J7mq/fs042q8D7owggnMK9vfSywun6rY/bdaXh8r1288P6ckbxppdFlyArblNK7cV6M1NeSqqbZIkeVotWpAep/tnJ9O9F4Akggj6YVJCiJ67LV0/XpGlV9fnKDVqmG6flmh2WXBSeZUNenNTnt7ZUaCG1q7tt6H+Xlo4I0l3z0xSdJCvyRUCcCYEEfTLzelxOlp+Qi9+eURPvb9XyeEBmp4SZnZZcBKdnYbWH6nQW5vytDa7QkbX8g+Njh6mB2an6LtT4tl+C+CMCCLot8evGqWj5fX6dG+pHvrrDv3j4ZkaExNodlkwUV1Tm1ZlFupvm/OU1333W0maNyZSi+aM0OyRbL8FcG4EEfSb1WrR726brNK6LdqZX6u7l27Vu/82S4lh/maXBgc7XFqvv27O0/tZRWrsnn4J9PXUbRmJuntmEttvAfSbxTB6BlGdj81mU3BwsOrq6hQUxH0lnEVtY6vueHWLDpfVKyncX6sWz6Ltthvo2f3y1uY8bcmp7j0+OnqY7p2VrO9OjleAD7/bABjY57fd98z985//1IwZM+Tn56eIiAjdcsst9j4l7CzE31t/XTRdiWF+Ol7VqLuXblXViRazy4KdVJ5o0R+/Pqq5v/1a/7Zsp7bkVMvDatH1E2K04qFL9cXjl2nhjCRCCIALYtd/Od5991099NBD+p//+R9deeWVMgxDe/futecp4SDRQb762wMzdNurm3WotF53vrZFyx6aoahAdkQMBYZhKPN4jZZvzdcne0rU2tEpSQoL8NYPpidq4YwkxYX4mVwlgKHAblMz7e3tSk5O1rPPPqtFixZd0Pdgasb5Has4obv+vEVlthaNiAjQ8ocuVUwwYcRV1TW16f2dhVqxrUCHy+p7j6cnBOveWcm6YWIsu18AnNdAPr/tNiKyc+dOFRUVyWq1asqUKSotLdXkyZP1/PPPa/z48Wd8T0tLi1paTg7x22w2e5WHQZIaOUz/eHim7vrzVuVUNuj2VzfrrQems1jRhRiGoV0FtVq+NV8f7ylWc1vX6Ievl1ULJsVp4aVJmpwYYm6RAIYsu42IvP322/rBD36g4cOH64UXXlBycrJ+97vfafXq1crOzlZY2Ok9KJ555hk9++yzpx1nRMT5FdY06q4/b1V+daNC/b30l3unKSOJPiPOrL65TR/sKtbyrfk6WHIy9I+OHqaFM5L03Snx3PsFwAUZyIjIgIPI2cLCqbZv367s7GwtXLhQr776qn74wx9K6hrxSEhI0G9+8xs9/PDDp73vTCMiiYmJBBEXUV7frAff2qE9hXXy9rTq93dM1g0TY80uC6cwDENZBbX6x/YCfbS7uHfrrbenVTdNjNVdM4YrIymU3h8ALopdp2Yee+wx3Xnnned8TXJysurru+aXx40b13vcx8dHI0aMUH5+/hnf5+PjIx8ftoG6qqhAX739w0v14xVZ+tfBcj2ybKd+fNUo/eSqUdwoz2Tltma9l1WkVZmFOlp+ovf4iMgALZyRpO9PjVeIv7eJFQJwVwMOIhEREYqIiDjv6zIyMuTj46PDhw9rzpw5kqS2tjbl5eUpKSlp4JXCJfh7e+rVu6fp158c0Jub8vTil0e0q6BW//eOyQoN4IPOkVrbO/XlwTK9k1moddkV6ujsGvz09bLq+gmxuuOSRM1ICWP0A4Cp7LZYNSgoSIsXL9bTTz+txMREJSUl6bnnnpMk3XbbbfY6LZyAh9WiZ24er0kJwfrV+3u1PrtCN720US/+YDLrRuzMMAwdKLHpnR2F+nBXkWoa23qfmzo8RLdNS9SNk2IV5MvaDwDOwa59RJ577jl5enrq7rvvVlNTk2bMmKGvvvpKoaGh9jwtnMQtUxM0NjZI//b3TOVVNeq2P23W4stT9fjVo+Xtafdeem6loLpRH+0u1oe7ipRddnLqJSrQR7dMTdCtGQkaGTXMxAoB4Mxo8Q67szW36ZmP9uu9nUWSpLGxQXru1kmaEB9scmWuraK+Rf/cU6yPdhdrZ35t73FvD6uuGRetW6claO7ICHl6EPoAOJZdd804EkFkaPl8X4l+9f4+VTe0ymqR7pmZrCfmj2aaYABqG1u15kCZPtpdrG+OVqp72YesFmlWaoRuTo/TtRNi2HYLwFQEETit8vpm/fqTg/p4d7EkKWKYj35x3RjdMiWe39zPotzWrC8OlOmLfaXanFPVu+hUktITQ/Sd9DjdNClWUUF0tAXgHAgicHobj1TqPz/ap5yKBknSyKhh+tn8Mbp2fDS7ONS15uOL/aX6bF+pdubX6NS/pWkxgbphYqxuTo9TMh1sATghgghcQkt7h97alKeX1x5TbffujgnxQfrhZam6YUKMW42QtLZ3antetdYeLtfXhyv69PqQpCnDQ3Td+BhdOz6G8AHA6RFE4FJszW36y/oc/WVjbm+nz/gQP90/O1m3TE1Q2BDsP2IYhgprmrThSKXWHi7XN0cr1dD9s0tdW6CnJ4fp+okxmj8uhhsJAnApBBG4pOqGVv1t83G9tTlP1Q2tkk7uALltWoLmuPgOkMKaRm0+VqUtOdXaklOlotqmPs9HDPPRFWMiNW9MlOaMimDBKQCXRRCBS2tu69C7Owu1Ylu+9hWdvBlbWIC3rkqL0rXjYzRnVIRT346+pb1D+4tt2pVfq10FtdqZX6PCmr7Bw9NqUXpiiK4YHal5aVEaFxskK63wAQwBBBEMGfuL6/TOjkJ9sKuodx2J1NWmPCMpVDNSwnXpiHBNSgg2LZjUNrbqcGm9ssvqdbisXnsL63SgxKa2jr5/tTysFk1KCNbMEV01T0sOlb+3XXsKAoApCCIYcto7OrUtt1qrD5Rp9f5SFdc193new2pRamSAxsUGaWxskJLC/ZUQ6q/EMP+LnuLo6DRU09iqopomFdQ0qqC6538blV1WrzJbyxnfFxbgrcmJIb2PqUmhGuZD8AAw9BFEMKQZhqGj5Se0JadKW3KrtTWnWpUnzhwGJCnQ11PhAd4K9vdWiJ+Xgv285O1plafVIg+rRZ5Wi1o7DLW0dai5vUMtbZ2qb2lXdUOrqhtaVdPYqvP9LYkP8dOYmECNjg7U2NhATUkMVWKYH1uRAbglggjcimEYKrO16EBJnQ4U23SotF4FNU0qrG5UVfei18EQHeSjxO5RloRQPyWG+is1aphGRw9TIN1hAaDXQD6/GSeGy7NYLIoJ9lVMsK+uTIvu81xja7uKa5tU09im2sY21Ta2qq6pTe2dhto7OtXeaaij05CXh1W+Xlb5eHrI18sqf++uUZSwYd4KD/BRqL+XS+/YAQBnRRDBkObv7amRUYFmlwEAOAt+xQMAAKYhiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqCCAAAMA1BBAAAmIYgAgAATEMQAQAApiGIAAAA0xBEAACAaQgiAADANAQRAABgGqe++65hGJIkm81mciUAAKC/ej63ez7Hz8Wpg0h9fb0kKTEx0eRKAADAQNXX1ys4OPicr7EY/YkrJuns7FRxcbECAwNlsVh6j9tsNiUmJqqgoEBBQUEmVogz4fo4P66Rc+P6OD+u0bkZhqH6+nrFxcXJaj33KhCnHhGxWq1KSEg46/NBQUH8AXBiXB/nxzVyblwf58c1OrvzjYT0YLEqAAAwDUEEAACYxiWDiI+Pj55++mn5+PiYXQrOgOvj/LhGzo3r4/y4RoPHqRerAgCAoc0lR0QAAMDQQBABAACmIYgAAADTEEQAAIBpnDaIvPzyy0pJSZGvr68yMjK0YcOGfr3vm2++kaenpyZPnmzfAt3cQK9PS0uLnnrqKSUlJcnHx0epqal6/fXXHVStexroNVq2bJnS09Pl7++v2NhY3X///aqqqnJQte5l/fr1WrBggeLi4mSxWPTBBx+c9z3r1q1TRkaGfH19NWLECP3pT3+yf6FuaqDX57333tM111yjyMhIBQUFaebMmfriiy8cU+wQ4JRBZOXKlXr88cf11FNPKSsrS3PnztX111+v/Pz8c76vrq5O99xzj6666ioHVeqeLuT63H777fryyy+1dOlSHT58WCtWrFBaWpoDq3YvA71GGzdu1D333KNFixZp//79euedd7R9+3Y9+OCDDq7cPTQ0NCg9PV1/+MMf+vX63Nxc3XDDDZo7d66ysrL0q1/9Sj/+8Y/17rvv2rlS9zTQ67N+/Xpdc801+vTTT5WZmal58+ZpwYIFysrKsnOlQ4ThhKZPn24sXry4z7G0tDTjl7/85Tnfd8cddxj/8R//YTz99NNGenq6HSt0bwO9Pp999pkRHBxsVFVVOaI8GAO/Rs8995wxYsSIPsdefPFFIyEhwW41oosk4/333z/na37xi18YaWlpfY49/PDDxqWXXmrHymAY/bs+ZzJu3Djj2WefHfyChiCnGxFpbW1VZmam5s+f3+f4/PnztWnTprO+74033tCxY8f09NNP27tEt3Yh1+ejjz7StGnT9Nvf/lbx8fEaPXq0fvazn6mpqckRJbudC7lGs2bNUmFhoT799FMZhqGysjKtWrVKN954oyNKxnls3rz5tOt57bXXaseOHWprazOpKpxNZ2en6uvrFRYWZnYpLsHpbnpXWVmpjo4ORUdH9zkeHR2t0tLSM77nyJEj+uUvf6kNGzbI09PpfqQh5UKuT05OjjZu3ChfX1+9//77qqys1COPPKLq6mrWidjBhVyjWbNmadmyZbrjjjvU3Nys9vZ23XzzzXrppZccUTLOo7S09IzXs729XZWVlYqNjTWpMpzJ7373OzU0NOj22283uxSX4HQjIj0sFkufrw3DOO2YJHV0dOiuu+7Ss88+q9GjRzuqPLfX3+sjdf12YLFYtGzZMk2fPl033HCDXnjhBb355puMitjRQK7RgQMH9OMf/1j/+Z//qczMTH3++efKzc3V4sWLHVEq+uFM1/NMx2GuFStW6JlnntHKlSsVFRVldjkuwemGDyIiIuTh4XHab27l5eWn/UYgSfX19dqxY4eysrL02GOPSer64DMMQ56enlq9erWuvPJKh9TuDgZ6fSQpNjZW8fHxfW4JPXbsWBmGocLCQo0aNcquNbubC7lGS5Ys0ezZs/Xzn/9ckjRp0iQFBARo7ty5+s1vfsNv3CaLiYk54/X09PRUeHi4SVXh21auXKlFixbpnXfe0dVXX212OS7D6UZEvL29lZGRoTVr1vQ5vmbNGs2aNeu01wcFBWnv3r3atWtX72Px4sUaM2aMdu3apRkzZjiqdLcw0OsjSbNnz1ZxcbFOnDjReyw7O1tWq1UJCQl2rdcdXcg1amxslNXa958DDw8PSSd/84Z5Zs6cedr1XL16taZNmyYvLy+TqsKpVqxYofvuu0/Lly9nbdVAmbdO9uzefvttw8vLy1i6dKlx4MAB4/HHHzcCAgKMvLw8wzAM45e//KVx9913n/X97Jqxr4Fen/r6eiMhIcG49dZbjf379xvr1q0zRo0aZTz44INm/QhD3kCv0RtvvGF4enoaL7/8snHs2DFj48aNxrRp04zp06eb9SMMafX19UZWVpaRlZVlSDJeeOEFIysryzh+/LhhGKdfn5ycHMPf39/46U9/ahw4cMBYunSp4eXlZaxatcqsH2FIG+j1Wb58ueHp6Wn88Y9/NEpKSnoftbW1Zv0ILsUpg4hhGMYf//hHIykpyfD29jamTp1qrFu3rve5e++917j88svP+l6CiP0N9PocPHjQuPrqqw0/Pz8jISHBeOKJJ4zGxkYHV+1eBnqNXnzxRWPcuHGGn5+fERsbayxcuNAoLCx0cNXu4euvvzYknfa49957DcM48/VZu3atMWXKFMPb29tITk42XnnlFccX7iYGen0uv/zyc74e52YxDMZdAQCAOZxujQgAAHAfBBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqCCAAAMA1BBAAAmOb/B1fpR6+u9qvRAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -608,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 35,
    "id": "79a2bb61-0a5e-4a3a-b195-46d027738a0e",
    "metadata": {},
    "outputs": [],
@@ -618,7 +692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 36,
    "id": "b4e6e0c9-a2c6-40ab-884e-a46e16c37b04",
    "metadata": {},
    "outputs": [
@@ -656,7 +730,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -667,7 +741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 37,
    "id": "c81e5148-3da3-428d-bf01-4608f7fdb978",
    "metadata": {
     "tags": []
@@ -679,7 +753,7 @@
        "False"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -690,30 +764,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "cef7c46f-551f-401e-96c2-214628e23967",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiIAAAGdCAYAAAAvwBgXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA6CklEQVR4nO3dd3Rc9bnu8WdGZVSs3rtkucgFNxkbN0y16YGE3sGQ+AIhhJNGODnAObnxOqHcc0gCCQk4JBhwgEAgNDuAe7dl4yoXSVazutW7tO8fksYWbpKtmT3l+1lr1sJ7Zjyv18aeR7/y/iyGYRgCAAAwgdXsAgAAgPciiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqCCAAAMA1BBAAAmIYgAgAATONrdgGn093drdLSUoWEhMhisZhdDgAAGADDMNTQ0KDExERZracf83DpIFJaWqqUlBSzywAAAGehqKhIycnJp32NSweRkJAQST1/kNDQUJOrAQAAA1FfX6+UlBT79/jpuHQQ6ZuOCQ0NJYgAAOBmBrKsgsWqAADANAQRAABgGoIIAAAwDUEEAACYhiACAABMQxABAACmIYgAAADTEEQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJjGpQ+9c5Tcsga9t61YkcH+Wjg30+xyAADwWl45InKkrkWvrMrTBzklZpcCAIBX88ogkhgeKEkqrW0xuRIAALybVwaRhLAASVJ9a6ca2zpNrgYAAO/llUEkJMBPoQE9y2OOMCoCAIBpvDKISMdNz9S1mlwJAADeiyDCiAgAAKbx2iDSt06EqRkAAMzjtUGkb0SkpJapGQAAzOLFQaR3RKSOEREAAMzivUEkjDUiAACYzXuDyHG7ZgzDMLkaAAC8k9cGkbjQAFksUntnt6qb2s0uBwAAr+S1QcTf16qYYTZJ0hEWrAIAYAqvDSLS8TtnWCcCAIAZvDyIsHMGAAAzeXcQYecMAACm8uogksB5MwAAmMqrg0hS79QMIyIAAJjDq4NIQu/UDLtmAAAwh1cHkb5dM+UNrero6ja5GgAAvI/TgsiiRYtksVj02GOPOesjzygq2F/+PlYZhlRez6gIAADO5pQgsnnzZr3yyiuaMGGCMz5uwKxWixLs60QIIgAAOJvDg0hjY6PuuOMO/fGPf1RERISjP27Q+rbw0ksEAADnc3gQefjhh3X11VfrsssuO+Nr29raVF9f3+/haH0jInRXBQDA+Xwd+Zu//fbb2rZtmzZv3jyg1y9atEjPPPOMI0s6QVJfm/ejBBEAAJzNYSMiRUVF+sEPfqA33nhDAQEBA3rPE088obq6OvujqKjIUeXZJUdw3gwAAGZx2IjI1q1bVVFRoezsbPu1rq4urVq1Sr/97W/V1tYmHx+ffu+x2Wyy2WyOKumkksKDJEnFjIgAAOB0Dgsil156qXbu3Nnv2n333aesrCz99Kc/PSGEmMU+InK0RYZhyGKxmFwRAADew2FBJCQkROPHj+93LTg4WFFRUSdcN1PfYtWWji7VNLUraphzR2QAAPBmXt1ZVZJsvj6KC+0JH6wTAQDAuRy6a+abVqxY4cyPG7Ck8ECV17ep+GiLJiSHm10OAABew+tHRCQpOaJnwSpbeAEAcC6CiKSk3gWrxUebTa4EAADvQhARvUQAADALQUTHuqvSSwQAAOciiOjEXiIAAMA5CCI61l21oa1T9S2dJlcDAID3IIhICvT3UVSwvySpuJYFqwAAOAtBpNfx0zMAAMA5CCK9jm3hJYgAAOAsBJFe9qZmbOEFAMBpCCK9jm3hZY0IAADOQhDpRVMzAACcjyDSizUiAAA4H0GkV9/UTG1zhxrb6CUCAIAzEER6hQT4KSzQTxJbeAEAcBaCyHH61okU1bBgFQAAZyCIHCc1smcLbxE7ZwAAcAqCyHH6gkghIyIAADgFQeQ4yX0jIjWsEQEAwBkIIsexT80wIgIAgFMQRI6T0rtYtbCmWYZhmFwNAACejyBynKSIQFksUktHl6qb2s0uBwAAj0cQOY7N10cJoQGSWLAKAIAzEES+IZl1IgAAOA1B5BtYsAoAgPMQRL4hJYJeIgAAOAtB5BtSo/ravNNLBAAARyOIfAMjIgAAOA9B5Bv61ogcqWtRR1e3ydUAAODZCCLfEBNik83Xqm5DKq1legYAAEciiHyDxWJRCoffAQDgFASRk0jl8DsAAJyCIHISx585AwAAHIcgchIpNDUDAMApCCInYZ+aOUoQAQDAkQgiJ9E3InK4miACAIAjEUROom9EpK6lQ3XNHSZXAwCA5yKInESwzVcxITZJ0uGaJpOrAQDAcxFETiE9qmdUpIDpGQAAHIYgcgppUcGSpMNVjIgAAOAoBJFTYEQEAADHI4icgn1EpJoREQAAHIUgcgrpfUGEpmYAADgMQeQUUnunZiob2tTU1mlyNQAAeCaCyCmEBfopIshPEo3NAABwFILIabBOBAAAxyKInAY7ZwAAcCyCyGn0jYgU0l0VAACHcGgQWbRokc4//3yFhIQoNjZW119/vXJzcx35kUMqPbp3RKSKEREAABzBoUFk5cqVevjhh7VhwwYtX75cnZ2dmjdvnpqa3GOEgTUiAAA4lq8jf/PPPvus368XL16s2NhYbd26VRdeeKEjP3pI9PUSKa1rVWtHlwL8fEyuCAAAz+LQIPJNdXV1kqTIyMiTPt/W1qa2tjb7r+vr651S16lEBPkpJMBXDa2dKqpp1si4EFPrAQDA0zhtsaphGHr88cc1e/ZsjR8//qSvWbRokcLCwuyPlJQUZ5V3UhaLxT4qws4ZAACGntOCyCOPPKKvv/5ab7311ilf88QTT6iurs7+KCoqclZ5p9TXYZV1IgAADD2nTM18//vf14cffqhVq1YpOTn5lK+z2Wyy2WzOKGnAjvUSIYgAADDUHBpEDMPQ97//fb3//vtasWKFMjIyHPlxDmGfmmELLwAAQ86hQeThhx/Wm2++qX/84x8KCQlRWVmZJCksLEyBgYGO/OghMzymJ4jkVzEiAgDAUHPoGpGXX35ZdXV1uuiii5SQkGB/LF261JEfO6QyoodJkkpqW9Ta0WVyNQAAeBaHT824u8hgf4UH+am2uUMF1U3Kig81uyQAADwGZ80MQEZ0z/RMXiXTMwAADCWCyAD0BRHWiQAAMLQIIgMwnBERAAAcgiAyAMNjehas5lc1mlwJAACehSAyAPY1IkzNAAAwpAgiA9DX1Ky2uUNHm9pNrgYAAM9BEBmAQH8fJYYFSGJUBACAoUQQGaCMmL4Fq6wTAQBgqBBEBmh4dN+CVUZEAAAYKgSRAaKXCAAAQ48gMkAZHH4HAMCQI4gM0PDjRkS6u93/DB0AAFwBQWSAkiOC5OdjUVtnt0rrWswuBwAAj0AQGSAfq0VpUUzPAAAwlAgig9C3YPVQBVt4AQAYCgSRQRgR27OF9yC9RAAAGBIEkUEY0Xv43UFGRAAAGBIEkUGwj4hUsEYEAIChQBAZhOG9vUSqGttU19xhcjUAALg/gsgghAT4KT605/A71okAAHDuCCKD1Dc9w84ZAADOHUFkkNg5AwDA0CGIDFJmLDtnAAAYKgSRQcrsXbBKEAEA4NwRRAapb2qm6GizWju6TK4GAAD3RhAZpJhhNoUG+MowpLxK+okAAHAuCCKDZLFYju2cYcEqAADnhCByFkawYBUAgCFBEDkLbOEFAGBoEETOQmYMTc0AABgKBJGz0DciklfVpK5uw+RqAABwXwSRs5AcESSbr1Xtnd0qrGk2uxwAANwWQeQs+FiP7ZzZX95gcjUAALgvgshZGh0XIknaX0YQAQDgbBFEztKo+N4gwoJVAADOGkHkLI2K652aYUQEAICzRhA5S6N6p2byqhrV0dVtcjUAALgngshZSgoPVLC/jzq6DBVUceYMAABngyByliwWi0b2jorksnMGAICzQhA5B/adM+UsWAUA4GwQRM7BSBasAgBwTggi52C0fQsvQQQAgLNBEDkHfVMzBVVNau3oMrkaAADcD0HkHMSE2BQW6KduQzpUyToRAAAGiyByDiwWi31U5AALVgEAGDSCyDnqW7DKFl4AAAaPIHKO7AtW2TkDAMCgEUTO0SiamgEAcNacEkReeuklZWRkKCAgQNnZ2Vq9erUzPtYpxsSHSpKKj7aovrXD5GoAAHAvDg8iS5cu1WOPPaYnn3xSOTk5mjNnjq688koVFhY6+qOdIizIT4lhAZKkXKZnAAAYFIcHkRdeeEELFizQAw88oDFjxuh//ud/lJKSopdfftnRH+00YxJ6RkX2Hqk3uRIAANyLQ4NIe3u7tm7dqnnz5vW7Pm/ePK1bt+6E17e1tam+vr7fwx1kJfSsEyGIAAAwOA4NIlVVVerq6lJcXFy/63FxcSorKzvh9YsWLVJYWJj9kZKS4sjyhsyxERGmZgAAGAynLFa1WCz9fm0YxgnXJOmJJ55QXV2d/VFUVOSM8s5ZVu+C1dyyBnV1GyZXAwCA+/B15G8eHR0tHx+fE0Y/KioqThglkSSbzSabzebIkhwiIzpYNl+rWjq6VFjTrIzoYLNLAgDALTh0RMTf31/Z2dlavnx5v+vLly/XzJkzHfnRTuVjtdgbm7FOBACAgXP41Mzjjz+uP/3pT3rttde0d+9e/fCHP1RhYaEWLlzo6I92qr5+IvsIIgAADJhDp2Yk6ZZbblF1dbX+8z//U0eOHNH48eP1ySefKC0tzdEf7VR9O2f2sGAVAIABc3gQkaSHHnpIDz30kDM+yjR9O2f2lTEiAgDAQHHWzBCh1TsAAINHEBkitHoHAGDwCCJDKItW7wAADApBZAiN7Q0ie0oJIgAADARBZAiNT+oJIrtK60yuBAAA90AQGULjEsMk9awRae/sNrkaAABcH0FkCCVHBCo0wFcdXYb2l7NgFQCAMyGIDCGLxaLxST2jIqwTAQDgzAgiQ6wviLBOBACAMyOIDLFxib0LVksIIgAAnAlBZIj1LVjde6RBXd2GydUAAODaCCJDLCM6WEH+Pmrp6FJ+VaPZ5QAA4NIIIkPMx2qxNzbbVcKCVQAATocg4gCsEwEAYGAIIg4wjp0zAAAMCEHEAcb3LljdXVovw2DBKgAAp0IQcYCRccPk72NVQ2unCmuazS4HAACXRRBxAD8fq7ISQiRJXxczPQMAwKkQRBxkQnLP9MzXxbXmFgIAgAsjiDjIhORwSdIORkQAADglgoiDTOwNIrtK6uiwCgDAKRBEHGRE7DAF+fuoub1LhyrpsAoAwMkQRBzEx2qxn8S7o6jW3GIAAHBRBBEHmmhfsMo6EQAAToYg4kB9C1bZOQMAwMkRRByob8Hq3iMNau/sNrcYAABcEEHEgVIiAxUR5Kf2rm7tK+MkXgAAvokg4kAWi0Xn9fUTYcEqAAAnIIg4WN+CVRqbAQBwIoKIg01kwSoAAKdEEHGwiSnhkqQDFY1qaO0wtxgAAFwMQcTBYkJsSo4IlGFIO4qYngEA4HgEESeYkhohSdpWeNTkSgAAcC0EESeYkhouScohiAAA0A9BxAkm946I5BTVyjA4iRcAgD4EEScYkxAqm69Vtc0dyqtqMrscAABcBkHECfx9rZrQ209k22GmZwAA6EMQcZLjp2cAAEAPgoiT9C1YZUQEAIBjCCJO0reFd395gxrbOk2uBgAA10AQcZLY0AAlhQeq2+AAPAAA+hBEnGgy/UQAAOiHIOJE2Wk90zNbWCcCAIAkgohTnZ8eKUnaeviourppbAYAAEHEibLiQxTs76OG1k7lljWYXQ4AAKYjiDiRr49VU3qnZzYX1JhcDQAA5iOIONm03ukZgggAAAQRp5t6XBDhADwAgLdzWBApKCjQggULlJGRocDAQGVmZuqpp55Se3u7oz7SLUxODZefj0Xl9W0qqmkxuxwAAEzl66jfeN++feru7tYf/vAHjRgxQrt27dKDDz6opqYmPffcc476WJcX4Oej85LCtK2wVpsKapQaFWR2SQAAmMZhQeSKK67QFVdcYf/18OHDlZubq5dfftmrg4jUs413W2GtthTU6MbsZLPLAQDANE5dI1JXV6fIyMhTPt/W1qb6+vp+D0/U109kEwtWAQBezmlB5NChQ/rNb36jhQsXnvI1ixYtUlhYmP2RkpLirPKcamp6zxbevMomVTW2mVwNAADmGXQQefrpp2WxWE772LJlS7/3lJaW6oorrtBNN92kBx544JS/9xNPPKG6ujr7o6ioaPB/IjcQHuSvUXHDJElbGBUBAHixQa8ReeSRR3Trrbee9jXp6en2/y4tLdXFF1+sGTNm6JVXXjnt+2w2m2w222BLckvTM6K0v7xRG/JqdMX4BLPLAQDAFIMOItHR0YqOjh7Qa0tKSnTxxRcrOztbixcvltVK25I+MzKj9NcNh7X+ULXZpQAAYBqH7ZopLS3VRRddpNTUVD333HOqrKy0PxcfH++oj3UbFwyPkiTlljeourFNUcO8YyQIAIDjOSyILFu2TAcPHtTBgweVnNx/iyodRaXIYH9lxYdoX1mDNuTV6OoJTM8AALyPw+ZK7r33XhmGcdIHevSNiqzPqzK5EgAAzMGiDRPNyOwNIqwTAQB4KYKIiaZnRMpikQ5VNqmivtXscgAAcDqCiInCg/w1Jj5UkrQ+j1ERAID3IYiYrG96ZkMejc0AAN6HIGKyGcP7gggjIgAA70MQMdm04ZGyWqT8qiaV1raYXQ4AAE5FEDFZaICfJqaES5LWHGAbLwDAuxBEXMCcET0t81cdqDzDKwEA8CwEERcwZ1SMJGndoWp1d9PwDQDgPQgiLmBSSriG2XxV09SuPUfqzS4HAACnIYi4AD8fq73dO9MzAABvQhBxEXNG9qwTYcEqAMCbEERcRF8Q2VJwVC3tXSZXAwCAcxBEXERGdLCSwgPV3tWtjfk0NwMAeAeCiIuwWCz2UZHVTM8AALwEQcSFzBnZs4135X4WrAIAHKehtUNf7C3Xf/1zj97aVGhqLb6mfjr6mT0iWj5Wiw5WNKqoplkpkUFmlwQA8AAdXd3KKazVmgOVWnOwSjuK69TV27dqWnqkbpuWalptBBEXEhbkp+zUCG0qqNGK3ArdNSPd7JIAAG7IMAwdrGjU6gNVWnOwShvzqtX0jY0Q6VFBmpEZrbmjok2qsgdBxMVcnBWrTQU1+iq3kiACABiwivpWrT1UpdUHqrT2YJXK69v6PR8V7K+ZI6I1Z0S0Zo6IUnKEa4y6E0RczMVZMfrvz/Zp3aEqtXZ0KcDPx+ySAAAuqKmtU5vya+zBI7e8od/zNl+rpmVEas7IaM0aEa0x8aGyWi0mVXtqBBEXMzouRAlhATpS16r1edW6eHSs2SUBAFyAYRjaXVqvlfsrtXJ/pXIKj6qj69j5ZBaLND4xTLNH9ox6TEmLcIsfZgkiLsZiseii0bF6a1OhVuyrIIgAgBerbW7XqgNVWplbqVUHKlXZ0H+6JTkiUHNGRmv2iBjNzIxSRLC/SZWePYKIC7okqyeIfJVbqacNQxaL6w2lAQCGXle3oZ0ldVqRW6GV+yu1o6hWxx/KHuTvo5m9C0wvHBWjtKhg84odIgQRFzQzM0r+PlYV1jTrUGWTRsQOM7skAICDVDa0afWBSq3IrdTqA5U62tzR7/ms+BDNHRWjuaNilJ0eIZuv60+3DAZBxAUF23w1fXikVh+o0pf7ygkiAOBBuroNbS86qq/2VWrF/grtKqnv93xIgK/mjIzW3FExunBUjBLCAk2q1DkIIi7q0qxYrT5QpX/tqdB3L8w0uxwAwDmob+3Q6v1V+mJvub7KrThh1GN8UqguGhWruaNjNCklXH4+3tP4nCDioi4bG6enP9qjLYdrVN3YpqhhNrNLAgAMQn5Vk77YW64v91VoU36NOo9b7BEa4Ku5o2N1Ue+oR0yI9/4bTxBxUckRQRqXGKrdpfX6Yl+Fbp6aYnZJAIDT6Ojq1paCo/pyX7m+2FehvMqmfs9nxgTr0jFxujQrVtlpEfL1olGP0yGIuLB5Y+O1u7Rey3aXE0QAwAUdbWrXyv2V+tfecq3cX6mG1k77c34+Fk3PiNIlWbG6JCtW6dHuv8PFEQgiLuzysXH6f//arzUHK9XS3qVAf89aKQ0A7qiwulnL9pRp2e5ybTlc0297bWSwvy4eHatLx8RqzshohQT4mVeomyCIuLAxCSFKjghU8dEWrTpQqfnj4s0uCQC8Tl9H02W7y7RsT7n2lfVvpZ4VH6JLx8Tqkqw4TUoJl48LtlF3ZQQRF2axWHT52DgtXlug5XvKCSIA4CSdXd3aVFCjZbvLtXxPuUpqW+zP+Vgtmp4Rqfnj4nXpmFiXOTzOXRFEXNy8sfFavLZAX+wtV2dXN4ubAMBBWtq7tHJ/pZbtKdOX+ypUe9wW20A/H80dFaN54+J0SVaswoPcr5W6qyKIuLjz0yMUHuSno80d2lRQo5mZ0WaXBAAeo6apXV/sLdeyPeVafaBSrR3d9ucigvx02Zg4zRsXrzkjo93iADl3RBBxcb4+Vs0bG6e/bSnWJzuPEEQA4BxVNrTps91l+nTnEW3Iq+632DQ5IlDzx8Vr3tg4ttg6CUHEDVx1XoL+tqVYn+0q0zPXjWchFAAMUnl9qz7bVaZPdh7RpoIaGceFj7EJoZo3Lk7zxsZrTEIIB406GUHEDcwaEa2wQD9VNbZrY341oyIAMACltS36bFeZPt11RFsOH+0XPiamhOuq8fG6cnyCUqNYbGomgogb8POxav44pmcA4EyKjzbrs11l+njnEeUU1vZ7bkpquK46L0FXjI9np4sLIYi4CaZnAODkimqa9fHOI/p05xHtKK6zX7dYpPPTInXlefG6Yny8x59i664IIm6C6RkAOKasrlUf7zyij3aUantRrf261SJNy4jUVeclaP64eMWFBphXJAaEIOImmJ4B4O1qmtr1SW/4OH7BqdUizciM0lXnJWje2HivPsnWHRFE3Ejf9MynO8v09LXj2FYGwOPVt3Zo2e5yfbSjVGsOVqnruL22U9MidN2kRF05PoHw4cYIIm5k1ohoRQb7q7qpXWsOVumi0bFmlwQAQ665vVNf7K3QRztKtSK3Uu1dx5qMnZcUpmsnJujqCYlKCmfNhycgiLgRPx+rrp2QoNfXH9YHOSUEEQAeo72zWyv3V+qjHaX6195yNbd32Z8bETtM101M1LUTE5URHWxilXAEgoib+dbkJL2+/rA+312uprZOBdu4hQDck2EY2nr4qN7PKdHHO4/0O9slNTJI105M0LUTEzU6jiZjnoxvMTczOSVcaVFBOlzdrOV7ynX95CSzSwKAQTlU2ah/5JTo/e0lKqo5dqptbIhN1/aOfExMDiN8eAmCiJuxWCz61qQkvfjFAX2wvYQgAsAtVDW26aMdpfogp6Rfr49gfx9dMT5BN0xO0ozMKHokeSGCiBu6flKiXvzigFYfqFJVY5uih7FaHIDraWnv0rI9Zfogp0SrDhzb8eJjtejCkdG6fnKS5o2NV6A/p9p6M6cEkba2Nk2fPl07duxQTk6OJk2a5IyP9VjDY4ZpYnKYdhTX6aMdpbpvVobZJQGAJKmr29C6Q1V6P6dEn+8qU9Nxi04nJofphslJumZiIj9Awc4pQeQnP/mJEhMTtWPHDmd8nFe4fnKSdhTX6b1txQQRAKY7WNGo97YV6+/bilVe32a/nhIZqBsmJelbk5OUGTPMxArhqhweRD799FMtW7ZM7733nj799FNHf5zXuH5SkhZ9sk+7Suq1u7RO4xLDzC4JgJepb+3QP3cc0Ttbi/odMBcW6KdrJiTo21OSNCU1gkWnOC2HBpHy8nI9+OCD+uCDDxQUdOaTDtva2tTWdixJ19fXO7I8txYR7K/Lx8bp451H9M6WYo27jiACwPH6pl7e2VKsz3eXqa2zp9mYj9Wii0bF6MbsZF0yJlY2X9Z9YGAcFkQMw9C9996rhQsXaurUqSooKDjjexYtWqRnnnnGUSV5nJumJuvjnUf0fk6JfnZllgL8+IsPwDHyKvumXkp0pK7Vfn1k7DDdNDVZ109KUiwHzOEsDDqIPP3002cMC5s3b9a6detUX1+vJ554YsC/9xNPPKHHH3/c/uv6+nqlpKQMtkSvMWdkjBLCAnSkrlX/2luuayYkml0SAA/S0Nqhj78+one3FmvL4aP262GBfvrWpETdmJ2s85Lo94FzYzEMwzjzy46pqqpSVVXVaV+Tnp6uW2+9VR999FG//0G7urrk4+OjO+64Q6+//voZP6u+vl5hYWGqq6tTaGjoYMr0Gs8vy9VvvjyoC0fF6C/3TzO7HABurrvb0Pq8ar2zpUif7S5Ta0fP1IvVIs0dFaMbs1N06ZhYRmBxWoP5/h50EBmowsLCfms8SktLNX/+fL377ruaPn26kpOTz/h7EETO7HB1k+Y+u0IWi7Tmp5dwCBSAs1JW16p3txZp6Zaift1OR8QO043ZybphcpLimHrBAA3m+9tha0RSU1P7/XrYsJ5tW5mZmQMKIRiYtKhgXTA8UhvyarR0U6Eenzfa7JIAuInOrm59lVuppZsL9eW+CvX2G1NIgK+um5iom6am0GodDkdnVQ9w5wVp2pBXo7c2F+n7l46Un4/V7JIAuLDC6mYt3VKod7YUq6Lh2E7FaemRuuX8FF11XgLdTuE0Tgsi6enpctAskNebNzZe0cNsqmxo07Ld5bp6QoLZJQFwMW2dXfp8d7mWbi7U2oPV9utRwf76Tnaybp6aohGxNByD8zEi4gH8fa26bVqKfvPlQb2x4TBBBIDd/vIGvb2pSH/PKVZtc4ckyWLp2XV36/kpumxMnPx9GUWFeQgiHuK2aan63VcHtT6vWgcrGjQiNsTskgCYpLm9U//8+oje3lSobcd1PE0IC9BNU1N0U3ayUiLP3GQScAaCiIdIDA/UpWPitHxPud7YUKinrxtndkkAnGx/eYOWbDisv28rUUNbpyTJ12rRpWNidev5qbpwVIx8rCw8hWshiHiQuy5I0/I95XpvW7F+PH+0gm3cXsDTtXV26bNdZVqyoVCbCmrs19OignTr+an6TnaSYkPYdgvXxTeVB5k9IlrDo4OVV9Wkd7cW656Z6WaXBMBBCqubtWTTYb2zpVg1Te2Ses57uWxMrO68IE2zMqNlZfQDboAg4kGsVovum52hX3ywS6+tzdedF6QxDAt4kM6ubn2xr0JLNhZq1f5K+/X40ADdNi1Vt5yfovgwRj/gXggiHuY7U5L03Oe5OlzdrC/2lmveuHizSwJwjsrqWvX25kK9valIZfXHDpy7cFSM7pyeqkuyYuVL/yC4KYKIhwny99Ud01P10opD+tOafIII4Ka6uw2tOVilJRsP6197K9TV2/Y0MthfN09N0e3TUpUaxc4XuD+CiAe6e0a6XlmVp035NdpZXKfzksPMLgnAANU2t+tvW4q0ZGOhDlc3269PS4/UHRek6orx8bL50vUUnoMg4oHiwwJ0zYQEfbC9VH9ak6f/vXWy2SUBOIPdpXX6y7rD+mB7ido6e068DbH56jvZybp9eqpGxdEbCJ6JIOKhHpgzXB9sL9VHO0r1b5ePZggXcEEdXd36bFeZ/rK+QJsLjtqvj0kI1T0z0nTdpEQF+fPPNDwb/4d7qPFJYZo7KkYr91fq96sO6Vc3nGd2SQB6VTS06q2NRVqy8bD90Dlfq0VXjI/XPTPTNTUtghNv4TUIIh7s4YtHaOX+Sr27pVg/uHSk4kLZ1geYxTAMbSs8qtfXHdanu46oo6tn8WlMiE23T0vV7dNT+TsKr0QQ8WDTMiJ1fnqENhcc1Z9W5+nJq8eaXRLgdVo7uvTh9lK9vr5Au0vr7dez0yJ094w0XTk+gUPn4NUIIh7uoYtH6L7Fm7VkY6EeumiEIoL9zS4J8ApFNc16Y+NhLd1cZD/11uZr1bcmJeruGekan8RuNkAiiHi8i0bFaGxCqPYcqdef1uTpx/OzzC4J8FiGYWjtwWr9eV2BvthXLqNn9kVJ4YG6a0aabpmawg8DwDcQRDycxWLRo5eO1MI3tmrx2gLdPytDUcNsZpcFeJTWji79Y3uJXltToNzyBvv1OSOjdfeMdF2SFctxC8ApEES8wPxxcRqfFKpdJfX6w6o8/fyqMWaXBHiEioZWvbH+sN7YWGg/eC7I30c3Zifr7hnpGhE7zOQKAddHEPECFotF/zZvtO5bvFmvryvQA7MzFMvqfOCs7S6t02trCvTRjlK1d/U0H0sKD9Q9M9N0y/mpCgv0M7lCwH0QRLzERaNiNCU1XNsKa/XSikN6+rpxZpcEuJWubkNf7qvQq2vytCGvxn59Smq4Fswervnj4jh4DjgLBBEvYbFY9KN5o3X7nzbqzY2FWjA7QymRdFsFzqSprVPvbCnS4nUF9rNffKwWXXVegu6fla7JqREmVwi4N4KIF5k5IlqzRkRp7cFqPbcslzNogNMoPtqs19cV6O3NRWpo7ZQkhQb46rbpqbpnRroSwwNNrhDwDAQRL/PElWN07W/X6B/bS3X/rAxNTAk3uyTAZfR1P31tTYE+212mru6e/bcZ0cG6f1a6vpOdzNkvwBDjb5SXGZ8UphsmJ+nv20r0fz/Zq6XfvYAzLeD1Orq69emuMr26Jl87imrt12eNiNKC2Rm6aFSsrGy/BRyCIOKFfjRvtD7++og25ddo+Z5yzRsXb3ZJgCnqmjv05qZC/WV9gY7UtUqS/H16up/ePztDYxJCTa4Q8HwEES+UGB6oB+Zk6HdfHdKiT/dp7ugY2Xx9zC4LcJq8ykYtXlugd7cWq6WjS5IUPcxfd16QpjumpykmhKZ/gLMQRLzUwrmZ+tuWYuVXNelPq/P18MUjzC4JcCjDMLTuULVeXZOvL/dV2K9nxYdowewMXTsxUQF+BHLA2QgiXiokwE9PXjVGjy3drt98eUDXT05SErsA4IH6Tr99bW2+9pX1tF+3WKRLs2J1/6wMzciMYp0UYCKCiBf71qREvbmpUJvya/TLf+7Ry3dmm10SMGQqG9r0xobDWrLxsKoae9qvB/r56KapybpvVoYyooNNrhCARBDxahaLRf/5rXG6+sU1+nRXmVbtr9SFo2LMLgs4J3tK6/Xa2nx9uP1Y+/XEsADdMzNdt56fqrAg2q8DroQg4uWy4kN178x0vbomX09+sFOfP3YhfRLgdrrt7dfztT6v2n59cmq4FszO0Pxx8fKj/TrgkvjGgX54+Sh9tqtMRTUten7Zfv3imrFmlwQMSFNbp97dWqzFa/NVcFz79SvHx+v+2RmaQvt1wOURRKBhNl/93xvG697Fm/Xa2nxdPSGBf8Dh0kpqW/SXdQV6a1Oh6nvbr4cE+Or2aam6e2Y6C68BN0IQgSTpotGx+vaUno6rP333a/3z0dn0FoHL2VZ4VK+uyddnu/q3X79vVrq+MyVZwTb+SQPcDX9rYfeLq8dqZW6lDlQ06oXl+/XElWPMLglQ53Ht17cf1359ZmaU7p+VoUuyaL8OuDOCCOwigv31q2+fp+/9dateWZWni0bFakZmlNllwUvVNXfo7c2Fen1dgUqPa79+3aRE3T8rQ2MTab8OeAKCCPqZPy5et56forc3F+nf/rZdnz52ocIC2e4I58mvatLitfl6d2uxmtt72q9HBfe0X7/zAtqvA56GIIIT/OKasVqfV63D1c36xQe79L+3TqLzJByqr/36a2vy9WVuhYye5R/Kig/R/bMzdB3t1wGPRRDBCYJtvvp/t0zSTb9frw93lGpGZpRum5ZqdlnwQK0dXfrH9hK9tqZAueUN9uuXZMVqwewMzaT9OuDxCCI4qSmpEfrRvNH678/26akPd+u8pDCNTwozuyx4iIr6Vv11w2Et2Viomqae9utB/j66KTtZ98xM1/CYYSZXCMBZCCI4pe9dOFxbCmr0xb4KPbRkmz76/mzWi+Cc7Cyu02tr8/XPr0vV0dUz/5IUHqh7Z6br5vNT+P8L8EIEEZyS1WrR8zdP1NUvrlFhTbMeX7pdr9w9VT5slcQgdHZ1a/mecr22Nl+bC47ar5+fHqH7Z2Xo8rFx8qX9OuC1CCI4rfAgf7185xTd+Pv1+mJfhX79+T76i2BA6lo69LfNRfrzugKV1LZIknytFl07MVH3zUrXhORwcwsE4BIIIjijCcnhevbGCfrB29v1h5V5Ghkbohuzk80uCy4qv6pJf16br3eO234bGeyvO6an6s4L0hQXGmByhQBcCUEEA/KtSUk6UN6o3351UD//+06lRgZpWkak2WXBRXR3G1p9sEqvryvQV8dtvx0dF6L7Z6frW5OS2H4L4KQIIhiwxy8fpYMVjfpsd5keeH2z/rZwhrLi6W7pzepbO/TulmL9dcNh5Vc12a9fmhWr+9l+C2AALIbR97OL66mvr1dYWJjq6uoUGsoXnitoae/Sna9u1NbDRxUXatN7/2emkiOCzC4LTpZb1qC/rC/Q+zkl9umXEJuvbpyarLsuSGP7LeDlBvP9TRDBoNU2t+um36/XgYpGDY8J1tLvzqDtthfo2/3y+voCbcirsV8fFTdMd89I1w2Tkzj9FoCkwX1/O3zP3Mcff6zp06crMDBQ0dHR+va3v+3oj4SDhQf56y8LpikxLEB5lU26/Y8bVNXYZnZZcJCqxjb99ssDmvPrr/R/lmzThrwa+VgtunJ8vN568AJ9/tiFuvOCNEIIgLPi0H853nvvPT344IP61a9+pUsuuUSGYWjnzp2O/Eg4SUJYoN588ALd8krPyMgdf9yoNx+crqhhjIx4AsMwtK2wVm9sOKyPvz6i9q5uST2Hz902LVW3T09VYnigyVUC8AQOm5rp7OxUenq6nnnmGS1YsOCsfg+mZlxfflWTbvnDelU0tGlk7DD9dcF0xYexPdNd1bd26IOcEr25sVD7yo6d/TIpJVz3zEzTVeclyObL7hcApzeY72+HjYhs27ZNJSUlslqtmjx5ssrKyjRp0iQ999xzGjdu3Enf09bWpra2Y0P89fX1jioPQyQjOlhvf/cC3fbHDTpQ0ajvvLxOf10wjcWKbsQwDG0vqtWbGwv10delau3oGf2w+Vp1zYRE3T0jTRNTws0tEoDHctiIyNtvv63bbrtNqampeuGFF5Senq7nn39ey5Yt0/79+xUZeWIPiqefflrPPPPMCdcZEXF9RTXNuvu1TcqvalJUsL9eu/d8vrxcXENrhz7YXqo3NxZq75FjoX9U3DDdPi1VN0xOVlgQZ78AGDyH7po5VVg43ubNm7V//37dcccd+sMf/qDvfve7knpGPJKTk/XLX/5S3/ve905438lGRFJSUggibqKqsU33vLZJu0vrZfO16vmbJ+qaCYlml4Xj9I1+LN1cpA93lNq33vr7WnXNeQm6fXqqstMi6P0B4Jw4dGrmkUce0a233nra16Snp6uhoWd+eezYsfbrNptNw4cPV2Fh4UnfZ7PZZLOx2NFdRQ+z6e3vXqBH38rRV7mVeuTNHB2saNSjl4yUlYPyTFVR36r3c0r0ztZiHaxotF/PjAnW7dPT9J0pSQoP8jexQgDeatBBJDo6WtHR0Wd8XXZ2tmw2m3JzczV79mxJUkdHhwoKCpSWljb4SuEWQgL89Kd7ztevPtmrV9fk63/+dUDbi2r1/E0T2VHjZO2d3fpib7ne2Vqslfsr1dXdM/gZ4GfVFePiddu0VE3LiGT0A4CpHLZYNTQ0VAsXLtRTTz2llJQUpaWl6dlnn5Uk3XTTTY76WLgAH6tFv7hmrEbHh+gXH+zSitxKXfXiar1462RNHx5ldnkeb1dJnd7dWqx/bC/R0eYO+/UpqeG6aWqKrp6QoNAA1n4AcA0O7SPy7LPPytfXV3fddZdaWlo0ffp0ffnll4qIiHDkx8JF3Dw1RROSw/Twkm06VNmk2/64QY9cMlKPXDxC/r4O76XnVYpqmvXhjlJ9uL1UueXHtt3Ghdr07SnJujE7WZnsZALggmjxDodrbu/Uf/xjt97dWiypZ1fGf39ngianEkjPRWVDmz7+ulT/2FGqnMJa+3V/H6suHxenm7KTNWdkjHxYnwPAyThrBi7pox2levrD3apuapfFIt07M13/Nm+0htEafMDqWjr0+e4yfbSjVGsPVql32YesFmlGZpS+NTFJ88fHKyyQqRcA5iGIwGUdbWrXf328R3/fViJJih7mr8cuG6Vbz0+Rrw/TNSdTUd+qZXvK9fnuMq0/VK3O7mN/ZSelhOu6iYm6ZkKCYkPpaAvANRBE4PJW7q/U0x/uVn5Vk6SebaQ/vSJLl4+NYxeHpMPVTfp8d5k+312ubYVHdfzf0lFxw3TdxERdOzFRaVHB5hUJAKdAEIFb6Ojq1psbC/W/XxxQTVO7JCkrPkQL52bqmgkJXjVC0t7ZrS0FNVq5v1Irciv7LTiVekY+5o+L1/xxcbTPB+DyCCJwK/WtHfr9ikN6fV2Bmno7fSZHBOremem6YXKSx/YfKapptgePdYeq7F1OpZ4t0DOGR2n+uDhdPjaegwQBuBWCCNxSXXOH/rqhQIvXFqi6d4TEz8eieePidcvUFM3MjHLbURLDMFRY06yNeTXakF+tjXk1Kqlt6fea6GE2zR0Vo4tGx2jOyGg6nQJwWwQRuLWW9i79PadYb28q0s6SOvv1iCA/XT42TleMj9fMzGgF+LnucfStHV3ae6ReO0vqtPXwUW3Mq1FZfWu/1/hYLZqSGq6LRsdq7qgYjU0IpRU+AI9AEIHH2FVSp6Wbi/TPr0v7dQm1+VqVnRahGcOjNCMzSuMSwxTob04wqW1u18GKRu0vb9Su0jp9XVyr3LIGdXT1/6vl52PRhORwTc+I1PThUcpOi2DrMgCPRBCBx+ns6tamghp9vqtMy/aU60hd/9EFq0XKjBmmcYmhykoIVXpUkFIjg5UWFaTgc/yy7+42VNXUppKjLSqtbVVpbYsKa5p1sKJRByoaVdXYdtL3RQb7a0JymD18TEmNMC0sAYAzEUTg0QzD0KHKJq3Pq9b6Q1XalF+jqsb2U74+xOaryGH+igz2V0SQvwL8rLL5+sjma5W/r1WG0bODp72zW+1d3Wrt6FZtc7uONrertrlDtS0d9gPjTiUpPFCZscM0Jj5EE5LDNSE5TMkRgWxFBuCVCCLwKoZhqKKhTbtL67SrpF4HKxp1uKZZhdVN/aZzzoXVIsWFBigpPFCJ4YFKighUZswwjYwdpszYYUyxAMBxBvP9zb+ecHsWi0VxoQGKCw3QJVlx/Z6rb+1QVUObapraVdXYrrqWdrV19ox+tHV2q62jS7JYZPO1ys/HIj+fntGS8CA/hQf52UdRIoP95eemO3YAwJURRODRQgP8FBrgp+ExZlcCADgZfsQDAACmIYgAAADTEEQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqXPn3XMAxJUn19vcmVAACAger73u77Hj8dlw4iDQ0NkqSUlBSTKwEAAIPV0NCgsLCw077GYgwkrpiku7tbpaWlCgkJkcVisV+vr69XSkqKioqKFBoaamKFOBnuj+vjHrk27o/r4x6dnmEYamhoUGJioqzW068CcekREavVquTk5FM+Hxoayv8ALoz74/q4R66N++P6uEendqaRkD4sVgUAAKYhiAAAANO4ZRCx2Wx66qmnZLPZzC4FJ8H9cX3cI9fG/XF93KOh49KLVQEAgGdzyxERAADgGQgiAADANAQRAABgGoIIAAAwjcsGkZdeekkZGRkKCAhQdna2Vq9ePaD3rV27Vr6+vpo0aZJjC/Ryg70/bW1tevLJJ5WWliabzabMzEy99tprTqrWOw32Hi1ZskQTJ05UUFCQEhISdN9996m6utpJ1XqXVatW6dprr1ViYqIsFos++OCDM75n5cqVys7OVkBAgIYPH67f//73ji/USw32/vz973/X5ZdfrpiYGIWGhmrGjBn6/PPPnVOsB3DJILJ06VI99thjevLJJ5WTk6M5c+boyiuvVGFh4WnfV1dXp7vvvluXXnqpkyr1Tmdzf26++WZ98cUXevXVV5Wbm6u33npLWVlZTqzauwz2Hq1Zs0Z33323FixYoN27d+udd97R5s2b9cADDzi5cu/Q1NSkiRMn6re//e2AXp+fn6+rrrpKc+bMUU5Ojn7+85/r0Ucf1XvvvefgSr3TYO/PqlWrdPnll+uTTz7R1q1bdfHFF+vaa69VTk6Ogyv1EIYLmjZtmrFw4cJ+17Kysoyf/exnp33fLbfcYvz7v/+78dRTTxkTJ050YIXebbD359NPPzXCwsKM6upqZ5QHY/D36NlnnzWGDx/e79qLL75oJCcnO6xG9JBkvP/++6d9zU9+8hMjKyur37Xvfe97xgUXXODAymAYA7s/JzN27FjjmWeeGfqCPJDLjYi0t7dr69atmjdvXr/r8+bN07p16075vsWLF+vQoUN66qmnHF2iVzub+/Phhx9q6tSp+vWvf62kpCSNGjVKP/rRj9TS0uKMkr3O2dyjmTNnqri4WJ988okMw1B5ebneffddXX311c4oGWewfv36E+7n/PnztWXLFnV0dJhUFU6lu7tbDQ0NioyMNLsUt+Byh95VVVWpq6tLcXFx/a7HxcWprKzspO85cOCAfvazn2n16tXy9XW5P5JHOZv7k5eXpzVr1iggIEDvv/++qqqq9NBDD6mmpoZ1Ig5wNvdo5syZWrJkiW655Ra1traqs7NT1113nX7zm984o2ScQVlZ2UnvZ2dnp6qqqpSQkGBSZTiZ559/Xk1NTbr55pvNLsUtuNyISB+LxdLv14ZhnHBNkrq6unT77bfrmWee0ahRo5xVntcb6P2Ren46sFgsWrJkiaZNm6arrrpKL7zwgv785z8zKuJAg7lHe/bs0aOPPqr/+I//0NatW/XZZ58pPz9fCxcudEapGICT3c+TXYe53nrrLT399NNaunSpYmNjzS7HLbjc8EF0dLR8fHxO+MmtoqLihJ8IJKmhoUFbtmxRTk6OHnnkEUk9X3yGYcjX11fLli3TJZdc4pTavcFg748kJSQkKCkpqd+R0GPGjJFhGCouLtbIkSMdWrO3OZt7tGjRIs2aNUs//vGPJUkTJkxQcHCw5syZo1/+8pf8xG2y+Pj4k95PX19fRUVFmVQVvmnp0qVasGCB3nnnHV122WVml+M2XG5ExN/fX9nZ2Vq+fHm/68uXL9fMmTNPeH1oaKh27typ7du32x8LFy7U6NGjtX37dk2fPt1ZpXuFwd4fSZo1a5ZKS0vV2Nhov7Z//35ZrVYlJyc7tF5vdDb3qLm5WVZr/38OfHx8JB37yRvmmTFjxgn3c9myZZo6dar8/PxMqgrHe+utt3TvvffqzTffZG3VYJm3TvbU3n77bcPPz8949dVXjT179hiPPfaYERwcbBQUFBiGYRg/+9nPjLvuuuuU72fXjGMN9v40NDQYycnJxo033mjs3r3bWLlypTFy5EjjgQceMOuP4PEGe48WL15s+Pr6Gi+99JJx6NAhY82aNcbUqVONadOmmfVH8GgNDQ1GTk6OkZOTY0gyXnjhBSMnJ8c4fPiwYRgn3p+8vDwjKCjI+OEPf2js2bPHePXVVw0/Pz/j3XffNeuP4NEGe3/efPNNw9fX1/jd735nHDlyxP6ora0164/gVlwyiBiGYfzud78z0tLSDH9/f2PKlCnGypUr7c/dc889xty5c0/5XoKI4w32/uzdu9e47LLLjMDAQCM5Odl4/PHHjebmZidX7V0Ge49efPFFY+zYsUZgYKCRkJBg3HHHHUZxcbGTq/YOX331lSHphMc999xjGMbJ78+KFSuMyZMnG/7+/kZ6errx8ssvO79wLzHY+zN37tzTvh6nZzEMxl0BAIA5XG6NCAAA8B4EEQAAYBqCCAAAMA1BBAAAmIYgAgAATEMQAQAApiGIAAAA0xBEAACAaQgiAADANAQRAABgGoIIAAAwDUEEAACY5v8DVFNSeP/dujsAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "murn = pr.create.job.Murnaghan(\"murn\")\n",
     "murn.input.task = pr.create.task.AseStatic()\n",
     "murn.input.task.input.calculator = MorsePotential()\n",
     "murn.input.structure = pr.create.structure.bulk(\"Fe\", a=1.2).to_ase()\n",
     "murn.input.set_strain_range(.5, 500)\n",
-    "exe = murn.run(executor='process')\n",
-    "if exe is not None:\n",
-    "    exe.wait()\n",
+    "murn.run(executor='process')\n",
+    "murn.wait()\n",
     "murn.output.plot()"
    ]
   },
@@ -791,7 +853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "id": "30871447-3e20-46ee-a58e-853d4f4cb5d9",
    "metadata": {},
    "outputs": [
@@ -799,18 +861,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "DEBUG:pyiron_log:Not supported parameter used!\n"
+      "DEBUG:pyiron_log:Not supported parameter used!\n",
+      "INFO:root:Job already finished!\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<pyiron_contrib.tinybase.executor.FuturesExecutionContext at 0x7fad4d845150>"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -821,7 +874,8 @@
     "j.input.timestep = 3.0\n",
     "j.input.temperature = 600.0\n",
     "j.input.output_steps = 20\n",
-    "j.run(executor='background')"
+    "j.run(executor='background')\n",
+    "j.wait()"
    ]
   },
   {
@@ -920,19 +974,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "id": "80da39e2-76d1-42e6-977f-241d2683188d",
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'bulk' is not defined",
+     "ename": "PermissionError",
+     "evalue": "[Errno 13] Permission denied: '/foo'",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[33], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m sub \u001b[38;5;241m=\u001b[39m pr\u001b[38;5;241m.\u001b[39mopen_location(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m/foo\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m j \u001b[38;5;241m=\u001b[39m sub\u001b[38;5;241m.\u001b[39mcreate\u001b[38;5;241m.\u001b[39mjob\u001b[38;5;241m.\u001b[39mAseMD(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mmd\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 3\u001b[0m j\u001b[38;5;241m.\u001b[39minput\u001b[38;5;241m.\u001b[39mstructure \u001b[38;5;241m=\u001b[39m \u001b[43mbulk\u001b[49m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mFe\u001b[39m\u001b[38;5;124m'\u001b[39m, a\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1.2\u001b[39m, cubic\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\u001b[38;5;241m.\u001b[39mrepeat(\u001b[38;5;241m2\u001b[39m)\n\u001b[1;32m      4\u001b[0m j\u001b[38;5;241m.\u001b[39minput\u001b[38;5;241m.\u001b[39mcalculator \u001b[38;5;241m=\u001b[39m MorsePotential()\n\u001b[1;32m      5\u001b[0m j\u001b[38;5;241m.\u001b[39minput\u001b[38;5;241m.\u001b[39msteps \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m100\u001b[39m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'bulk' is not defined"
+      "\u001b[0;31mPermissionError\u001b[0m                           Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[34], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m sub \u001b[38;5;241m=\u001b[39m \u001b[43mpr\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mopen_location\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m/foo\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m j \u001b[38;5;241m=\u001b[39m sub\u001b[38;5;241m.\u001b[39mcreate\u001b[38;5;241m.\u001b[39mjob\u001b[38;5;241m.\u001b[39mAseMD(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mmd\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m      3\u001b[0m j\u001b[38;5;241m.\u001b[39minput\u001b[38;5;241m.\u001b[39mstructure \u001b[38;5;241m=\u001b[39m bulk(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mFe\u001b[39m\u001b[38;5;124m'\u001b[39m, a\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1.2\u001b[39m, cubic\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\u001b[38;5;241m.\u001b[39mrepeat(\u001b[38;5;241m2\u001b[39m)\n",
+      "File \u001b[0;32m~/pyiron/contrib/pyiron_contrib/tinybase/project.py:117\u001b[0m, in \u001b[0;36mProjectAdapter.open_location\u001b[0;34m(cls, location)\u001b[0m\n\u001b[1;32m    115\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m    116\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mopen_location\u001b[39m(\u001b[38;5;28mcls\u001b[39m, location):\n\u001b[0;32m--> 117\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mcls\u001b[39m(\u001b[43mProject\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlocation\u001b[49m\u001b[43m)\u001b[49m)\n",
+      "File \u001b[0;32m~/micromamba/envs/contrib/lib/python3.10/site-packages/pyiron_base/project/generic.py:117\u001b[0m, in \u001b[0;36mProject.__init__\u001b[0;34m(self, path, user, sql_query, default_working_directory)\u001b[0m\n\u001b[1;32m    114\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    115\u001b[0m         path \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m--> 117\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mProject\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__init__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    119\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39muser \u001b[38;5;241m=\u001b[39m user\n\u001b[1;32m    120\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msql_query \u001b[38;5;241m=\u001b[39m sql_query\n",
+      "File \u001b[0;32m~/micromamba/envs/contrib/lib/python3.10/site-packages/pyiron_base/project/path.py:224\u001b[0m, in \u001b[0;36mProjectPath.__init__\u001b[0;34m(self, path)\u001b[0m\n\u001b[1;32m    222\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m path \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m    223\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mProjectPath: path is not allowed to be empty!\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 224\u001b[0m generic_path \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_convert_str_to_generic_path\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    225\u001b[0m \u001b[38;5;28msuper\u001b[39m(ProjectPath, \u001b[38;5;28mself\u001b[39m)\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m    226\u001b[0m     generic_path\u001b[38;5;241m.\u001b[39mroot_path, generic_path\u001b[38;5;241m.\u001b[39mproject_path\n\u001b[1;32m    227\u001b[0m )\n\u001b[1;32m    228\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_history \u001b[38;5;241m=\u001b[39m []\n",
+      "File \u001b[0;32m~/micromamba/envs/contrib/lib/python3.10/site-packages/pyiron_base/project/path.py:373\u001b[0m, in \u001b[0;36mProjectPath._convert_str_to_generic_path\u001b[0;34m(self, path)\u001b[0m\n\u001b[1;32m    371\u001b[0m     path \u001b[38;5;241m=\u001b[39m posixpath\u001b[38;5;241m.\u001b[39mjoin(path_local, path)\n\u001b[1;32m    372\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mexists(path):\n\u001b[0;32m--> 373\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_create_path\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    374\u001b[0m \u001b[38;5;66;03m# else:\u001b[39;00m\n\u001b[1;32m    375\u001b[0m \u001b[38;5;66;03m#     raise ValueError(path, ' does not exist!')\u001b[39;00m\n\u001b[1;32m    376\u001b[0m path \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_windows_path_to_unix_path(path)\n",
+      "File \u001b[0;32m~/micromamba/envs/contrib/lib/python3.10/site-packages/pyiron_base/project/path.py:394\u001b[0m, in \u001b[0;36mProjectPath._create_path\u001b[0;34m(self, path, rel_path)\u001b[0m\n\u001b[1;32m    392\u001b[0m     rel_path \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_windows_path_to_unix_path(rel_path)\n\u001b[1;32m    393\u001b[0m     path \u001b[38;5;241m=\u001b[39m posixpath\u001b[38;5;241m.\u001b[39mjoin(path, rel_path)\n\u001b[0;32m--> 394\u001b[0m \u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmakedirs\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexist_ok\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/micromamba/envs/contrib/lib/python3.10/os.py:225\u001b[0m, in \u001b[0;36mmakedirs\u001b[0;34m(name, mode, exist_ok)\u001b[0m\n\u001b[1;32m    223\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m\n\u001b[1;32m    224\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 225\u001b[0m     \u001b[43mmkdir\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    226\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mOSError\u001b[39;00m:\n\u001b[1;32m    227\u001b[0m     \u001b[38;5;66;03m# Cannot rely on checking for EEXIST, since the operating system\u001b[39;00m\n\u001b[1;32m    228\u001b[0m     \u001b[38;5;66;03m# could give priority to other errors like EACCES or EROFS\u001b[39;00m\n\u001b[1;32m    229\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m exist_ok \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m path\u001b[38;5;241m.\u001b[39misdir(name):\n",
+      "\u001b[0;31mPermissionError\u001b[0m: [Errno 13] Permission denied: '/foo'"
      ]
     }
    ],
@@ -945,7 +1005,8 @@
     "j.input.timestep = 3.0\n",
     "j.input.temperature = 600.0\n",
     "j.input.output_steps = 20\n",
-    "j.run(how='process')"
+    "j.run(how='process')\n",
+    "j.wait()"
    ]
   },
   {

--- a/notebooks/tinybase/TinyJob.ipynb
+++ b/notebooks/tinybase/TinyJob.ipynb
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "95763abb-4480-4ced-bf73-db72dae9ffe0",
+   "id": "1e5208d9-d7b8-4ca3-92cf-5d32c30c20f9",
    "metadata": {
     "tags": []
    },
@@ -23,7 +23,75 @@
       "/home/poul/pyiron/contrib/pyiron_contrib/__init__.py:9: UserWarning: pyiron module not found, importing Project from pyiron_base\n",
       "  warnings.warn(\"pyiron module not found, importing Project from pyiron_base\")\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "from pyiron_contrib.tinybase.project import ProjectAdapter, InMemoryProject"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "059021a8-6e20-4265-94f4-8fb9bdaebde3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from ase.calculators.morse import MorsePotential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f2e0123f-f0be-41ef-9733-af547b38d846",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "logging.getLogger().setLevel(20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc092b74-64c6-49c9-9576-ef5d871fcd1e",
+   "metadata": {},
+   "source": [
+    "# Create Project and a new Job\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0f30286b-4434-4569-8f03-fadab46ebe34",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pr = ProjectAdapter.open_location('tinyjob')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "450e6b64-9824-4b8a-8854-3999a93fc781",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## MD Job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e31baebd-b2c8-4343-90ad-92d9128d1496",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
     {
      "data": {
       "text/html": [
@@ -47,7 +115,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7257515de92a452395badcf83fb46b03",
+       "model_id": "d365d332f5f44babad1dc4f275dc3284",
        "version_major": 2,
        "version_minor": 0
       },
@@ -58,187 +126,25 @@
     }
    ],
    "source": [
-    "from pyiron_contrib.tinybase.job import GenericTinyJob"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "9730e2a5-9079-4863-905d-f21e47b65816",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from pyiron_contrib.tinybase.executor import ProcessExecutor"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "09003a07-be8d-4607-b533-54214ae64056",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from pyiron_contrib.tinybase.murn import MurnaghanTask"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "70c5d3c8-2d81-4539-9453-cd85010e7373",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from pyiron_contrib.tinybase.ase import AseMDTask, AseMinimizeTask, AseStaticTask"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "1e5208d9-d7b8-4ca3-92cf-5d32c30c20f9",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from pyiron_contrib.tinybase.project import ProjectAdapter, InMemoryProject"
+    "j = pr.create.job.AseMD('md')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "5606f2b7-ba23-4b0d-b44e-b41cda6e5d4d",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from ase import Atoms"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "9a28ea42-360a-4e35-9fce-427b661a05c5",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from ase.build import bulk"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "059021a8-6e20-4265-94f4-8fb9bdaebde3",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from ase.calculators.morse import MorsePotential"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "f6fb49d0-dbfc-4b33-8b4d-999a2002831e",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from pyiron_base import Project"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "id": "f2e0123f-f0be-41ef-9733-af547b38d846",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "logging.getLogger().setLevel(10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bc092b74-64c6-49c9-9576-ef5d871fcd1e",
-   "metadata": {},
-   "source": [
-    "# Create Project and a new Job\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "0f30286b-4434-4569-8f03-fadab46ebe34",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "pr = ProjectAdapter(Project('tinyjob'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "450e6b64-9824-4b8a-8854-3999a93fc781",
-   "metadata": {},
-   "source": [
-    "## MD Job"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "ba190052-7bc1-4383-b3da-c7221c4e38d0",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "j = GenericTinyJob(pr, 'md')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "1e21980e-14a6-4578-b4b9-8195a74a3593",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "j.task_class = AseMDTask"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
    "id": "18e6de26-308c-46ae-9672-b2db43447ea5",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "j.input.structure = bulk('Fe', a=1.2, cubic=True).repeat(2)\n",
+    "j.input.structure = pr.create.structure.bulk('Fe', a=1.2, cubic=True).repeat(2).to_ase()\n",
     "j.input.calculator = MorsePotential()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "id": "72848cd2-fd51-4ad8-b56e-ca686074bb26",
    "metadata": {
     "tags": []
@@ -253,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "id": "56c0e73a-c42b-4814-a25a-e6974fea3d00",
    "metadata": {
     "tags": []
@@ -268,12 +174,12 @@
     }
    ],
    "source": [
-    "j.run(how='foreground')"
+    "j.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "id": "49ccfe01-7b7e-4615-bf43-21c1bbffec66",
    "metadata": {
     "tags": []
@@ -282,7 +188,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "16c628e0bea4418f8c357e500e5ed146",
+       "model_id": "1945295762b54d49809da2f8840cf80d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -308,45 +214,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "049f056e-47ff-4c2f-9e85-612744af15a8",
+   "execution_count": 10,
+   "id": "7b807119-da8d-475c-9aa8-c8e8c9afa115",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "j = GenericTinyJob(pr, 'min')"
+    "j = pr.create.job.AseMinimize('min')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "1137a899-b00b-4ce4-92df-23a4bbcf7aa8",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "j.task_class = AseMinimizeTask"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "id": "3a8cda32-df2e-4884-8cfd-84e438c5be69",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "j.input.structure = Atoms(symbols=['Fe', 'Fe'], positions=[[0,0,0], [0,0, .75]], cell=[10,10,10])\n",
+    "j.input.structure = pr.create.structure.atoms(\n",
+    "    symbols=['Fe', 'Fe'], \n",
+    "    positions=[[0,0,0], [0,0, .75]], \n",
+    "    cell=[10,10,10]\n",
+    ").to_ase()\n",
     "j.input.structure.rattle(1e-3)\n",
     "j.input.calculator = MorsePotential()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 12,
    "id": "d4b81c3f-4667-4b99-a2b3-08c7ee7e2c82",
    "metadata": {
     "tags": []
@@ -354,13 +252,14 @@
    "outputs": [],
    "source": [
     "j.input.lbfgs(damping=.25)\n",
+    "j.input.ionic_force_tolerance = 1e-3\n",
     "j.input.max_steps = 100\n",
     "j.input.output_steps = 10"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 13,
    "id": "e7494fee-d565-45e3-a819-c77ab0d2c7f6",
    "metadata": {
     "scrolled": true,
@@ -376,14 +275,16 @@
     }
    ],
    "source": [
-    "exe = j.run(how='process')\n",
+    "exe = j.run(\n",
+    "    executor=pr.create.executor.process(4)\n",
+    ")\n",
     "if exe is not None:\n",
     "    exe.wait()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 14,
    "id": "7c16a615-0913-4880-9694-2c125285babc",
    "metadata": {
     "tags": []
@@ -429,7 +330,7 @@
        "      <td>md</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>4</td>\n",
+       "      <td>8</td>\n",
        "      <td>/home/poul/pyiron/contrib/notebooks/tinybase/t...</td>\n",
        "      <td>finished</td>\n",
        "      <td>AseMDTask</td>\n",
@@ -439,9 +340,9 @@
        "      <td>5</td>\n",
        "      <td>pyiron</td>\n",
        "      <td>min</td>\n",
-       "      <td>2</td>\n",
+       "      <td>3</td>\n",
        "      <td>1</td>\n",
-       "      <td>5</td>\n",
+       "      <td>9</td>\n",
        "      <td>/home/poul/pyiron/contrib/notebooks/tinybase/t...</td>\n",
        "      <td>finished</td>\n",
        "      <td>AseMinimizeTask</td>\n",
@@ -451,9 +352,9 @@
        "      <td>6</td>\n",
        "      <td>pyiron</td>\n",
        "      <td>murn</td>\n",
-       "      <td>3</td>\n",
+       "      <td>2</td>\n",
        "      <td>1</td>\n",
-       "      <td>6</td>\n",
+       "      <td>11</td>\n",
        "      <td>/home/poul/pyiron/contrib/notebooks/tinybase/t...</td>\n",
        "      <td>finished</td>\n",
        "      <td>MurnaghanTask</td>\n",
@@ -464,9 +365,9 @@
       ],
       "text/plain": [
        "   id username  name  jobtype_id  project_id  status_id  \\\n",
-       "0   4   pyiron    md           1           1          4   \n",
-       "1   5   pyiron   min           2           1          5   \n",
-       "2   6   pyiron  murn           3           1          6   \n",
+       "0   4   pyiron    md           1           1          8   \n",
+       "1   5   pyiron   min           3           1          9   \n",
+       "2   6   pyiron  murn           2           1         11   \n",
        "\n",
        "                                            location    status  \\\n",
        "0  /home/poul/pyiron/contrib/notebooks/tinybase/t...  finished   \n",
@@ -479,7 +380,7 @@
        "2    MurnaghanTask  "
       ]
      },
-     "execution_count": 26,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -490,7 +391,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 15,
+   "id": "59ea5510-b6ce-4317-90c3-4af77db3d59a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAur0lEQVR4nO3de3SU9b3v8c8zk2Ryn4QEAoEAkQTkjoBySyi2lb2osmX12GprFd1dbV0Fhc3qrtJ2V7e1ZrfdbemSA7v2rKN4rOJaW6Wcs6wt1UIICOVikC0WEogQLiEkkJlcJ8lkzh/JDERuuTwzz1zer7We1c4zT+b5Osu15uPv93u+P8Pn8/kEAAAQIjarCwAAALGF8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEIqzuoCPqurq0tnz55VWlqaDMOwuhwAANAHPp9PjY2Nys3Nlc1247GNsAsfZ8+eVV5entVlAACAAaiurtaoUaNueE3YhY+0tDRJ3cWnp6dbXA0AAOgLt9utvLy8wO/4jYRd+PBPtaSnpxM+AACIMH1ZMsGCUwAAEFKEDwAAEFKEDwAAEFJht+YDAACreb1edXR0WF1G2LHb7YqLixt0KwzCBwAAV2hqatLp06fl8/msLiUsJScna8SIEUpISBjwZxA+AADo4fV6dfr0aSUnJ2vo0KE0u7yCz+dTe3u7Lly4oKqqKhUWFt60mdj1ED4AAOjR0dEhn8+noUOHKikpyepywk5SUpLi4+N18uRJtbe3KzExcUCfw4JTAAA+gxGP6xvoaEevzzChDgAAgD4jfAAAgJAifAAAEONefvllZWRkhOx+hA8AABBSMRM+GlratXH7cX3/vw5ZXQoAAKZatGiRVq5cqZUrVyojI0NZWVn60Y9+FOhVcunSJT388MPKzMxUcnKylixZooqKCknS9u3b9eijj8rlcskwDBmGoWeeeSao9cbUo7Y//9Pf5fNJa+6aoOHOgT0eBACIHT6fT60dXkvunRRv79dTN5s2bdI3v/lN7d27V/v379e3v/1tjRkzRt/61rf0yCOPqKKiQlu3blV6erqefPJJfelLX9KRI0c0f/58rVu3Tj/+8Y919OhRSVJqamqw/rEkxVD4yEhO0LSRTh067dLOigv6yuw8q0sCAIS51g6vJv34T5bc+8iz/6DkhL7/TOfl5enXv/61DMPQhAkTdPjwYf3617/WokWLtHXrVu3atUvz58+XJP3+979XXl6etmzZoq985StyOp0yDEPDhw8P1j9OLzEz7SJJRYXZkqSyyjqLKwEAwFxz587tNVIyb948VVRU6MiRI4qLi9OcOXMC72VlZWnChAn65JNPrCg1dkY+JKm4cKj+51+Pa1dlnbq6fLLZaCIDALi+pHi7jjz7D5bdO5h8Pp9lzdT6PfJRWlqqpUuXKjc3V4ZhaMuWLYH3Ojo69OSTT2rq1KlKSUlRbm6uHn74YZ09e9bMmgds5uhMJSfYVdfUrk9q3FaXAwAIc4ZhKDkhzpKjv8Fgz549V70uLCzUpEmT1NnZqb179wbeq6+v17FjxzRx4kRJUkJCgrze0K1t6Xf4aG5u1vTp07V+/fqr3mtpadHBgwf1r//6rzp48KDeeustHTt2TP/4j/9oSrGDlRBn09xbsiRJZRVMvQAAokd1dbXWrFmjo0eP6vXXX9cLL7ygVatWqbCwUPfee6++9a1vqaysTIcOHdI3vvENjRw5Uvfee68kaezYsWpqatJ7772nuro6tbS0BLXWfk+7LFmyREuWLLnme06nU9u2bet17oUXXtAdd9yhU6dOafTo0QOr0kRFBdl6/++12llRp+98bpzV5QAAYIqHH35Yra2tuuOOO2S32/X444/r29/+tiTppZde0qpVq3TPPfeovb1dCxcu1DvvvKP4+HhJ0vz58/XYY4/p/vvvV319vZ5++umgPm4b9DUf/ueGr9c5zePxyOPxBF673cGdDinuWXT6t08vqq3Dq8Qgz6kBABAK8fHxWrdunTZu3HjVe5mZmXrllVdu+PcbN2685t8GQ1Cfdmlra9NTTz2lr3/960pPT7/mNSUlJXI6nYEjLy+4j8AWDEvV8PREtXd2ad+nF4N6LwAAcLWghY+Ojg498MAD6urq0oYNG6573dq1a+VyuQJHdXV1sEqS1L14yP/I7U7WfQAAEHJBmXbp6OjQV7/6VVVVVen999+/7qiHJDkcDjkcjmCUcV3Fhdn6rwOnCR8AgKiwfft2q0voF9NHPvzBo6KiQn/5y1+UlZVl9i0GbUFB98jHJ+fcutDoucnVAADATP0OH01NTSovL1d5ebkkqaqqSuXl5Tp16pQ6Ozt13333af/+/fr9738vr9ermpoa1dTUqL293ezaByw71aHJud2jMbvodgoAQEj1O3zs379ft912m2677TZJ0po1a3Tbbbfpxz/+sU6fPq2tW7fq9OnTmjFjhkaMGBE4du/ebXrxg+Ff91FaccHiSgAAiC39XvOxaNGiwBa913Kj98JJccFQ/XbHCZVV1FnaYhYAgFgTUxvLXWn22Ew54myqbfSoorbJ6nIAAIgZMRs+EuPtuiN/iCSp9BhTLwAAhErMhg9JWlg4VJJUxqJTAEAEW7RokVavXn3N9x555BEtW7YspPXcTNDbq4cz/6LTPSfq5en0yhFHq3UAQHT5zW9+E3brMWN65OPW4WnKTnWoraNLB05esrocAABM53Q6r7u/mlViOnwYhhHYaK6MbqcAgCjx7rvvyul06pVXXrlq2mXRokV64okn9P3vf19DhgzR8OHDg7qD7bXEdPiQpKIC9nkBAFyHzye1N1tzDHCqZPPmzfrqV7+qV155RQ8//PA1r9m0aZNSUlK0d+9e/fznP9ezzz6rbdu2Deab6peYXvMhKTDy8d9nXbrY3K4hKQkWVwQACBsdLdLzudbc+wdnpYSUfv3Jhg0b9IMf/EB/+MMfdOedd173umnTpunpp5+WJBUWFmr9+vV67733dNdddw2q5L6K+fAxLD1RE3LSdPR8o3ZV1mnpdIv+JQMAYBDefPNNnT9/XmVlZbrjjjtueO20adN6vR4xYoRqa2uDWV4vMR8+pO7Rj6PnG1VWQfgAAFwhPrl7BMKqe/fDjBkzdPDgQb300ku6/fbbb9i5Oz4+vtdrwzDU1dU1oDIHgvCh7kdu/1dZlXZWXKDVOgDgMsPo99SHVcaNG6df/vKXWrRokex2u9avX291SdcV8wtOJWlOfpYS7DaddbXpRF2z1eUAADAg48eP11//+le9+eab1206Fg4Y+ZCUlGDX7LGZ2n28XmUVdRo3NNXqkgAAGJAJEybo/fffD4yAhCPCR4+iwmztPl6vnRUXtHz+WKvLAQCgz7Zv397r9cSJE3X+/Pk+XStJW7ZsMb+oG2DapYd/n5cPjterwxu6RTcAAMQawkePSSPSNSQlQc3tXn14qsHqcgAAiFqEjx42m6EFBf5W6xcsrgYAgOhF+LhCsb/VeiWt1gEACBbCxxWKelqtH6pukKulw+JqAACIToSPK+RmJGnc0BR1+aQPTjD6AQCxyjfATd1igRnfDeHjM4p7nnopZZdbAIg5/r4Y7e3tFlcSvlpaWiRd3aK9P+jz8RnFhdl6efenKiN8AEDMiYuLU3Jysi5cuKD4+HjZbPw3up/P51NLS4tqa2uVkZExqAZmhI/PmHNLluJshk5dbNHJ+maNyYqMnv4AgMEzDEMjRoxQVVWVTp48aXU5YSkjI0PDhw8f1GcQPj4j1RGnmWMy9beqi9pZUUf4AIAYk5CQoMLCQqZeriE+Pt6Ulu2Ej2soLsjW36ouqqyiTt+YO8bqcgAAIWaz2ZSYmGh1GVGLyaxr8D9yu+t4nTpptQ4AgKkIH9cwbVSG0hPj1NjWqY/OuKwuBwCAqEL4uAb7Fa3Wdx7jqRcAAMxE+LgOf7+Pskr2eQEAwEyEj+so7ln38eGpBjW20WodAACzED6uI29IssZkJauzy6c9Jy5aXQ4AAFGD8HED/tGPsgqmXgAAMAvh4waKCrrXfeyk1ToAAKYhfNzAvHFZstsMnahr1ulLLVaXAwBAVCB83IAzKV7TRzkliY3mAAAwCeHjJvyP3O6sJHwAAGAGwsdN+Bed7qqsk7fLZ3E1AABEPsLHTUzPy1CqI04NLR36+Cyt1gEAGCzCx03E222aNy5LEk+9AABgBsJHH/inXnbS7wMAgEEjfPSBf9HpgZOX1NLeaXE1AABENsJHH4zNStbIjCR1eH3aW0WrdQAABoPw0QeGYVyeejnGug8AAAaD8NFH/qmXskrWfQAAMBj9Dh+lpaVaunSpcnNzZRiGtmzZ0ut9n8+nZ555Rrm5uUpKStKiRYv08ccfm1WvZeaPy5JhSMfON6nG1WZ1OQAARKx+h4/m5mZNnz5d69evv+b7P//5z/WrX/1K69ev1759+zR8+HDdddddamxsHHSxVspMSdC0kT2t1ul2CgDAgPU7fCxZskTPPfecvvzlL1/1ns/n07p16/TDH/5QX/7ylzVlyhRt2rRJLS0teu2110wp2EpFPHILAMCgmbrmo6qqSjU1NVq8eHHgnMPh0Oc+9znt3r37mn/j8Xjkdrt7HeHKv+5jV2Wdumi1DgDAgJgaPmpqaiRJOTk5vc7n5OQE3vuskpISOZ3OwJGXl2dmSaaaOTpTyQl21TW16+81kT2NBACAVYLytIthGL1e+3y+q875rV27Vi6XK3BUV1cHoyRTJMTZNCd/iCSmXgAAGChTw8fw4cMl6apRjtra2qtGQ/wcDofS09N7HeHs8iO3LDoFAGAgTA0f+fn5Gj58uLZt2xY4197erh07dmj+/Plm3soy/mZje6suqq3Da3E1AABEnrj+/kFTU5MqKysDr6uqqlReXq4hQ4Zo9OjRWr16tZ5//nkVFhaqsLBQzz//vJKTk/X1r3/d1MKtUjAsVcPTE1XjbtO+Ty8GRkIAAEDf9Dt87N+/X3feeWfg9Zo1ayRJy5cv18svv6zvf//7am1t1Xe/+11dunRJc+bM0Z///GelpaWZV7WFDMNQUWG2/uvAaZVV1BE+AADoJ8Pn84XVM6Nut1tOp1Mulyts13/8ofyMVm0u18QR6frjqmKrywEAwHL9+f1mb5cBWFDQve7jk3NuXWj0WFwNAACRhfAxANmpDk0a0Z3qdvHUCwAA/UL4GKDi8f5W64QPAAD6g/AxQMUF3QtNd1ZcUJgtmwEAIKwRPgZo9thMOeJsqm30qKK2yepyAACIGISPAUqMt+uOQKt1pl4AAOgrwscg+Ludss8LAAB9R/gYBH+Dsb0nLsrTSat1AAD6gvAxCLcOT1N2qkOtHV4dOHnJ6nIAAIgIhI9BMAwjMPVSxroPAAD6hPAxSEUF9PsAAKA/CB+D5B/5+O+zLl1qbre4GgAAwh/hY5CGpSdqQk6afD5p13FGPwAAuBnChwmK/I/cHiN8AABwM4QPEwQWnVbW0WodAICbIHyYYE5+lhLsNp1paNWJumarywEAIKwRPkyQlGDX7LGZknjkFgCAmyF8mCSw7oPwAQDADRE+TLKwp9X6nhP16vB2WVwNAADhi/Bhkkkj0jUkJUFNnk6VVzdYXQ4AAGGL8GESm83Q/HFZkqSdx9jlFgCA6yF8mMg/9bKzknUfAABcD+HDRP5Fp4eqG+Rq6bC4GgAAwhPhw0S5GUkaNzRFXT7pgxOMfgAAcC2ED5MV+6deeOQWAIBrInyYrKiAfh8AANwI4cNkc8dlKc5m6NTFFp2sp9U6AACfRfgwWaojTjNHd7daZ/QDAICrET6CILDLLeEDAICrED6CwP/I7e7jdeqk1ToAAL0QPoJg2qgMpSfGyd3WqY/OuKwuBwCAsEL4CAK7zdCCAqZeAAC4FsJHkPinXnZWsM8LAABXInwEiX+flw9PNaixjVbrAAD4ET6CJG9IssZkJauzy6c9Jy5aXQ4AAGGD8BFElx+5ZeoFAAA/wkcQFRX07PNSyaJTAAD8CB9BNG9clmyGdOJCs840tFpdDgAAYYHwEUTOpHjNyMuQxNQLAAB+hI8gK+p56qWUfh8AAEgifATdQn+r9co6dXX5LK4GAADrET6CbHpehlIdcbrU0qGPz7qtLgcAAMsRPoIs3m7TvHFZkqRS1n0AAED4CIXL/T5Y9wEAgOnho7OzUz/60Y+Un5+vpKQk3XLLLXr22WfV1RW7W8sX9Wwyt//kRbW0d1pcDQAA1ooz+wN/9rOf6T//8z+1adMmTZ48Wfv379ejjz4qp9OpVatWmX27iJCfnaKRGUk609CqvVUXdeeEYVaXBACAZUwf+fjggw9077336u6779bYsWN13333afHixdq/f7/Zt4oYhmEEpl52HmPqBQAQ20wPH0VFRXrvvfd07NgxSdKhQ4dUVlamL33pS9e83uPxyO129zqiUXFPv4+yShadAgBim+nTLk8++aRcLpduvfVW2e12eb1e/fSnP9XXvva1a15fUlKif/u3fzO7jLAzf1yWDEM6dr5J591tyklPtLokAAAsYfrIxxtvvKFXX31Vr732mg4ePKhNmzbpP/7jP7Rp06ZrXr927Vq5XK7AUV1dbXZJYSEzJUHTRjolSTt56gUAEMNMH/n4l3/5Fz311FN64IEHJElTp07VyZMnVVJSouXLl191vcPhkMPhMLuMsFRUmK1Dp10qq7ig+2aNsrocAAAsYfrIR0tLi2y23h9rt9tj+lFbv6IC/7oPWq0DAGKX6SMfS5cu1U9/+lONHj1akydP1ocffqhf/epX+qd/+iezbxVxZo7JUHKCXXVN7fp7TaMm5aZbXRIAACFn+sjHCy+8oPvuu0/f/e53NXHiRH3ve9/Td77zHf3kJz8x+1YRxxFn15z8IZJ46gUAELsMn88XVuP/brdbTqdTLpdL6enRNzLwv8uq9Oz/O6Liwmz9n2/OsbocAABM0Z/fb/Z2CTF/s7G/VV1UW4fX4moAAAg9wkeIFQxLVU66Q57OLu379KLV5QAAEHKEjxDrbrXe89QL/T4AADGI8GEB/9RLKeEDABCDCB8WWFDQHT4+OefWhUaPxdUAABBahA8LZKc6NGlE90rg3ccZ/QAAxBbCh0WKx/dMvRwjfAAAYgvhwyLFgVbrFxRmrVYAAAgqwodFZo/NlCPOpvNujypqm6wuBwCAkCF8WCQx3q47elqt7+SpFwBADCF8WMj/yG1ZBfu8AABiB+HDQv5mY3tOXJSnk1brAIDYQPiw0K3D05Sd6lBrh1cHTzZYXQ4AACFB+LBQd6v17qmXnUy9AABiBOHDYkU93U7LKll0CgCIDYQPixX1jHwcPuPSpeZ2i6sBACD4CB8Wy0lP1IScNPl80i5arQMAYgDhIwwUBR65JXwAAKIf4SMMXF50WkerdQBA1CN8hIE5+VlKsNt0pqFVVXXNVpcDAEBQET7CQFKCXbPGZEqi1ToAIPoRPsJE8fjLUy8AAEQzwkeYKC7wt1qvV4e3y+JqAAAIHsJHmJicm67M5Hg1eTpVXt1gdTkAAAQN4SNM2GyGFhQw9QIAiH6EjzCysGeXW/Z5AQBEM8JHGPE3GztU3SBXa4fF1QAAEByEjzCSm5GkW4amqMsnfUCrdQBAlCJ8hJnLUy+EDwBAdCJ8hJminkWnZZWEDwBAdCJ8hJm547IUZzN0sr5Fp+pbrC4HAADTET7CTKojTjNH97Rar+SpFwBA9CF8hCH/Uy87jzH1AgCIPoSPMFTcEz52H69TJ63WAQBRhvARhqaNylB6YpzcbZ366IzL6nIAADAV4SMM2a9otV7GI7cAgChD+AhT/nUfhA8AQLQhfIQpf7Oxg6cuqcnTaXE1AACYh/ARpvKGJGtMVrI6u3zac7ze6nIAADAN4SOM+budssstACCaED7CWLF/nxdarQMAogjhI4zNG5clmyGduNCsMw2tVpcDAIApCB9hzJkUrxl5GZKkMqZeAABRIijh48yZM/rGN76hrKwsJScna8aMGTpw4EAwbhX1ivxTLzxyCwCIEqaHj0uXLmnBggWKj4/XH//4Rx05ckS//OUvlZGRYfatYsLCnn4fuyrr1NXls7gaAAAGL87sD/zZz36mvLw8vfTSS4FzY8eONfs2MWN6XoZSHXG61NKhj8+6NXWU0+qSAAAYFNNHPrZu3arZs2frK1/5ioYNG6bbbrtNv/vd7657vcfjkdvt7nXgsni7TXNvyZIklbLuAwAQBUwPHydOnNDGjRtVWFioP/3pT3rsscf0xBNP6JVXXrnm9SUlJXI6nYEjLy/P7JIi3sLxtFoHAEQPw+fzmbqQICEhQbNnz9bu3bsD55544gnt27dPH3zwwVXXezweeTyewGu32628vDy5XC6lp6ebWVrEOnGhSZ//5Q4l2G0qf/ouJSeYPlsGAMCguN1uOZ3OPv1+mz7yMWLECE2aNKnXuYkTJ+rUqVPXvN7hcCg9Pb3Xgd7ys1M0MiNJ7d4u7a26aHU5AAAMiunhY8GCBTp69Givc8eOHdOYMWPMvlXMMAxDxexyCwCIEqaHj3/+53/Wnj179Pzzz6uyslKvvfaaXnzxRa1YscLsW8WUokL2eQEARAfTw8ftt9+ut99+W6+//rqmTJmin/zkJ1q3bp0efPBBs28VUxaMy5ZhSMfON+m8u83qcgAAGLCgrFy85557dM899wTjo2NWZkqCpo506qPTLpVV1Ol/zBpldUkAAAwIe7tEkGKmXgAAUYDwEUGKCrr3eSmrrKfVOgAgYhE+IsjMMRlKTrCrrsmjv9c0Wl0OAAADQviIII44u+bkD5EklVUy9QIAiEyEjwhTVNg99bKTfh8AgAhF+IgwC3sWnf6t6qLaOrwWVwMAQP8RPiJMwbBU5aQ75Ons0v5PL1ldDgAA/Ub4iDDdrdb9Uy+s+wAARB7CRwS63O+DdR8AgMhD+IhACwq6w8eRc25daPRYXA0AAP1D+IhA2akOTRqRLknafZzRDwBAZCF8RCimXgAAkYrwEaGuXHTq89FqHQAQOQgfEWr22Ew54mw67/aosrbJ6nIAAOgzwkeESoy3646eVuulTL0AACII4SOC+dd9lNHvAwAQQQgfEayooHvdx54TF+XppNU6ACAyED4i2K3D05Sd6lBrh1cHTzZYXQ4AAH1C+IhgNpuhooIsSVJZJVMvAIDIQPiIcJcfuWXRKQAgMhA+IlxRz6LTw2dcutTcbnE1AADcHOEjwuWkJ2pCTpp8PmkXrdYBABGA8BEFigKP3BI+AADhj/ARBYqu2OeFVusAgHBH+IgCc/KHKMFu05mGVlXVNVtdDgAAN0T4iALJCXGaNSZTklRWydQLACC8ET6iRPH47qmX0mOEDwBAeCN8RIniQKv1enV4uyyuBgCA6yN8RInJuenKTI5Xk6dT5dUNVpcDAMB1ET6ihM1maEHB5adeAAAIV4SPKFIc6PfBPi8AgPBF+IgiRT37vJRXN8jV2mFxNQAAXBvhI4qMzEjSLUNT1OWTPjheb3U5AABcE+EjyiwM7HLL1AsAIDwRPqJMUc+iU5qNAQDCFeEjyswdl6U4m6GT9S06Vd9idTkAAFyF8BFlUh1xmjm6u9X6zkqmXgAA4YfwEYWKAo/cMvUCAAg/hI8o5O/3sauyTt4un8XVAADQG+EjCk0blaH0xDi52zr10ekGq8sBAKAXwkcUstNqHQAQxggfUYp1HwCAcEX4iFLFBd3Nxg6euqQmT6fF1QAAcBnhI0qNzkrWmKxkdXb5tIdW6wCAMBL08FFSUiLDMLR69epg3wqfQbdTAEA4Cmr42Ldvn1588UVNmzYtmLfBdRT37PNSyj4vAIAwErTw0dTUpAcffFC/+93vlJmZGazb4AbmjcuSzZBOXGjWmYZWq8sBAEBSEMPHihUrdPfdd+uLX/ziDa/zeDxyu929DpjDmRSv6XkZkqQyRj8AAGEiKOFj8+bNOnjwoEpKSm56bUlJiZxOZ+DIy8sLRkkxyz/1Qr8PAEC4MD18VFdXa9WqVXr11VeVmJh40+vXrl0rl8sVOKqrq80uKaZd2Wq9i1brAIAwEGf2Bx44cEC1tbWaNWtW4JzX61VpaanWr18vj8cju90eeM/hcMjhcJhdBnrMyMtQqiNOl1o69PFZt6aOclpdEgAgxpkePr7whS/o8OHDvc49+uijuvXWW/Xkk0/2Ch4Ivni7TXNvydJfPjmvnZUXCB8AAMuZHj7S0tI0ZcqUXudSUlKUlZV11XmExsLx2d3h41idvruowOpyAAAxjg6nMcDfbOzAyUtqbfdaXA0AINaZPvJxLdu3bw/FbXAd+dkpGpmRpDMNrdpbVa9FE4ZZXRIAIIYx8hEDDMMIPPXCI7cAAKsRPmJEUU/4KCN8AAAsRviIEQvGZcswpKPnG3Xe3WZ1OQCAGEb4iBGZKQmaOrL7MVtGPwAAViJ8xJDL6z7Y5wUAYB3CRwwpKuje56Wssl4+H63WAQDWIHzEkJljMpQUb1ddk0d/r2m0uhwAQIwifMQQR5xdc28ZIompFwCAdQgfMaaosHvqhX4fAACrED5izMKeRad/q7qotg5arQMAQo/wEWMKhqUqJ90hT2eX9n96yepyAAAxiPARYwzDCDz1srOSdR8AgNAjfMSgheN7+n0cY90HACD0CB8xaEFBd/g4cs6tuiaPxdUAAGIN4SMGZac6NGlEuiRpVyWjHwCA0CJ8xKjLrdYJHwCA0CJ8xKjiQL+PC7RaBwCEFOEjRs0emylHnE3n3R5V1jZZXQ4AIIYQPmJUYrxdd+T7W60z9QIACB3CRwy7vO6Dfh8AgNAhfMQwf7OxPScuytNJq3UAQGgQPmLYrcPTlJ3qUGuHVwdPNlhdDgAgRhA+YpjNZqioIEuSVEardQBAiBA+YlxRzyO3ZSw6BQCECOEjxvkXnX50xqVLze0WVwMAiAWEjxiXk56o8Tmp8vmk3cfrrS4HABADCB/o1e0UAIBgI3xARVfs80KrdQBAsBE+oDn5Q5Rgt+lMQ6uq6pqtLgcAEOUIH1ByQpxmjcmUJJVV8tQLACC4CB+Q1HvqBQCAYCJ8QJK0sGfR6QfH69Xh7bK4GgBANCN8QJI0OTddmcnxavJ06lB1g9XlAACiGOEDkrpbrS8o6J56KWXqBQAQRIQPBPi7nZbR7wMAEESEDwT493k5dNolV2uHxdUAAKIV4QMBIzOSdMvQFHm7fPqAVusAgCAhfKCX4p51H2WVTL0AAIKD8IFeLu/zwqJTAEBwED7Qy9xxWYqzGTpZ36JT9S1WlwMAiEKED/SS6ojTzNHdrdZ3MvUCAAgCwgeuUhR45JapFwCA+QgfuIo/fOyqrJO3y2dxNQCAaEP4wFWmjXQqPTFO7rZOfXS6wepyAABRxvTwUVJSottvv11paWkaNmyYli1bpqNHj5p9GwRRnN2m+eOYegEABIfp4WPHjh1asWKF9uzZo23btqmzs1OLFy9Wc3Oz2bdCEBWP7w4fPHILADBbnNkf+O677/Z6/dJLL2nYsGE6cOCAFi5caPbtECTFBd39Pg6euqQmT6dSHab/qwIAiFFBX/PhcrkkSUOGDLnm+x6PR263u9cB643OStaYrGR1dvm09wSt1gEA5glq+PD5fFqzZo2Kioo0ZcqUa15TUlIip9MZOPLy8oJZEvqhqICpFwCA+YIaPlauXKmPPvpIr7/++nWvWbt2rVwuV+Corq4OZknoh+JCf/ig2RgAwDxBm8h//PHHtXXrVpWWlmrUqFHXvc7hcMjhcASrDAzCvHHZshnS8QvNOtvQqtyMJKtLAgBEAdNHPnw+n1auXKm33npL77//vvLz882+BULEmRSv6XkZknjkFgBgHtPDx4oVK/Tqq6/qtddeU1pammpqalRTU6PW1lazb4UQ8O9yW8rUCwDAJKaHj40bN8rlcmnRokUaMWJE4HjjjTfMvhVCwL/uY/fxenXRah0AYALT13z4fPxARZMZeRlKdcTpYnO7jpxza8pIp9UlAQAiHHu74Ibi7TbNvSVLElMvAABzED5wU/6pFxadAgDMQPjATfnDx/5PL6m13WtxNQCASEf4wE3lZ6doZEaS2r1d2ltFq3UAwOAQPnBThmEw9QIAMA3hA31SVMg+LwAAcxA+0CcLxmXLMKSj5xtV626zuhwAQAQjfKBPMlMSNLWnxwejHwCAwSB8oM+KCnrWfVQSPgAAA0f4QJ/593nZWVFHJ1sAwIARPtBnM8dkKCnerromj/5e02h1OQCACEX4QJ854uyae8sQSTxyCwAYOMIH+qWoZ+qFfV4AAANF+EC/+JuN/a3qoto6aLUOAOg/wgf6pXBYqnLSHfJ0dmn/p5esLgcAEIEIH+gXwzBUVNDz1EslUy8AgP4jfKDfFo7vabV+jEWnAID+I3yg3xb0NBs7cs6tuiaPxdUAACIN4QP9lp3q0MQR6ZKkXXQ7BQD0E+EDA7KQXW4BAANE+MCAFPWEjzJarQMA+onwgQG5fewQOeJsqnG3qbK2yepyAAARhPCBAUmMt+uO/O5W60y9AAD6g/CBAfN3Oy1j0SkAoB8IHxgwf7OxPSfq1d7ZZXE1AIBIQfjAgN06PE3ZqQlqaffq4ClarQMA+obwgQGz2QwVFfgfuaXVOgCgbwgfGJSiwu6plzIWnQIA+ojwgUHxLzr96IxLl5rbLa4GABAJCB8YlJz0RI3PSZXPJ+0+Xm91OQCACED4wKAV+6deKln3AQC4OcIHBs3far30GK3WAQA3R/jAoM3JH6IEu01nGlr1aX2L1eUAAMIc4QODlpwQp1ljMiXxyC0A4OYIHzCFf+qFfV4AADdD+IApFvYsOt1zvF4dXlqtAwCuj/ABU0zOTVdmcrwaPZ06VN1gdTkAgDBG+IApbDZD8wuYegEA3BzhA6ZZWMg+LwCAmyN8wDT+fV4OnXbJ1dphcTUAgHBF+IBpRmYk6ZahKfJ2+fQBrdYBANdB+ICpinvWfdBqHQBwPYQPmCqwzwuLTgEA1xEXrA/esGGDfvGLX+jcuXOaPHmy1q1bp+Li4mDdDmFi7rgsxdkMfVrfoilP/0mJ8XYlxtuUFG9XUoJdiXF2JSbYlRRvU2K8XUnx9p5r/P/f1n3dFef85xP9n3HFeUecTTabYfU/NgCgH4ISPt544w2tXr1aGzZs0IIFC/Tb3/5WS5Ys0ZEjRzR69Ohg3BJhItURpyVTR+j/HjqrJk+nmjydQb+nI+5ykElK6A4kSQmXg83lgHNFCPrsuStDUELv846e/423GzIMgg4ADJbhC8I2pHPmzNHMmTO1cePGwLmJEydq2bJlKikpueHfut1uOZ1OuVwupaenm1eUzyd1sOlZKPh8PtU2etTa0aW2Du/lo9Ortvbuc60dXnk6L7/f2t6ltk6vPD3XtbZ71dbRpbbOz3xGR/f5dgu6qNpthhJ7go4j7ooQE2cLjMxcOWLjuHJ0x/93PaEm0T8KdEUISuwJTYlxdkZzAARffLJk4n9Q9ef32/SRj/b2dh04cEBPPfVUr/OLFy/W7t27r7re4/HI4/EEXrvdbrNL6tbRIj2fG5zPRi+GpJxg3iC+57CKt+fw3OxCAAhjPzgrJaRYcmvTF5zW1dXJ6/UqJ6f3z09OTo5qamquur6kpEROpzNw5OXlmV0SAAAII0FbcPrZuXGfz3fN+fK1a9dqzZo1gddutzs4ASQ+uTvlAWGqq8snT2eXWv1TVB1dam33T0V1n/f4p6x6zrV19H36qT8TrD71bza2f58dpA/u92f351LTZ6cBS9lsNj0Rn2zZ/U0PH9nZ2bLb7VeNctTW1l41GiJJDodDDofD7DKuZhiWDS8BfWGTlNRzAEA0M33aJSEhQbNmzdK2bdt6nd+2bZvmz59v9u0AAECECcq0y5o1a/TQQw9p9uzZmjdvnl588UWdOnVKjz32WDBuBwAAIkhQwsf999+v+vp6Pfvsszp37pymTJmid955R2PGjAnG7QAAQAQJSp+PwQhanw8AABA0/fn9Zm8XAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUkFprz4Y/oarbrfb4koAAEBf+X+3+9I4PezCR2NjoyQpLy/P4koAAEB/NTY2yul03vCasNvbpaurS2fPnlVaWpoMwzD1s91ut/Ly8lRdXc2+MUHE9xwafM+hw3cdGnzPoRGs79nn86mxsVG5ubmy2W68qiPsRj5sNptGjRoV1Hukp6fzL3YI8D2HBt9z6PBdhwbfc2gE43u+2YiHHwtOAQBASBE+AABASMVU+HA4HHr66aflcDisLiWq8T2HBt9z6PBdhwbfc2iEw/ccdgtOAQBAdIupkQ8AAGA9wgcAAAgpwgcAAAgpwgcAAAipmAkfGzZsUH5+vhITEzVr1izt3LnT6pKiTmlpqZYuXarc3FwZhqEtW7ZYXVJUKikp0e233660tDQNGzZMy5Yt09GjR60uK+ps3LhR06ZNCzRimjdvnv74xz9aXVbUKykpkWEYWr16tdWlRJ1nnnlGhmH0OoYPH25JLTERPt544w2tXr1aP/zhD/Xhhx+quLhYS5Ys0alTp6wuLao0Nzdr+vTpWr9+vdWlRLUdO3ZoxYoV2rNnj7Zt26bOzk4tXrxYzc3NVpcWVUaNGqV///d/1/79+7V//359/vOf17333quPP/7Y6tKi1r59+/Tiiy9q2rRpVpcStSZPnqxz584FjsOHD1tSR0w8ajtnzhzNnDlTGzduDJybOHGili1bppKSEgsri16GYejtt9/WsmXLrC4l6l24cEHDhg3Tjh07tHDhQqvLiWpDhgzRL37xC33zm9+0upSo09TUpJkzZ2rDhg167rnnNGPGDK1bt87qsqLKM888oy1btqi8vNzqUqJ/5KO9vV0HDhzQ4sWLe51fvHixdu/ebVFVgHlcLpek7h9GBIfX69XmzZvV3NysefPmWV1OVFqxYoXuvvtuffGLX7S6lKhWUVGh3Nxc5efn64EHHtCJEycsqSPsNpYzW11dnbxer3Jycnqdz8nJUU1NjUVVAebw+Xxas2aNioqKNGXKFKvLiTqHDx/WvHnz1NbWptTUVL399tuaNGmS1WVFnc2bN+vgwYPat2+f1aVEtTlz5uiVV17R+PHjdf78eT333HOaP3++Pv74Y2VlZYW0lqgPH36GYfR67fP5rjoHRJqVK1fqo48+UllZmdWlRKUJEyaovLxcDQ0NevPNN7V8+XLt2LGDAGKi6upqrVq1Sn/+85+VmJhodTlRbcmSJYH/P3XqVM2bN0/jxo3Tpk2btGbNmpDWEvXhIzs7W3a7/apRjtra2qtGQ4BI8vjjj2vr1q0qLS3VqFGjrC4nKiUkJKigoECSNHv2bO3bt0+/+c1v9Nvf/tbiyqLHgQMHVFtbq1mzZgXOeb1elZaWav369fJ4PLLb7RZWGL1SUlI0depUVVRUhPzeUb/mIyEhQbNmzdK2bdt6nd+2bZvmz59vUVXAwPl8Pq1cuVJvvfWW3n//feXn51tdUszw+XzyeDxWlxFVvvCFL+jw4cMqLy8PHLNnz9aDDz6o8vJygkcQeTweffLJJxoxYkTI7x31Ix+StGbNGj300EOaPXu25s2bpxdffFGnTp3SY489ZnVpUaWpqUmVlZWB11VVVSovL9eQIUM0evRoCyuLLitWrNBrr72mP/zhD0pLSwuM6jmdTiUlJVlcXfT4wQ9+oCVLligvL0+NjY3avHmztm/frnfffdfq0qJKWlraVeuVUlJSlJWVxTomk33ve9/T0qVLNXr0aNXW1uq5556T2+3W8uXLQ15LTISP+++/X/X19Xr22Wd17tw5TZkyRe+8847GjBljdWlRZf/+/brzzjsDr/1ziMuXL9fLL79sUVXRx//I+KJFi3qdf+mll/TII4+EvqAodf78eT300EM6d+6cnE6npk2bpnfffVd33XWX1aUBA3L69Gl97WtfU11dnYYOHaq5c+dqz549lvwWxkSfDwAAED6ifs0HAAAIL4QPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUv8fCM/lx7x5X9QAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "j.output.plot_energies()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "id": "3fb09d42-f800-46ee-9919-83180863e1ee",
    "metadata": {
     "tags": []
@@ -499,12 +423,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d3db4f34e6854a4f9c2c8d065ce81347",
+       "model_id": "fe8ba3dea3e74cf09a80af51a1a8a727",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "NGLWidget(max_frame=11)"
+       "NGLWidget(max_frame=5)"
       ]
      },
      "metadata": {},
@@ -517,14 +441,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "023fbf27-f75c-4177-b35a-a18c33cc2f87",
-   "metadata": {},
-   "source": [
-    "Escape hatch to old HDF output."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "858edf07-75ee-4a40-8cff-c26f34d555f5",
    "metadata": {},
    "source": [
@@ -533,7 +449,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 17,
+   "id": "d32508b9-2854-4076-9109-08ede1b52dc2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[11.28814567708869,\n",
+       " -0.8747049787590951,\n",
+       " -0.9988764739052705,\n",
+       " -0.9999959367316252,\n",
+       " -0.9999999870081488,\n",
+       " -0.999999995888409]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "j.output.pot_energies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "id": "db691097-72c6-45a4-89b1-6ec16018c8b8",
    "metadata": {
     "tags": []
@@ -541,7 +485,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAApYklEQVR4nO3de3BUdZ738c9Jp7tzIelcEHIFcSorCN4G1BUYjTUjT6GyWtY6421E3RqHGlCYVM0A6oyMW5LRWR22zIKLfzC4LkrVo8OwW3MxKwrLeuMiaokP6A4FAYwRDOmEJN1J5zx/JN1JyIV0ck6f7pz3q6prpk93+nynZ8r+zO98f99jmKZpCgAAIEHSnC4AAAC4C+EDAAAkFOEDAAAkFOEDAAAkFOEDAAAkFOEDAAAkFOEDAAAkFOEDAAAkVLrTBZyrq6tLJ0+eVE5OjgzDcLocAAAwAqZpqrm5WSUlJUpLG35tI+nCx8mTJ1VeXu50GQAAYBTq6upUVlY27HuSLnzk5ORI6i4+NzfX4WoAAMBIBINBlZeXx37Hh5N04SN6qSU3N5fwAQBAihlJywQNpwAAIKEIHwAAIKEIHwAAIKGSrucDAACnRSIRdXR0OF1G0vF4PEpPTx/zKAzCBwAAfbS0tOj48eMyTdPpUpJSVlaWiouL5fP5Rv0ZhA8AAHpEIhEdP35cWVlZuuCCCxh22YdpmgqHw/r666915MgRVVRUnHeY2FAIHwAA9Ojo6JBpmrrggguUmZnpdDlJJzMzU16vV0ePHlU4HFZGRsaoPoeGUwAAzsGKx9BGu9rR7zMsqAMAAGDECB8AACChCB8AALjc7373O+Xl5SXsfIQPAACQUK4JH83tHXr2jUNa+X8/Zu82AGBcqays1LJly7Rs2TLl5eWpsLBQjz/+eOz3rrGxUffdd5/y8/OVlZWlhQsX6vPPP5ckvf3223rggQfU1NQkwzBkGIbWrFlja72u2Wrr9aTp+R1fSJJW3zRdeVmjH44CAHAH0zTV1hFx5NyZXk9cu242b96sf/iHf9D777+vvXv36qGHHtLUqVP1ox/9SPfff78+//xzbd++Xbm5uVq5cqVuuukmHTx4UHPnztW6dev0y1/+UocOHZIkTZgwwa7/WJJcFD4yvB5NnODTqZawjje2ET4AAOfV1hHRJb/8iyPnPvjk/1GWb+Q/0+Xl5frtb38rwzB08cUX65NPPtFvf/tbVVZWavv27fqf//kfzZ07V5L07//+7yovL9e2bdt0xx13KBAIyDAMFRUV2fUfpx/XXHaRpNL8LEnS8cY2hysBAMBaf/u3f9tvpeTaa6/V559/roMHDyo9PV3XXHNN7LXCwkJdfPHF+uyzz5wo1T0rH5JUlpepj+rO6Hhjq9OlAABSQKbXo4NP/h/Hzm0n0zQdG6YW98rHrl27tGjRIpWUlMgwDG3bti32WkdHh1auXKlLL71U2dnZKikp0X333aeTJ09aWfOoleV3j8o9cYaVDwDA+RmGoSxfuiOPeIPBe++9N+B5RUWFLrnkEnV2dur999+PvXb69GkdPnxYM2bMkCT5fD5FIonrbYk7fJw9e1aXX365ampqBrzW2tqq/fv36xe/+IX279+v119/XYcPH9bf/d3fWVLsWJX2hA8uuwAAxpu6ujpVVVXp0KFDeuWVV/T8889r+fLlqqio0K233qof/ehH2r17tz766CPde++9Ki0t1a233ipJuvDCC9XS0qI333xTp06dUmurvVcI4r7ssnDhQi1cuHDQ1wKBgGpra/sde/7553X11Vfr2LFjmjJlyuiqtEhs5YPwAQAYZ+677z61tbXp6quvlsfj0cMPP6yHHnpIkrRp0yYtX75ct9xyi8LhsK677jr98Y9/lNfrlSTNnTtXS5Ys0Q9+8AOdPn1aTzzxhK3bbW3v+YjuGx5qclooFFIoFIo9DwaDttVSmhdtOKXnAwAwvni9Xq1bt04bNmwY8Fp+fr5eeumlYf9+w4YNg/6tHWzd7dLe3q5Vq1bp7rvvVm5u7qDvqa6uViAQiD3Ky8ttqyd62SXY3qlge4dt5wEAAEOzLXx0dHTozjvvVFdXl9avXz/k+1avXq2mpqbYo66uzq6SNMGfrvys7iUmLr0AAOAMWy67dHR06Pvf/76OHDmiHTt2DLnqIUl+v19+v9+OMgZVmp+pxtYOHW9s04zioesCACBVvP32206XEBfLVz6iwePzzz/Xf/3Xf6mwsNDqU4xJWU/fxwn6PgAAcETcKx8tLS364osvYs+PHDmiAwcOqKCgQCUlJfr7v/977d+/X//5n/+pSCSi+vp6SVJBQYF8PudHmrPdFgAAZ8UdPvbu3asbbrgh9ryqqkqStHjxYq1Zs0bbt2+XJF1xxRX9/u6tt95SZWXl6Cu1CIPGAABwVtzho7Kycthb0if77epL81j5AADASa66sZwklfXcXI6VDwAAnOG68BHt+fjmbFit4U6HqwEAwH1cFz4CmV7lZHRfbWLWBwBgPKisrNSKFSsGfe3+++/XbbfdltB6zsf28erJqCw/S599GdTxxjZVTM5xuhwAAGzzz//8z0nXj+m6lQ+pb9Mpsz4AAONbIBAY8v5qTnFl+Ihutz1O0ykAYBz685//rEAgoJdeemnAZZfKyko98sgj+vnPf66CggIVFRXZegfbwbj0sgvbbQEAI2CaUodDq+TeLMkw4v6zV199VQ899JD+7d/+Tbfeeqt27Ngx4D2bN29WVVWV3n//fb377ru6//77NW/ePN14441WVH5erg4fNJwCAIbV0SqtLXHm3I+elHzZcf3J+vXr9eijj+oPf/hDv4Gg57rsssv0xBNPSJIqKipUU1OjN998k/Bhp9Ke+7uw8gEAGC9ee+01ffXVV9q9e7euvvrqYd972WWX9XteXFyshoYGO8vrx5XhI7rycaolpPaOiDK8HocrAgAkJW9W9wqEU+eOwxVXXKH9+/dr06ZNuuqqq2QMc8nG6/X2e24Yhrq6ukZV5mi4MnzkZXmV5fOoNRzRiTNt+tYFE5wuCQCQjAwj7ksfTvnWt76lZ599VpWVlfJ4PKqpqXG6pCG5creLYRj0fQAAxp2/+Zu/0VtvvaXXXnttyKFjycCVKx9S96Cxw1+10PcBABhXLr74Yu3YsSO2ApKMXBs+GDQGABgv3n777X7PZ8yYoa+++mpE75Wkbdu2WV/UMFx52UXqs92WQWMAACSUa8NHKYPGAABwhGvDR1l+9xYmGk4BAEgs14aPaM/HV83tCncmbm8zAABu59rwMXGCT/70NJmm9GUTqx8AACSKa8OHYRj0fQAABmWaptMlJC0rvhvXhg+Jvg8AQH/RuRjhcNjhSpJXa2v3iIpzR7THw7VzPqTe7bbM+gAASFJ6erqysrL09ddfy+v1Ki3N1f8fvR/TNNXa2qqGhgbl5eWNaYCZq8NH76AxVj4AAN2X5IuLi3XkyBEdPXrU6XKSUl5enoqKisb0Ga4OH7GVDwaNAQB6+Hw+VVRUcOllEF6v15KR7YQP0fMBAOgvLS1NGRkZTpcxbrn6Yla04bQ+2K7OCLM+AABIBFeHjwsm+OXzpCnSZerLpnanywEAwBVcHT7S0gyV5HUvq3GDOQAAEsPV4UPiBnMAACSa68NHWR6DxgAASCTCB4PGAABIKNeHDy67AACQWK4PH7H7u9BwCgBAQrg+fERXPk6eaVOki7sYAgBgN9eHj8k5fqWnGersMtXQzKwPAADs5vrwke5JU1Gge9YHfR8AANjP9eFD4h4vAAAkEuFDUmnPrA+22wIAYD/Ch/qsfLDjBQAA2xE+1HfQGOEDAAC7ET7EoDEAABKJ8CGpvM+gsS5mfQAAYCvCh6SiQIbSDCnc2aVTLSGnywEAYFwjfEjyetJUlNsz64OmUwAAbBV3+Ni1a5cWLVqkkpISGYahbdu29XvdNE2tWbNGJSUlyszMVGVlpT799FOr6rUNfR8AACRG3OHj7Nmzuvzyy1VTUzPo688884yee+451dTUaM+ePSoqKtKNN96o5ubmMRdrp9gN5ggfAADYKj3eP1i4cKEWLlw46GumaWrdunV67LHHdPvtt0uSNm/erMmTJ2vLli368Y9/PLZqbVSaF135YNAYAAB2srTn48iRI6qvr9eCBQtix/x+v66//nq98847g/5NKBRSMBjs93ACg8YAAEgMS8NHfX29JGny5Mn9jk+ePDn22rmqq6sVCARij/LycitLGrHoZRd6PgAAsJctu10Mw+j33DTNAceiVq9eraamptijrq7OjpLOq7fhtFWmyawPAADsEnfPx3CKiookda+AFBcXx443NDQMWA2J8vv98vv9VpYxKiV53Vtt2zu69M3ZsAonOF8TAADjkaUrH9OmTVNRUZFqa2tjx8LhsHbu3Km5c+daeSrL+dM9mpTTHTi49AIAgH3iXvloaWnRF198EXt+5MgRHThwQAUFBZoyZYpWrFihtWvXqqKiQhUVFVq7dq2ysrJ09913W1q4HcryM9XQHNKJM226vDzP6XIAABiX4g4fe/fu1Q033BB7XlVVJUlavHixfve73+nnP/+52tra9JOf/ESNjY265ppr9MYbbygnJ8e6qm1Smp+l/cfOsN0WAAAbxR0+Kisrh23INAxDa9as0Zo1a8ZSlyNi22257AIAgG24t0sfvYPGCB8AANiF8NEHg8YAALAf4aOPvoPGmPUBAIA9CB99RC+7tIQ6FWzrdLgaAADGJ8JHH5k+jyZO8EmS6tjxAgCALQgf56DpFAAAexE+zhHt+6DpFAAAexA+ztH3BnMAAMB6hI9zMGgMAAB7ET7OQc8HAAD2Inycg54PAADsRfg4R7Tno6mtQ83tHQ5XAwDA+EP4OMcEf7rysrySWP0AAMAOhI9BRJtOj39D+AAAwGqEj0H0Np2y3RYAAKsRPgZB0ykAAPYhfAyC7bYAANiH8DGI2KAxVj4AALAc4WMQvSPWCR8AAFiN8DGIaM/HN2fDag13OlwNAADjC+FjEIFMr3Iy0iVxjxcAAKxG+BhCrOmUvg8AACxF+BhC9NILfR8AAFiL8DGE2JRTBo0BAGApwscQYtttWfkAAMBShI8hMGgMAAB7ED6GwIh1AADsQfgYQnTQ2NfNIbV3RByuBgCA8YPwMYT8LK+yfB5J0klWPwAAsAzhYwiGYfTZ8UL4AADAKoSPYUSbTun7AADAOoSPYfQOGmPWBwAAViF8DIO72wIAYD3CxzAYNAYAgPUIH8Ng0BgAANYjfAwj2vPxVXO7wp1dDlcDAMD4QPgYxsQJPvnT02Sa0pdNrH4AAGAFwscwDMOINZ3S9wEAgDUIH+fRu92W8AEAgBUIH+cRazpl0BgAAJYgfJxH74h1Bo0BAGAFwsd5cH8XAACsRfg4DwaNAQBgLcLHeZTmdTec1gfb1Rlh1gcAAGNlefjo7OzU448/rmnTpikzM1MXXXSRnnzySXV1peYP96Qcv7weQ5EuU/XBdqfLAQAg5aVb/YFPP/20XnjhBW3evFkzZ87U3r179cADDygQCGj58uVWn852aWmGSvIydfR0q443tsW23gIAgNGxPHy8++67uvXWW3XzzTdLki688EK98sor2rt3r9WnSpiy/O7wQd8HAABjZ/lll/nz5+vNN9/U4cOHJUkfffSRdu/erZtuumnQ94dCIQWDwX6PZFOWx6AxAACsYvnKx8qVK9XU1KTp06fL4/EoEonoqaee0l133TXo+6urq/WrX/3K6jIsFRuxfoZZHwAAjJXlKx9bt27Vyy+/rC1btmj//v3avHmz/umf/kmbN28e9P2rV69WU1NT7FFXV2d1SWPGrA8AAKxj+crHz372M61atUp33nmnJOnSSy/V0aNHVV1drcWLFw94v9/vl9/vt7oMS8VGrBM+AAAYM8tXPlpbW5WW1v9jPR5Pym61laSygu6ejy+b2hTpMh2uBgCA1Gb5yseiRYv01FNPacqUKZo5c6Y+/PBDPffcc3rwwQetPlXCTM7xy5NmqCNiqqG5XcWBTKdLAgAgZVkePp5//nn94he/0E9+8hM1NDSopKREP/7xj/XLX/7S6lMlTLonTcWBDB1vbNOJxjbCBwAAY2B5+MjJydG6deu0bt06qz/aUaV5mTre2KbjjW2ac6HT1QAAkLq4t8sIRSebnjhD0ykAAGNB+Bih3u22zPoAAGAsCB8jVMqsDwAALEH4GKHoygf3dwEAYGwIHyMUu7/LmTZ1MesDAIBRI3yMUFEgQ2mGFO7s0qmzIafLAQAgZRE+RsiXnqbJuRmS6PsAAGAsCB9xoO8DAICxI3zEgRvMAQAwdoSPOPQOGmPWBwAAo0X4iEMZsz4AABgzwkccSun5AABgzAgfcYhedjne2CbTZNYHAACjQfiIQ3Gge6ttW0dEja0dDlcDAEBqInzEIcPr0aQcvyRuMAcAwGgRPuLEDeYAABgbwkecYtttCR8AAIwK4SNOvYPGuOwCAMBoED7iFBuxfoaVDwAARoPwEScGjQEAMDaEjzj1vbkcsz4AAIgf4SNOpXndDafNoU4F2zodrgYAgNRD+IhTps+jwmyfJOk4N5gDACBuhI9RoO8DAIDRI3yMAoPGAAAYPcLHKDBoDACA0SN8jAKDxgAAGD3CxygwaAwAgNEjfIxC9LILPR8AAMSP8DEK0YbTprYONbd3OFwNAACphfAxChP86crL8kri0gsAAPEifIxStOmUHS8AAMSH8DFKDBoDAGB0CB+jFL3HC9ttAQCID+FjlNhuCwDA6BA+RokR6wAAjA7hY5RiKx+EDwAA4kL4GKXooLHTZ8NqDXc6XA0AAKmD8DFKgUyvcvzpkqST9H0AADBihI8xiPZ91HHpBQCAESN8jAF9HwAAxI/wMQbcYA4AgPgRPsYgOmKdQWMAAIycLeHjxIkTuvfee1VYWKisrCxdccUV2rdvnx2nchSDxgAAiF+61R/Y2NioefPm6YYbbtCf/vQnTZo0Sf/7v/+rvLw8q0/lOAaNAQAQP8vDx9NPP63y8nJt2rQpduzCCy+0+jRJIdrz8XVzSO0dEWV4PQ5XBABA8rP8ssv27ds1Z84c3XHHHZo0aZKuvPJKvfjii0O+PxQKKRgM9nukivwsrzJ7AgezPgAAGBnLw8df//pXbdiwQRUVFfrLX/6iJUuW6JFHHtFLL7006Purq6sVCARij/LycqtLso1hGPR9AAAQJ8M0TdPKD/T5fJozZ47eeeed2LFHHnlEe/bs0bvvvjvg/aFQSKFQKPY8GAyqvLxcTU1Nys3NtbI0Wzyw6QO9dehrVd9+qe66eorT5QAA4IhgMKhAIDCi32/LVz6Ki4t1ySWX9Ds2Y8YMHTt2bND3+/1+5ebm9nukklIGjQEAEBfLw8e8efN06NChfscOHz6sqVOnWn2qpNA7aIxZHwAAjITl4eOnP/2p3nvvPa1du1ZffPGFtmzZoo0bN2rp0qVWnyop9A4aY+UDAICRsDx8XHXVVfr973+vV155RbNmzdI//uM/at26dbrnnnusPlVSoOEUAID4WD7nQ5JuueUW3XLLLXZ8dNKJ9nzUB9sV7uySL52J9QAADIdfyjG6YIJf/vQ0maZU39TudDkAACQ9wscYGYbBDeYAAIgD4cMCsXu80PcBAMB5ET4s0LvdlvABAMD5ED4sUMagMQAARozwYYFo+KDnAwCA8yN8WIBBYwAAjBzhwwLRno/6YLs6I10OVwMAQHIjfFhgUo5fXo+hSJep+iCzPgAAGA7hwwJpaYZK8mg6BQBgJAgfFqHvAwCAkSF8WIQbzAEAMDKED4v0Dhpjuy0AAMMhfFgketmFlQ8AAIZH+LBI76AxwgcAAMMhfFgkenO5k2fa1NVlOlwNAADJi/BhkaLcDHnSDHVETDU0h5wuBwCApEX4sEi6J01FuRmSaDoFAGA4hA8Lsd0WAIDzI3xYqJSmUwAAzovwYaHeWR+EDwAAhkL4sFDvdlt6PgAAGArhw0JlDBoDAOC8CB8Wil52OdHYJtNk1gcAAIMhfFioKJAhw5BCnV061RJ2uhwAAJIS4cNCvnRmfQAAcD6ED4tFbzDHjhcAAAZH+LAYg8YAABge4cNipWy3BQBgWIQPi/Xd8QIAAAYifFisjBHrAAAMi/BhsdI+g8aY9QEAwECED4uV9ISP1nBEja0dDlcDAEDyIXxYLMPr0QU5fkn0fQAAMBjChw24wRwAAEMjfNiAQWMAAAyN8GGD2HZbBo0BADAA4cMGDBoDAGBohA8bMOsDAIChET5sUB69vwvhAwCAAQgfNojO+mgOdaqpjVkfAAD0RfiwQZYvXYXZPkn0fQAAcC7Ch01KufQCAMCgCB82oekUAIDB2R4+qqurZRiGVqxYYfepkgqDxgAAGJyt4WPPnj3auHGjLrvsMjtPk5R6B43R8wEAQF+2hY+Wlhbdc889evHFF5Wfn2/XaZIWKx8AAAzOtvCxdOlS3Xzzzfre97437PtCoZCCwWC/x3hQVtDTcMqIdQAA+km340NfffVV7d+/X3v27Dnve6urq/WrX/3KjjIcFV35ONPaoZZQpyb4bfmqAQBIOZavfNTV1Wn58uV6+eWXlZGRcd73r169Wk1NTbFHXV2d1SU5IifDq0CmVxLbbQEA6Mvy/zu+b98+NTQ0aPbs2bFjkUhEu3btUk1NjUKhkDweT+w1v98vv99vdRlJoSw/U01tHTre2KqLi3KcLgcAgKRgefj47ne/q08++aTfsQceeEDTp0/XypUr+wWP8a40L1OfngzS9wEAQB+Wh4+cnBzNmjWr37Hs7GwVFhYOOD7eRbfbsuMFAIBeTDi1UWlsyimzPgAAiErIFoy33347EadJOmXc3wUAgAFY+bARg8YAABiI8GGj8p6ej9Nnw2oLRxyuBgCA5ED4sFFuZrpyeoaLcY8XAAC6ET5sZBhGn6ZTLr0AACARPmxXRvgAAKAfwofNok2nDBoDAKAb4cNmDBoDAKA/wofNGDQGAEB/hA+bMWgMAID+CB82i/Z8NDSH1N7BrA8AAAgfNivI9inT230n3y+b2h2uBgAA5xE+bGYYRp/ttvR9AABA+EiAUvo+AACIIXwkAIPGAADoRfhIgNK87lkfDBoDAIDwkRD0fAAA0IvwkQDcXA4AgF6EjwSIrnx8FWxXuLPL4WoAAHAW4SMBJmb75UtPU5cp1TPrAwDgcoSPBEhLM1TWM+n0+Bn6PgAA7kb4SBD6PgAA6Eb4SBBuMAcAQDfCR4KU5XfP+mDlAwDgdoSPBIne3fYEPR8AAJcjfCQII9YBAOhG+EiQaMNpfVO7OiPM+gAAuBfhI0Em5WTI6zHU2WXqq+aQ0+UAAOAYwkeCeNIMFQd6Lr18Q98HAMC9CB8JFNtuy91tAQAuRvhIIJpOAQAgfCRUaV73rA8GjQEA3IzwkUCxlQ9mfQAAXIzwkUCljFgHAIDwkUjRlY+TZ9rV1WU6XA0AAM4gfCRQUW6GPGmGwpEufd3CrA8AgDsRPhIo3ZOmotwMSdLxRvo+AADuRPhIsFK22wIAXI7wkWDM+gAAuB3hI8HK8rtnfRA+AABuRfhIsLI8RqwDANyN8JFgvZddaDgFALgT4SPB+g4aM01mfQAA3IfwkWDFgUwZhhTq7NKplrDT5QAAkHCEjwTzpadpck73rA/6PgAAbmR5+KiurtZVV12lnJwcTZo0SbfddpsOHTpk9WlSGn0fAAA3szx87Ny5U0uXLtV7772n2tpadXZ2asGCBTp79qzVp0pZDBoDALhZutUf+Oc//7nf802bNmnSpEnat2+frrvuOqtPl5LKuLstAMDFLA8f52pqapIkFRQUDPp6KBRSKNR7k7VgMGh3SY7rHTTGZRcAgPvY2nBqmqaqqqo0f/58zZo1a9D3VFdXKxAIxB7l5eV2lpQUShk0BgBwMVvDx7Jly/Txxx/rlVdeGfI9q1evVlNTU+xRV1dnZ0lJoe/9XZj1AQBwG9suuzz88MPavn27du3apbKysiHf5/f75ff77SojKZX0rHy0hiM609qh/GyfwxUBAJA4lq98mKapZcuW6fXXX9eOHTs0bdo0q0+R8jK8Hl2Q0x242PECAHAby8PH0qVL9fLLL2vLli3KyclRfX296uvr1dbGj2xfvX0fNJ0CANzF8vCxYcMGNTU1qbKyUsXFxbHH1q1brT5VSitj1gcAwKUs7/mggXJkGDQGAHAr7u3ikN5ZH4QPAIC7ED4cwv1dAABuRfhwSBmDxgAALkX4cEi056O5vVNNbR0OVwMAQOIQPhyS5UtXQc9wMW4wBwBwE8KHg+j7AAC4EeHDQdxgDgDgRoQPBzFoDADgRoQPB0VXPrjsAgBwE8KHg6KDxrjsAgBwE8KHg8oKuOwCAHAfwoeDopddzrR2qCXU6XA1AAAkBuHDQTkZXgUyvZKY9QEAcA/Ch8N6t9vSdAoAcAfCh8PYbgsAcBvCh8Oi93jhsgsAwC0IHw6Lbrdl5QMA4BaED4cxaAwA4DaED4dFez4YNAYAcAvCh8PKey67nGoJqy0ccbgaAADsR/hwWG5muib40yWx+gEAcAfCh8MMw+iz3Za+DwDA+Ef4SAK9g8ZY+QAAjH+EjyTAoDEAgJsQPpIAg8YAAG5C+EgCvYPG6PkAAIx/hI8kQM8HAMBNCB9JINrz8VUwpFAnsz4AAOMb4SMJFGT7lOn1SJJOnml3uBoAAOxF+EgChmHQdAoAcA3CR5Jg0BgAwC0IH0mCplMAgFsQPpJE73ZbwgcAYHwjfCQJej4AAG5B+EgS9HwAANyC8JEkynp6PuqD7eqIdDlcDQAA9iF8JImJE/zypaepy5Tqm5j1AQAYvwgfSSItzYitftRx6QUAMI4RPpIITacAADcgfCSR3qZTwgcAYPwifCQRBo0BANyA8JFEegeN0fMBABi/CB9JJNbzwcoHAGAcS7frg9evX6/f/OY3+vLLLzVz5kytW7dO3/nOd+w63bgQ7fmo+6ZN8369Q4UTfCrI9qkw2x/79wXZPk2c4FNBtl+FPc+zfB4ZhuFw9QAAjIwt4WPr1q1asWKF1q9fr3nz5ulf//VftXDhQh08eFBTpkyx45TjwuScDE0vytH/q2/WiTNtI14B8aenaeIEfyycFGb7esJKb0ApmODTxGy/Cib4lE1YAQA4yDBN07T6Q6+55hp9+9vf1oYNG2LHZsyYodtuu03V1dXD/m0wGFQgEFBTU5Nyc3OtK8o0pY7k76XoiHTpy6Z2fXM2rNNnw2o8G9I3rR1qbAmrsTWsU2e7/7WxJaxvWsMKdcY/DdWXnqaCrO5Akp/VHVbys3zKz/apMNur/Gx/9+vZPhVkezXBn05YAYDxxpslWfjP9nh+vy1f+QiHw9q3b59WrVrV7/iCBQv0zjvvDHh/KBRSKBSKPQ8Gg1aX1K2jVVpbYs9nW8graUrP47zSNfr/BsOSvul5AADc59GTki/bkVNb3nB66tQpRSIRTZ48ud/xyZMnq76+fsD7q6urFQgEYo/y8nKrSwIAAEnEtobTc5fpTdMcdOl+9erVqqqqij0PBoP2BBBvVnfKQ1zaOyL6pjWs0z2Xebov/3SorSMy4L2DXcAzNfDg4O8bxCBvHPx9IzsvAKBbWlqaHvFmOXZ+y8PHxIkT5fF4BqxyNDQ0DFgNkSS/3y+/3291GQMZhmPLS6kswyeVZEslFzhdCQBgvLD8sovP59Ps2bNVW1vb73htba3mzp1r9ekAAECKseWyS1VVlX74wx9qzpw5uvbaa7Vx40YdO3ZMS5YsseN0AAAghdgSPn7wgx/o9OnTevLJJ/Xll19q1qxZ+uMf/6ipU6facToAAJBCbJnzMRa2zfkAAAC2ief3m3u7AACAhCJ8AACAhCJ8AACAhCJ8AACAhCJ8AACAhCJ8AACAhCJ8AACAhCJ8AACAhCJ8AACAhLJlvPpYRAeuBoNBhysBAAAjFf3dHsng9KQLH83NzZKk8vJyhysBAADxam5uViAQGPY9SXdvl66uLp08eVI5OTkyDMPSzw4GgyovL1ddXR33jRkDvkdr8D1ag+/RGnyP1nDz92iappqbm1VSUqK0tOG7OpJu5SMtLU1lZWW2niM3N9d1/6OwA9+jNfgercH3aA2+R2u49Xs834pHFA2nAAAgoQgfAAAgoVwVPvx+v5544gn5/X6nS0lpfI/W4Hu0Bt+jNfgercH3ODJJ13AKAADGN1etfAAAAOcRPgAAQEIRPgAAQEIRPgAAQEK5JnysX79e06ZNU0ZGhmbPnq3//u//drqklFNdXa2rrrpKOTk5mjRpkm677TYdOnTI6bJSWnV1tQzD0IoVK5wuJSWdOHFC9957rwoLC5WVlaUrrrhC+/btc7qslNLZ2anHH39c06ZNU2Zmpi666CI9+eST6urqcrq0pLZr1y4tWrRIJSUlMgxD27Zt6/e6aZpas2aNSkpKlJmZqcrKSn366afOFJuEXBE+tm7dqhUrVuixxx7Thx9+qO985ztauHChjh075nRpKWXnzp1aunSp3nvvPdXW1qqzs1MLFizQ2bNnnS4tJe3Zs0cbN27UZZdd5nQpKamxsVHz5s2T1+vVn/70Jx08eFDPPvus8vLynC4tpTz99NN64YUXVFNTo88++0zPPPOMfvOb3+j55593urSkdvbsWV1++eWqqakZ9PVnnnlGzz33nGpqarRnzx4VFRXpxhtvjN2/zPVMF7j66qvNJUuW9Ds2ffp0c9WqVQ5VND40NDSYksydO3c6XUrKaW5uNisqKsza2lrz+uuvN5cvX+50SSln5cqV5vz5850uI+XdfPPN5oMPPtjv2O23327ee++9DlWUeiSZv//972PPu7q6zKKiIvPXv/517Fh7e7sZCATMF154wYEKk8+4X/kIh8Pat2+fFixY0O/4ggUL9M477zhU1fjQ1NQkSSooKHC4ktSzdOlS3Xzzzfre977ndCkpa/v27ZozZ47uuOMOTZo0SVdeeaVefPFFp8tKOfPnz9ebb76pw4cPS5I++ugj7d69WzfddJPDlaWuI0eOqL6+vt/vjt/v1/XXX8/vTo+ku7Gc1U6dOqVIJKLJkyf3Oz558mTV19c7VFXqM01TVVVVmj9/vmbNmuV0OSnl1Vdf1f79+7Vnzx6nS0lpf/3rX7VhwwZVVVXp0Ucf1QcffKBHHnlEfr9f9913n9PlpYyVK1eqqalJ06dPl8fjUSQS0VNPPaW77rrL6dJSVvS3ZbDfnaNHjzpRUtIZ9+EjyjCMfs9N0xxwDCO3bNkyffzxx9q9e7fTpaSUuro6LV++XG+88YYyMjKcLieldXV1ac6cOVq7dq0k6corr9Snn36qDRs2ED7isHXrVr388svasmWLZs6cqQMHDmjFihUqKSnR4sWLnS4vpfG7M7RxHz4mTpwoj8czYJWjoaFhQCrFyDz88MPavn27du3apbKyMqfLSSn79u1TQ0ODZs+eHTsWiUS0a9cu1dTUKBQKyePxOFhh6iguLtYll1zS79iMGTP02muvOVRRavrZz36mVatW6c4775QkXXrppTp69Kiqq6sJH6NUVFQkqXsFpLi4OHac351e477nw+fzafbs2aqtre13vLa2VnPnznWoqtRkmqaWLVum119/XTt27NC0adOcLinlfPe739Unn3yiAwcOxB5z5szRPffcowMHDhA84jBv3rwBW70PHz6sqVOnOlRRamptbVVaWv+fAo/Hw1bbMZg2bZqKior6/e6Ew2Ht3LmT350e437lQ5Kqqqr0wx/+UHPmzNG1116rjRs36tixY1qyZInTpaWUpUuXasuWLfrDH/6gnJyc2GpSIBBQZmamw9WlhpycnAE9MtnZ2SosLKR3Jk4//elPNXfuXK1du1bf//739cEHH2jjxo3auHGj06WllEWLFumpp57SlClTNHPmTH344Yd67rnn9OCDDzpdWlJraWnRF198EXt+5MgRHThwQAUFBZoyZYpWrFihtWvXqqKiQhUVFVq7dq2ysrJ09913O1h1EnF2s03i/Mu//Is5depU0+fzmd/+9rfZHjoKkgZ9bNq0yenSUhpbbUfvP/7jP8xZs2aZfr/fnD59urlx40anS0o5wWDQXL58uTllyhQzIyPDvOiii8zHHnvMDIVCTpeW1N56661B/3m4ePFi0zS7t9s+8cQTZlFRken3+83rrrvO/OSTT5wtOokYpmmaDuUeAADgQuO+5wMAACQXwgcAAEgowgcAAEgowgcAAEgowgcAAEgowgcAAEgowgcAAEgowgcAAEgowgcAAEgowgcAAEgowgcAAEgowgcAAEio/w9hHopmxnvDfAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGdCAYAAACyzRGfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAur0lEQVR4nO3de3SU9b3v8c8zk2Ryn4QEAoEAkQTkjoBySyi2lb2osmX12GprFd1dbV0Fhc3qrtJ2V7e1ZrfdbemSA7v2rKN4rOJaW6Wcs6wt1UIICOVikC0WEogQLiEkkJlcJ8lkzh/JDERuuTwzz1zer7We1c4zT+b5Osu15uPv93u+P8Pn8/kEAAAQIjarCwAAALGF8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEKK8AEAAEIqzuoCPqurq0tnz55VWlqaDMOwuhwAANAHPp9PjY2Nys3Nlc1247GNsAsfZ8+eVV5entVlAACAAaiurtaoUaNueE3YhY+0tDRJ3cWnp6dbXA0AAOgLt9utvLy8wO/4jYRd+PBPtaSnpxM+AACIMH1ZMsGCUwAAEFKEDwAAEFKEDwAAEFJht+YDAACreb1edXR0WF1G2LHb7YqLixt0KwzCBwAAV2hqatLp06fl8/msLiUsJScna8SIEUpISBjwZxA+AADo4fV6dfr0aSUnJ2vo0KE0u7yCz+dTe3u7Lly4oKqqKhUWFt60mdj1ED4AAOjR0dEhn8+noUOHKikpyepywk5SUpLi4+N18uRJtbe3KzExcUCfw4JTAAA+gxGP6xvoaEevzzChDgAAgD4jfAAAgJAifAAAEONefvllZWRkhOx+hA8AABBSMRM+GlratXH7cX3/vw5ZXQoAAKZatGiRVq5cqZUrVyojI0NZWVn60Y9+FOhVcunSJT388MPKzMxUcnKylixZooqKCknS9u3b9eijj8rlcskwDBmGoWeeeSao9cbUo7Y//9Pf5fNJa+6aoOHOgT0eBACIHT6fT60dXkvunRRv79dTN5s2bdI3v/lN7d27V/v379e3v/1tjRkzRt/61rf0yCOPqKKiQlu3blV6erqefPJJfelLX9KRI0c0f/58rVu3Tj/+8Y919OhRSVJqamqw/rEkxVD4yEhO0LSRTh067dLOigv6yuw8q0sCAIS51g6vJv34T5bc+8iz/6DkhL7/TOfl5enXv/61DMPQhAkTdPjwYf3617/WokWLtHXrVu3atUvz58+XJP3+979XXl6etmzZoq985StyOp0yDEPDhw8P1j9OLzEz7SJJRYXZkqSyyjqLKwEAwFxz587tNVIyb948VVRU6MiRI4qLi9OcOXMC72VlZWnChAn65JNPrCg1dkY+JKm4cKj+51+Pa1dlnbq6fLLZaCIDALi+pHi7jjz7D5bdO5h8Pp9lzdT6PfJRWlqqpUuXKjc3V4ZhaMuWLYH3Ojo69OSTT2rq1KlKSUlRbm6uHn74YZ09e9bMmgds5uhMJSfYVdfUrk9q3FaXAwAIc4ZhKDkhzpKjv8Fgz549V70uLCzUpEmT1NnZqb179wbeq6+v17FjxzRx4kRJUkJCgrze0K1t6Xf4aG5u1vTp07V+/fqr3mtpadHBgwf1r//6rzp48KDeeustHTt2TP/4j/9oSrGDlRBn09xbsiRJZRVMvQAAokd1dbXWrFmjo0eP6vXXX9cLL7ygVatWqbCwUPfee6++9a1vqaysTIcOHdI3vvENjRw5Uvfee68kaezYsWpqatJ7772nuro6tbS0BLXWfk+7LFmyREuWLLnme06nU9u2bet17oUXXtAdd9yhU6dOafTo0QOr0kRFBdl6/++12llRp+98bpzV5QAAYIqHH35Yra2tuuOOO2S32/X444/r29/+tiTppZde0qpVq3TPPfeovb1dCxcu1DvvvKP4+HhJ0vz58/XYY4/p/vvvV319vZ5++umgPm4b9DUf/ueGr9c5zePxyOPxBF673cGdDinuWXT6t08vqq3Dq8Qgz6kBABAK8fHxWrdunTZu3HjVe5mZmXrllVdu+PcbN2685t8GQ1Cfdmlra9NTTz2lr3/960pPT7/mNSUlJXI6nYEjLy+4j8AWDEvV8PREtXd2ad+nF4N6LwAAcLWghY+Ojg498MAD6urq0oYNG6573dq1a+VyuQJHdXV1sEqS1L14yP/I7U7WfQAAEHJBmXbp6OjQV7/6VVVVVen999+/7qiHJDkcDjkcjmCUcV3Fhdn6rwOnCR8AgKiwfft2q0voF9NHPvzBo6KiQn/5y1+UlZVl9i0GbUFB98jHJ+fcutDoucnVAADATP0OH01NTSovL1d5ebkkqaqqSuXl5Tp16pQ6Ozt13333af/+/fr9738vr9ermpoa1dTUqL293ezaByw71aHJud2jMbvodgoAQEj1O3zs379ft912m2677TZJ0po1a3Tbbbfpxz/+sU6fPq2tW7fq9OnTmjFjhkaMGBE4du/ebXrxg+Ff91FaccHiSgAAiC39XvOxaNGiwBa913Kj98JJccFQ/XbHCZVV1FnaYhYAgFgTUxvLXWn22Ew54myqbfSoorbJ6nIAAIgZMRs+EuPtuiN/iCSp9BhTLwAAhErMhg9JWlg4VJJUxqJTAEAEW7RokVavXn3N9x555BEtW7YspPXcTNDbq4cz/6LTPSfq5en0yhFHq3UAQHT5zW9+E3brMWN65OPW4WnKTnWoraNLB05esrocAABM53Q6r7u/mlViOnwYhhHYaK6MbqcAgCjx7rvvyul06pVXXrlq2mXRokV64okn9P3vf19DhgzR8OHDg7qD7bXEdPiQpKIC9nkBAFyHzye1N1tzDHCqZPPmzfrqV7+qV155RQ8//PA1r9m0aZNSUlK0d+9e/fznP9ezzz6rbdu2Deab6peYXvMhKTDy8d9nXbrY3K4hKQkWVwQACBsdLdLzudbc+wdnpYSUfv3Jhg0b9IMf/EB/+MMfdOedd173umnTpunpp5+WJBUWFmr9+vV67733dNdddw2q5L6K+fAxLD1RE3LSdPR8o3ZV1mnpdIv+JQMAYBDefPNNnT9/XmVlZbrjjjtueO20adN6vR4xYoRqa2uDWV4vMR8+pO7Rj6PnG1VWQfgAAFwhPrl7BMKqe/fDjBkzdPDgQb300ku6/fbbb9i5Oz4+vtdrwzDU1dU1oDIHgvCh7kdu/1dZlXZWXKDVOgDgMsPo99SHVcaNG6df/vKXWrRokex2u9avX291SdcV8wtOJWlOfpYS7DaddbXpRF2z1eUAADAg48eP11//+le9+eab1206Fg4Y+ZCUlGDX7LGZ2n28XmUVdRo3NNXqkgAAGJAJEybo/fffD4yAhCPCR4+iwmztPl6vnRUXtHz+WKvLAQCgz7Zv397r9cSJE3X+/Pk+XStJW7ZsMb+oG2DapYd/n5cPjterwxu6RTcAAMQawkePSSPSNSQlQc3tXn14qsHqcgAAiFqEjx42m6EFBf5W6xcsrgYAgOhF+LhCsb/VeiWt1gEACBbCxxWKelqtH6pukKulw+JqAACIToSPK+RmJGnc0BR1+aQPTjD6AQCxyjfATd1igRnfDeHjM4p7nnopZZdbAIg5/r4Y7e3tFlcSvlpaWiRd3aK9P+jz8RnFhdl6efenKiN8AEDMiYuLU3Jysi5cuKD4+HjZbPw3up/P51NLS4tqa2uVkZExqAZmhI/PmHNLluJshk5dbNHJ+maNyYqMnv4AgMEzDEMjRoxQVVWVTp48aXU5YSkjI0PDhw8f1GcQPj4j1RGnmWMy9beqi9pZUUf4AIAYk5CQoMLCQqZeriE+Pt6Ulu2Ej2soLsjW36ouqqyiTt+YO8bqcgAAIWaz2ZSYmGh1GVGLyaxr8D9yu+t4nTpptQ4AgKkIH9cwbVSG0hPj1NjWqY/OuKwuBwCAqEL4uAb7Fa3Wdx7jqRcAAMxE+LgOf7+Pskr2eQEAwEyEj+so7ln38eGpBjW20WodAACzED6uI29IssZkJauzy6c9Jy5aXQ4AAFGD8HED/tGPsgqmXgAAMAvh4waKCrrXfeyk1ToAAKYhfNzAvHFZstsMnahr1ulLLVaXAwBAVCB83IAzKV7TRzkliY3mAAAwCeHjJvyP3O6sJHwAAGAGwsdN+Bed7qqsk7fLZ3E1AABEPsLHTUzPy1CqI04NLR36+Cyt1gEAGCzCx03E222aNy5LEk+9AABgBsJHH/inXnbS7wMAgEEjfPSBf9HpgZOX1NLeaXE1AABENsJHH4zNStbIjCR1eH3aW0WrdQAABoPw0QeGYVyeejnGug8AAAaD8NFH/qmXskrWfQAAMBj9Dh+lpaVaunSpcnNzZRiGtmzZ0ut9n8+nZ555Rrm5uUpKStKiRYv08ccfm1WvZeaPy5JhSMfON6nG1WZ1OQAARKx+h4/m5mZNnz5d69evv+b7P//5z/WrX/1K69ev1759+zR8+HDdddddamxsHHSxVspMSdC0kT2t1ul2CgDAgPU7fCxZskTPPfecvvzlL1/1ns/n07p16/TDH/5QX/7ylzVlyhRt2rRJLS0teu2110wp2EpFPHILAMCgmbrmo6qqSjU1NVq8eHHgnMPh0Oc+9znt3r37mn/j8Xjkdrt7HeHKv+5jV2Wdumi1DgDAgJgaPmpqaiRJOTk5vc7n5OQE3vuskpISOZ3OwJGXl2dmSaaaOTpTyQl21TW16+81kT2NBACAVYLytIthGL1e+3y+q875rV27Vi6XK3BUV1cHoyRTJMTZNCd/iCSmXgAAGChTw8fw4cMl6apRjtra2qtGQ/wcDofS09N7HeHs8iO3LDoFAGAgTA0f+fn5Gj58uLZt2xY4197erh07dmj+/Plm3soy/mZje6suqq3Da3E1AABEnrj+/kFTU5MqKysDr6uqqlReXq4hQ4Zo9OjRWr16tZ5//nkVFhaqsLBQzz//vJKTk/X1r3/d1MKtUjAsVcPTE1XjbtO+Ty8GRkIAAEDf9Dt87N+/X3feeWfg9Zo1ayRJy5cv18svv6zvf//7am1t1Xe/+11dunRJc+bM0Z///GelpaWZV7WFDMNQUWG2/uvAaZVV1BE+AADoJ8Pn84XVM6Nut1tOp1Mulyts13/8ofyMVm0u18QR6frjqmKrywEAwHL9+f1mb5cBWFDQve7jk3NuXWj0WFwNAACRhfAxANmpDk0a0Z3qdvHUCwAA/UL4GKDi8f5W64QPAAD6g/AxQMUF3QtNd1ZcUJgtmwEAIKwRPgZo9thMOeJsqm30qKK2yepyAACIGISPAUqMt+uOQKt1pl4AAOgrwscg+Ludss8LAAB9R/gYBH+Dsb0nLsrTSat1AAD6gvAxCLcOT1N2qkOtHV4dOHnJ6nIAAIgIhI9BMAwjMPVSxroPAAD6hPAxSEUF9PsAAKA/CB+D5B/5+O+zLl1qbre4GgAAwh/hY5CGpSdqQk6afD5p13FGPwAAuBnChwmK/I/cHiN8AABwM4QPEwQWnVbW0WodAICbIHyYYE5+lhLsNp1paNWJumarywEAIKwRPkyQlGDX7LGZknjkFgCAmyF8mCSw7oPwAQDADRE+TLKwp9X6nhP16vB2WVwNAADhi/Bhkkkj0jUkJUFNnk6VVzdYXQ4AAGGL8GESm83Q/HFZkqSdx9jlFgCA6yF8mMg/9bKzknUfAABcD+HDRP5Fp4eqG+Rq6bC4GgAAwhPhw0S5GUkaNzRFXT7pgxOMfgAAcC2ED5MV+6deeOQWAIBrInyYrKiAfh8AANwI4cNkc8dlKc5m6NTFFp2sp9U6AACfRfgwWaojTjNHd7daZ/QDAICrET6CILDLLeEDAICrED6CwP/I7e7jdeqk1ToAAL0QPoJg2qgMpSfGyd3WqY/OuKwuBwCAsEL4CAK7zdCCAqZeAAC4FsJHkPinXnZWsM8LAABXInwEiX+flw9PNaixjVbrAAD4ET6CJG9IssZkJauzy6c9Jy5aXQ4AAGGD8BFElx+5ZeoFAAA/wkcQFRX07PNSyaJTAAD8CB9BNG9clmyGdOJCs840tFpdDgAAYYHwEUTOpHjNyMuQxNQLAAB+hI8gK+p56qWUfh8AAEgifATdQn+r9co6dXX5LK4GAADrET6CbHpehlIdcbrU0qGPz7qtLgcAAMsRPoIs3m7TvHFZkqRS1n0AAED4CIXL/T5Y9wEAgOnho7OzUz/60Y+Un5+vpKQk3XLLLXr22WfV1RW7W8sX9Wwyt//kRbW0d1pcDQAA1ooz+wN/9rOf6T//8z+1adMmTZ48Wfv379ejjz4qp9OpVatWmX27iJCfnaKRGUk609CqvVUXdeeEYVaXBACAZUwf+fjggw9077336u6779bYsWN13333afHixdq/f7/Zt4oYhmEEpl52HmPqBQAQ20wPH0VFRXrvvfd07NgxSdKhQ4dUVlamL33pS9e83uPxyO129zqiUXFPv4+yShadAgBim+nTLk8++aRcLpduvfVW2e12eb1e/fSnP9XXvva1a15fUlKif/u3fzO7jLAzf1yWDEM6dr5J591tyklPtLokAAAsYfrIxxtvvKFXX31Vr732mg4ePKhNmzbpP/7jP7Rp06ZrXr927Vq5XK7AUV1dbXZJYSEzJUHTRjolSTt56gUAEMNMH/n4l3/5Fz311FN64IEHJElTp07VyZMnVVJSouXLl191vcPhkMPhMLuMsFRUmK1Dp10qq7ig+2aNsrocAAAsYfrIR0tLi2y23h9rt9tj+lFbv6IC/7oPWq0DAGKX6SMfS5cu1U9/+lONHj1akydP1ocffqhf/epX+qd/+iezbxVxZo7JUHKCXXVN7fp7TaMm5aZbXRIAACFn+sjHCy+8oPvuu0/f/e53NXHiRH3ve9/Td77zHf3kJz8x+1YRxxFn15z8IZJ46gUAELsMn88XVuP/brdbTqdTLpdL6enRNzLwv8uq9Oz/O6Liwmz9n2/OsbocAABM0Z/fb/Z2CTF/s7G/VV1UW4fX4moAAAg9wkeIFQxLVU66Q57OLu379KLV5QAAEHKEjxDrbrXe89QL/T4AADGI8GEB/9RLKeEDABCDCB8WWFDQHT4+OefWhUaPxdUAABBahA8LZKc6NGlE90rg3ccZ/QAAxBbCh0WKx/dMvRwjfAAAYgvhwyLFgVbrFxRmrVYAAAgqwodFZo/NlCPOpvNujypqm6wuBwCAkCF8WCQx3q47elqt7+SpFwBADCF8WMj/yG1ZBfu8AABiB+HDQv5mY3tOXJSnk1brAIDYQPiw0K3D05Sd6lBrh1cHTzZYXQ4AACFB+LBQd6v17qmXnUy9AABiBOHDYkU93U7LKll0CgCIDYQPixX1jHwcPuPSpeZ2i6sBACD4CB8Wy0lP1IScNPl80i5arQMAYgDhIwwUBR65JXwAAKIf4SMMXF50WkerdQBA1CN8hIE5+VlKsNt0pqFVVXXNVpcDAEBQET7CQFKCXbPGZEqi1ToAIPoRPsJE8fjLUy8AAEQzwkeYKC7wt1qvV4e3y+JqAAAIHsJHmJicm67M5Hg1eTpVXt1gdTkAAAQN4SNM2GyGFhQw9QIAiH6EjzCysGeXW/Z5AQBEM8JHGPE3GztU3SBXa4fF1QAAEByEjzCSm5GkW4amqMsnfUCrdQBAlCJ8hJnLUy+EDwBAdCJ8hJminkWnZZWEDwBAdCJ8hJm547IUZzN0sr5Fp+pbrC4HAADTET7CTKojTjNH97Rar+SpFwBA9CF8hCH/Uy87jzH1AgCIPoSPMFTcEz52H69TJ63WAQBRhvARhqaNylB6YpzcbZ366IzL6nIAADAV4SMM2a9otV7GI7cAgChD+AhT/nUfhA8AQLQhfIQpf7Oxg6cuqcnTaXE1AACYh/ARpvKGJGtMVrI6u3zac7ze6nIAADAN4SOM+budssstACCaED7CWLF/nxdarQMAogjhI4zNG5clmyGduNCsMw2tVpcDAIApCB9hzJkUrxl5GZKkMqZeAABRIijh48yZM/rGN76hrKwsJScna8aMGTpw4EAwbhX1ivxTLzxyCwCIEqaHj0uXLmnBggWKj4/XH//4Rx05ckS//OUvlZGRYfatYsLCnn4fuyrr1NXls7gaAAAGL87sD/zZz36mvLw8vfTSS4FzY8eONfs2MWN6XoZSHXG61NKhj8+6NXWU0+qSAAAYFNNHPrZu3arZs2frK1/5ioYNG6bbbrtNv/vd7657vcfjkdvt7nXgsni7TXNvyZIklbLuAwAQBUwPHydOnNDGjRtVWFioP/3pT3rsscf0xBNP6JVXXrnm9SUlJXI6nYEjLy/P7JIi3sLxtFoHAEQPw+fzmbqQICEhQbNnz9bu3bsD55544gnt27dPH3zwwVXXezweeTyewGu32628vDy5XC6lp6ebWVrEOnGhSZ//5Q4l2G0qf/ouJSeYPlsGAMCguN1uOZ3OPv1+mz7yMWLECE2aNKnXuYkTJ+rUqVPXvN7hcCg9Pb3Xgd7ys1M0MiNJ7d4u7a26aHU5AAAMiunhY8GCBTp69Givc8eOHdOYMWPMvlXMMAxDxexyCwCIEqaHj3/+53/Wnj179Pzzz6uyslKvvfaaXnzxRa1YscLsW8WUokL2eQEARAfTw8ftt9+ut99+W6+//rqmTJmin/zkJ1q3bp0efPBBs28VUxaMy5ZhSMfON+m8u83qcgAAGLCgrFy85557dM899wTjo2NWZkqCpo506qPTLpVV1Ol/zBpldUkAAAwIe7tEkGKmXgAAUYDwEUGKCrr3eSmrrKfVOgAgYhE+IsjMMRlKTrCrrsmjv9c0Wl0OAAADQviIII44u+bkD5EklVUy9QIAiEyEjwhTVNg99bKTfh8AgAhF+IgwC3sWnf6t6qLaOrwWVwMAQP8RPiJMwbBU5aQ75Ons0v5PL1ldDgAA/Ub4iDDdrdb9Uy+s+wAARB7CRwS63O+DdR8AgMhD+IhACwq6w8eRc25daPRYXA0AAP1D+IhA2akOTRqRLknafZzRDwBAZCF8RCimXgAAkYrwEaGuXHTq89FqHQAQOQgfEWr22Ew54mw67/aosrbJ6nIAAOgzwkeESoy3646eVuulTL0AACII4SOC+dd9lNHvAwAQQQgfEayooHvdx54TF+XppNU6ACAyED4i2K3D05Sd6lBrh1cHTzZYXQ4AAH1C+IhgNpuhooIsSVJZJVMvAIDIQPiIcJcfuWXRKQAgMhA+IlxRz6LTw2dcutTcbnE1AADcHOEjwuWkJ2pCTpp8PmkXrdYBABGA8BEFigKP3BI+AADhj/ARBYqu2OeFVusAgHBH+IgCc/KHKMFu05mGVlXVNVtdDgAAN0T4iALJCXGaNSZTklRWydQLACC8ET6iRPH47qmX0mOEDwBAeCN8RIniQKv1enV4uyyuBgCA6yN8RInJuenKTI5Xk6dT5dUNVpcDAMB1ET6ihM1maEHB5adeAAAIV4SPKFIc6PfBPi8AgPBF+IgiRT37vJRXN8jV2mFxNQAAXBvhI4qMzEjSLUNT1OWTPjheb3U5AABcE+EjyiwM7HLL1AsAIDwRPqJMUc+iU5qNAQDCFeEjyswdl6U4m6GT9S06Vd9idTkAAFyF8BFlUh1xmjm6u9X6zkqmXgAA4YfwEYWKAo/cMvUCAAg/hI8o5O/3sauyTt4un8XVAADQG+EjCk0blaH0xDi52zr10ekGq8sBAKAXwkcUstNqHQAQxggfUYp1HwCAcEX4iFLFBd3Nxg6euqQmT6fF1QAAcBnhI0qNzkrWmKxkdXb5tIdW6wCAMBL08FFSUiLDMLR69epg3wqfQbdTAEA4Cmr42Ldvn1588UVNmzYtmLfBdRT37PNSyj4vAIAwErTw0dTUpAcffFC/+93vlJmZGazb4AbmjcuSzZBOXGjWmYZWq8sBAEBSEMPHihUrdPfdd+uLX/ziDa/zeDxyu929DpjDmRSv6XkZkqQyRj8AAGEiKOFj8+bNOnjwoEpKSm56bUlJiZxOZ+DIy8sLRkkxyz/1Qr8PAEC4MD18VFdXa9WqVXr11VeVmJh40+vXrl0rl8sVOKqrq80uKaZd2Wq9i1brAIAwEGf2Bx44cEC1tbWaNWtW4JzX61VpaanWr18vj8cju90eeM/hcMjhcJhdBnrMyMtQqiNOl1o69PFZt6aOclpdEgAgxpkePr7whS/o8OHDvc49+uijuvXWW/Xkk0/2Ch4Ivni7TXNvydJfPjmvnZUXCB8AAMuZHj7S0tI0ZcqUXudSUlKUlZV11XmExsLx2d3h41idvruowOpyAAAxjg6nMcDfbOzAyUtqbfdaXA0AINaZPvJxLdu3bw/FbXAd+dkpGpmRpDMNrdpbVa9FE4ZZXRIAIIYx8hEDDMMIPPXCI7cAAKsRPmJEUU/4KCN8AAAsRviIEQvGZcswpKPnG3Xe3WZ1OQCAGEb4iBGZKQmaOrL7MVtGPwAAViJ8xJDL6z7Y5wUAYB3CRwwpKuje56Wssl4+H63WAQDWIHzEkJljMpQUb1ddk0d/r2m0uhwAQIwifMQQR5xdc28ZIompFwCAdQgfMaaosHvqhX4fAACrED5izMKeRad/q7qotg5arQMAQo/wEWMKhqUqJ90hT2eX9n96yepyAAAxiPARYwzDCDz1srOSdR8AgNAjfMSgheN7+n0cY90HACD0CB8xaEFBd/g4cs6tuiaPxdUAAGIN4SMGZac6NGlEuiRpVyWjHwCA0CJ8xKjLrdYJHwCA0CJ8xKjiQL+PC7RaBwCEFOEjRs0emylHnE3n3R5V1jZZXQ4AIIYQPmJUYrxdd+T7W60z9QIACB3CRwy7vO6Dfh8AgNAhfMQwf7OxPScuytNJq3UAQGgQPmLYrcPTlJ3qUGuHVwdPNlhdDgAgRhA+YpjNZqioIEuSVEardQBAiBA+YlxRzyO3ZSw6BQCECOEjxvkXnX50xqVLze0WVwMAiAWEjxiXk56o8Tmp8vmk3cfrrS4HABADCB/o1e0UAIBgI3xARVfs80KrdQBAsBE+oDn5Q5Rgt+lMQ6uq6pqtLgcAEOUIH1ByQpxmjcmUJJVV8tQLACC4CB+Q1HvqBQCAYCJ8QJK0sGfR6QfH69Xh7bK4GgBANCN8QJI0OTddmcnxavJ06lB1g9XlAACiGOEDkrpbrS8o6J56KWXqBQAQRIQPBPi7nZbR7wMAEESEDwT493k5dNolV2uHxdUAAKIV4QMBIzOSdMvQFHm7fPqAVusAgCAhfKCX4p51H2WVTL0AAIKD8IFeLu/zwqJTAEBwED7Qy9xxWYqzGTpZ36JT9S1WlwMAiEKED/SS6ojTzNHdrdZ3MvUCAAgCwgeuUhR45JapFwCA+QgfuIo/fOyqrJO3y2dxNQCAaEP4wFWmjXQqPTFO7rZOfXS6wepyAABRxvTwUVJSottvv11paWkaNmyYli1bpqNHj5p9GwRRnN2m+eOYegEABIfp4WPHjh1asWKF9uzZo23btqmzs1OLFy9Wc3Oz2bdCEBWP7w4fPHILADBbnNkf+O677/Z6/dJLL2nYsGE6cOCAFi5caPbtECTFBd39Pg6euqQmT6dSHab/qwIAiFFBX/PhcrkkSUOGDLnm+x6PR263u9cB643OStaYrGR1dvm09wSt1gEA5glq+PD5fFqzZo2Kioo0ZcqUa15TUlIip9MZOPLy8oJZEvqhqICpFwCA+YIaPlauXKmPPvpIr7/++nWvWbt2rVwuV+Corq4OZknoh+JCf/ig2RgAwDxBm8h//PHHtXXrVpWWlmrUqFHXvc7hcMjhcASrDAzCvHHZshnS8QvNOtvQqtyMJKtLAgBEAdNHPnw+n1auXKm33npL77//vvLz882+BULEmRSv6XkZknjkFgBgHtPDx4oVK/Tqq6/qtddeU1pammpqalRTU6PW1lazb4UQ8O9yW8rUCwDAJKaHj40bN8rlcmnRokUaMWJE4HjjjTfMvhVCwL/uY/fxenXRah0AYALT13z4fPxARZMZeRlKdcTpYnO7jpxza8pIp9UlAQAiHHu74Ibi7TbNvSVLElMvAABzED5wU/6pFxadAgDMQPjATfnDx/5PL6m13WtxNQCASEf4wE3lZ6doZEaS2r1d2ltFq3UAwOAQPnBThmEw9QIAMA3hA31SVMg+LwAAcxA+0CcLxmXLMKSj5xtV626zuhwAQAQjfKBPMlMSNLWnxwejHwCAwSB8oM+KCnrWfVQSPgAAA0f4QJ/593nZWVFHJ1sAwIARPtBnM8dkKCnerromj/5e02h1OQCACEX4QJ854uyae8sQSTxyCwAYOMIH+qWoZ+qFfV4AAANF+EC/+JuN/a3qoto6aLUOAOg/wgf6pXBYqnLSHfJ0dmn/p5esLgcAEIEIH+gXwzBUVNDz1EslUy8AgP4jfKDfFo7vabV+jEWnAID+I3yg3xb0NBs7cs6tuiaPxdUAACIN4QP9lp3q0MQR6ZKkXXQ7BQD0E+EDA7KQXW4BAANE+MCAFPWEjzJarQMA+onwgQG5fewQOeJsqnG3qbK2yepyAAARhPCBAUmMt+uO/O5W60y9AAD6g/CBAfN3Oy1j0SkAoB8IHxgwf7OxPSfq1d7ZZXE1AIBIQfjAgN06PE3ZqQlqaffq4ClarQMA+obwgQGz2QwVFfgfuaXVOgCgbwgfGJSiwu6plzIWnQIA+ojwgUHxLzr96IxLl5rbLa4GABAJCB8YlJz0RI3PSZXPJ+0+Xm91OQCACED4wKAV+6deKln3AQC4OcIHBs3far30GK3WAQA3R/jAoM3JH6IEu01nGlr1aX2L1eUAAMIc4QODlpwQp1ljMiXxyC0A4OYIHzCFf+qFfV4AADdD+IApFvYsOt1zvF4dXlqtAwCuj/ABU0zOTVdmcrwaPZ06VN1gdTkAgDBG+IApbDZD8wuYegEA3BzhA6ZZWMg+LwCAmyN8wDT+fV4OnXbJ1dphcTUAgHBF+IBpRmYk6ZahKfJ2+fQBrdYBANdB+ICpinvWfdBqHQBwPYQPmCqwzwuLTgEA1xEXrA/esGGDfvGLX+jcuXOaPHmy1q1bp+Li4mDdDmFi7rgsxdkMfVrfoilP/0mJ8XYlxtuUFG9XUoJdiXF2JSbYlRRvU2K8XUnx9p5r/P/f1n3dFef85xP9n3HFeUecTTabYfU/NgCgH4ISPt544w2tXr1aGzZs0IIFC/Tb3/5WS5Ys0ZEjRzR69Ohg3BJhItURpyVTR+j/HjqrJk+nmjydQb+nI+5ykElK6A4kSQmXg83lgHNFCPrsuStDUELv846e/423GzIMgg4ADJbhC8I2pHPmzNHMmTO1cePGwLmJEydq2bJlKikpueHfut1uOZ1OuVwupaenm1eUzyd1sOlZKPh8PtU2etTa0aW2Du/lo9Ortvbuc60dXnk6L7/f2t6ltk6vPD3XtbZ71dbRpbbOz3xGR/f5dgu6qNpthhJ7go4j7ooQE2cLjMxcOWLjuHJ0x/93PaEm0T8KdEUISuwJTYlxdkZzAARffLJk4n9Q9ef32/SRj/b2dh04cEBPPfVUr/OLFy/W7t27r7re4/HI4/EEXrvdbrNL6tbRIj2fG5zPRi+GpJxg3iC+57CKt+fw3OxCAAhjPzgrJaRYcmvTF5zW1dXJ6/UqJ6f3z09OTo5qamquur6kpEROpzNw5OXlmV0SAAAII0FbcPrZuXGfz3fN+fK1a9dqzZo1gddutzs4ASQ+uTvlAWGqq8snT2eXWv1TVB1dam33T0V1n/f4p6x6zrV19H36qT8TrD71bza2f58dpA/u92f351LTZ6cBS9lsNj0Rn2zZ/U0PH9nZ2bLb7VeNctTW1l41GiJJDodDDofD7DKuZhiWDS8BfWGTlNRzAEA0M33aJSEhQbNmzdK2bdt6nd+2bZvmz59v9u0AAECECcq0y5o1a/TQQw9p9uzZmjdvnl588UWdOnVKjz32WDBuBwAAIkhQwsf999+v+vp6Pfvsszp37pymTJmid955R2PGjAnG7QAAQAQJSp+PwQhanw8AABA0/fn9Zm8XAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUkFprz4Y/oarbrfb4koAAEBf+X+3+9I4PezCR2NjoyQpLy/P4koAAEB/NTY2yul03vCasNvbpaurS2fPnlVaWpoMwzD1s91ut/Ly8lRdXc2+MUHE9xwafM+hw3cdGnzPoRGs79nn86mxsVG5ubmy2W68qiPsRj5sNptGjRoV1Hukp6fzL3YI8D2HBt9z6PBdhwbfc2gE43u+2YiHHwtOAQBASBE+AABASMVU+HA4HHr66aflcDisLiWq8T2HBt9z6PBdhwbfc2iEw/ccdgtOAQBAdIupkQ8AAGA9wgcAAAgpwgcAAAgpwgcAAAipmAkfGzZsUH5+vhITEzVr1izt3LnT6pKiTmlpqZYuXarc3FwZhqEtW7ZYXVJUKikp0e233660tDQNGzZMy5Yt09GjR60uK+ps3LhR06ZNCzRimjdvnv74xz9aXVbUKykpkWEYWr16tdWlRJ1nnnlGhmH0OoYPH25JLTERPt544w2tXr1aP/zhD/Xhhx+quLhYS5Ys0alTp6wuLao0Nzdr+vTpWr9+vdWlRLUdO3ZoxYoV2rNnj7Zt26bOzk4tXrxYzc3NVpcWVUaNGqV///d/1/79+7V//359/vOf17333quPP/7Y6tKi1r59+/Tiiy9q2rRpVpcStSZPnqxz584FjsOHD1tSR0w8ajtnzhzNnDlTGzduDJybOHGili1bppKSEgsri16GYejtt9/WsmXLrC4l6l24cEHDhg3Tjh07tHDhQqvLiWpDhgzRL37xC33zm9+0upSo09TUpJkzZ2rDhg167rnnNGPGDK1bt87qsqLKM888oy1btqi8vNzqUqJ/5KO9vV0HDhzQ4sWLe51fvHixdu/ebVFVgHlcLpek7h9GBIfX69XmzZvV3NysefPmWV1OVFqxYoXuvvtuffGLX7S6lKhWUVGh3Nxc5efn64EHHtCJEycsqSPsNpYzW11dnbxer3Jycnqdz8nJUU1NjUVVAebw+Xxas2aNioqKNGXKFKvLiTqHDx/WvHnz1NbWptTUVL399tuaNGmS1WVFnc2bN+vgwYPat2+f1aVEtTlz5uiVV17R+PHjdf78eT333HOaP3++Pv74Y2VlZYW0lqgPH36GYfR67fP5rjoHRJqVK1fqo48+UllZmdWlRKUJEyaovLxcDQ0NevPNN7V8+XLt2LGDAGKi6upqrVq1Sn/+85+VmJhodTlRbcmSJYH/P3XqVM2bN0/jxo3Tpk2btGbNmpDWEvXhIzs7W3a7/apRjtra2qtGQ4BI8vjjj2vr1q0qLS3VqFGjrC4nKiUkJKigoECSNHv2bO3bt0+/+c1v9Nvf/tbiyqLHgQMHVFtbq1mzZgXOeb1elZaWav369fJ4PLLb7RZWGL1SUlI0depUVVRUhPzeUb/mIyEhQbNmzdK2bdt6nd+2bZvmz59vUVXAwPl8Pq1cuVJvvfWW3n//feXn51tdUszw+XzyeDxWlxFVvvCFL+jw4cMqLy8PHLNnz9aDDz6o8vJygkcQeTweffLJJxoxYkTI7x31Ix+StGbNGj300EOaPXu25s2bpxdffFGnTp3SY489ZnVpUaWpqUmVlZWB11VVVSovL9eQIUM0evRoCyuLLitWrNBrr72mP/zhD0pLSwuM6jmdTiUlJVlcXfT4wQ9+oCVLligvL0+NjY3avHmztm/frnfffdfq0qJKWlraVeuVUlJSlJWVxTomk33ve9/T0qVLNXr0aNXW1uq5556T2+3W8uXLQ15LTISP+++/X/X19Xr22Wd17tw5TZkyRe+8847GjBljdWlRZf/+/brzzjsDr/1ziMuXL9fLL79sUVXRx//I+KJFi3qdf+mll/TII4+EvqAodf78eT300EM6d+6cnE6npk2bpnfffVd33XWX1aUBA3L69Gl97WtfU11dnYYOHaq5c+dqz549lvwWxkSfDwAAED6ifs0HAAAIL4QPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUoQPAAAQUv8fCM/lx7x5X9QAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -556,19 +500,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 19,
    "id": "23ce6822-b38b-41f3-9269-109dbb152ecf",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "759d4d0f319d4ffaa54b959293166c9b",
+       "model_id": "717e3bf94e2a46c39a07430192eb21fc",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "NGLWidget(max_frame=11)"
+       "NGLWidget(max_frame=5)"
       ]
      },
      "metadata": {},
@@ -589,68 +533,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "id": "d0f62439-3492-4392-ac2a-2b2545b85527",
-   "metadata": {},
+   "execution_count": 20,
+   "id": "654ce992-b73f-42e3-a32e-2e0dafa7c952",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "murn = GenericTinyJob(pr, 'murn')"
+    "murn = pr.create.job.Murnaghan('murn')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
-   "id": "5c9ab533-cf97-49a1-8c4b-0e5e2f9758c2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "murn.task_class = MurnaghanTask"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 21,
    "id": "253237f0-b338-470c-bc54-3c7400a757b7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "murn.input.task = AseStaticTask()\n",
+    "murn.input.task = pr.create.task.AseStatic()\n",
     "murn.input.task.input.calculator = MorsePotential()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 22,
    "id": "c801093b-499e-48a7-8444-77602ed88a96",
    "metadata": {},
    "outputs": [],
    "source": [
-    "murn.input.structure = bulk(\"Fe\", a=1.2)"
+    "murn.input.structure = pr.create.structure.bulk(\"Fe\", a=1.2).to_ase()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 23,
    "id": "1e30b36e-11e6-47d1-836e-cffea7b73cdd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "murn.input.set_strain_range(.5, 500)"
+    "murn.input.set_strain_range(.5, 1000)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
-   "id": "9920e4b7-8395-4fb9-96c3-792b044c4e3a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "murn.input.child_executor = ProcessExecutor"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 24,
    "id": "18b5305a-8950-44af-bc2e-c9734b059713",
    "metadata": {},
    "outputs": [
@@ -658,23 +584,36 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "DEBUG:h5py._conv:Creating converter from 5 to 3\n"
+      "INFO:root:Job already finished!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.5 ms, sys: 727 µs, total: 2.23 ms\n",
+      "Wall time: 2.08 ms\n"
      ]
     }
    ],
    "source": [
-    "exe = murn.run()"
+    "%%time\n",
+    "exe = murn.run(\n",
+    "    executor=pr.create.executor.process(4)\n",
+    ")\n",
+    "if exe is not None:\n",
+    "    exe.wait()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 25,
    "id": "836bb2ec-4295-4a3c-b976-7a35d04aad36",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiIAAAGdCAYAAAAvwBgXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA6CklEQVR4nO3dd3Rc9bnu8WdGZVSs3rtkucgFNxkbN0y16YGE3sGQ+AIhhJNGODnAObnxOqHcc0gCCQk4JBhwgEAgNDuAe7dl4yoXSVazutW7tO8fksYWbpKtmT3l+1lr1sJ7Zjyv18aeR7/y/iyGYRgCAAAwgdXsAgAAgPciiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqCCAAAMA1BBAAAmIYgAgAATONrdgGn093drdLSUoWEhMhisZhdDgAAGADDMNTQ0KDExERZracf83DpIFJaWqqUlBSzywAAAGehqKhIycnJp32NSweRkJAQST1/kNDQUJOrAQAAA1FfX6+UlBT79/jpuHQQ6ZuOCQ0NJYgAAOBmBrKsgsWqAADANAQRAABgGoIIAAAwDUEEAACYhiACAABMQxABAACmIYgAAADTEEQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJjGpQ+9c5Tcsga9t61YkcH+Wjg30+xyAADwWl45InKkrkWvrMrTBzklZpcCAIBX88ogkhgeKEkqrW0xuRIAALybVwaRhLAASVJ9a6ca2zpNrgYAAO/llUEkJMBPoQE9y2OOMCoCAIBpvDKISMdNz9S1mlwJAADeiyDCiAgAAKbx2iDSt06EqRkAAMzjtUGkb0SkpJapGQAAzOLFQaR3RKSOEREAAMzivUEkjDUiAACYzXuDyHG7ZgzDMLkaAAC8k9cGkbjQAFksUntnt6qb2s0uBwAAr+S1QcTf16qYYTZJ0hEWrAIAYAqvDSLS8TtnWCcCAIAZvDyIsHMGAAAzeXcQYecMAACm8uogksB5MwAAmMqrg0hS79QMIyIAAJjDq4NIQu/UDLtmAAAwh1cHkb5dM+UNrero6ja5GgAAvI/TgsiiRYtksVj02GOPOesjzygq2F/+PlYZhlRez6gIAADO5pQgsnnzZr3yyiuaMGGCMz5uwKxWixLs60QIIgAAOJvDg0hjY6PuuOMO/fGPf1RERISjP27Q+rbw0ksEAADnc3gQefjhh3X11VfrsssuO+Nr29raVF9f3+/haH0jInRXBQDA+Xwd+Zu//fbb2rZtmzZv3jyg1y9atEjPPPOMI0s6QVJfm/ejBBEAAJzNYSMiRUVF+sEPfqA33nhDAQEBA3rPE088obq6OvujqKjIUeXZJUdw3gwAAGZx2IjI1q1bVVFRoezsbPu1rq4urVq1Sr/97W/V1tYmHx+ffu+x2Wyy2WyOKumkksKDJEnFjIgAAOB0Dgsil156qXbu3Nnv2n333aesrCz99Kc/PSGEmMU+InK0RYZhyGKxmFwRAADew2FBJCQkROPHj+93LTg4WFFRUSdcN1PfYtWWji7VNLUraphzR2QAAPBmXt1ZVZJsvj6KC+0JH6wTAQDAuRy6a+abVqxY4cyPG7Ck8ECV17ep+GiLJiSHm10OAABew+tHRCQpOaJnwSpbeAEAcC6CiKSk3gWrxUebTa4EAADvQhARvUQAADALQUTHuqvSSwQAAOciiOjEXiIAAMA5CCI61l21oa1T9S2dJlcDAID3IIhICvT3UVSwvySpuJYFqwAAOAtBpNfx0zMAAMA5CCK9jm3hJYgAAOAsBJFe9qZmbOEFAMBpCCK9jm3hZY0IAADOQhDpRVMzAACcjyDSizUiAAA4H0GkV9/UTG1zhxrb6CUCAIAzEER6hQT4KSzQTxJbeAEAcBaCyHH61okU1bBgFQAAZyCIHCc1smcLbxE7ZwAAcAqCyHH6gkghIyIAADgFQeQ4yX0jIjWsEQEAwBkIIsexT80wIgIAgFMQRI6T0rtYtbCmWYZhmFwNAACejyBynKSIQFksUktHl6qb2s0uBwAAj0cQOY7N10cJoQGSWLAKAIAzEES+IZl1IgAAOA1B5BtYsAoAgPMQRL4hJYJeIgAAOAtB5BtSo/ravNNLBAAARyOIfAMjIgAAOA9B5Bv61ogcqWtRR1e3ydUAAODZCCLfEBNik83Xqm5DKq1legYAAEciiHyDxWJRCoffAQDgFASRk0jl8DsAAJyCIHISx585AwAAHIcgchIpNDUDAMApCCInYZ+aOUoQAQDAkQgiJ9E3InK4miACAIAjEUROom9EpK6lQ3XNHSZXAwCA5yKInESwzVcxITZJ0uGaJpOrAQDAcxFETiE9qmdUpIDpGQAAHIYgcgppUcGSpMNVjIgAAOAoBJFTYEQEAADHI4icgn1EpJoREQAAHIUgcgrpfUGEpmYAADgMQeQUUnunZiob2tTU1mlyNQAAeCaCyCmEBfopIshPEo3NAABwFILIabBOBAAAxyKInAY7ZwAAcCyCyGn0jYgU0l0VAACHcGgQWbRokc4//3yFhIQoNjZW119/vXJzcx35kUMqPbp3RKSKEREAABzBoUFk5cqVevjhh7VhwwYtX75cnZ2dmjdvnpqa3GOEgTUiAAA4lq8jf/PPPvus368XL16s2NhYbd26VRdeeKEjP3pI9PUSKa1rVWtHlwL8fEyuCAAAz+LQIPJNdXV1kqTIyMiTPt/W1qa2tjb7r+vr651S16lEBPkpJMBXDa2dKqpp1si4EFPrAQDA0zhtsaphGHr88cc1e/ZsjR8//qSvWbRokcLCwuyPlJQUZ5V3UhaLxT4qws4ZAACGntOCyCOPPKKvv/5ab7311ilf88QTT6iurs7+KCoqclZ5p9TXYZV1IgAADD2nTM18//vf14cffqhVq1YpOTn5lK+z2Wyy2WzOKGnAjvUSIYgAADDUHBpEDMPQ97//fb3//vtasWKFMjIyHPlxDmGfmmELLwAAQ86hQeThhx/Wm2++qX/84x8KCQlRWVmZJCksLEyBgYGO/OghMzymJ4jkVzEiAgDAUHPoGpGXX35ZdXV1uuiii5SQkGB/LF261JEfO6QyoodJkkpqW9Ta0WVyNQAAeBaHT824u8hgf4UH+am2uUMF1U3Kig81uyQAADwGZ80MQEZ0z/RMXiXTMwAADCWCyAD0BRHWiQAAMLQIIgMwnBERAAAcgiAyAMNjehas5lc1mlwJAACehSAyAPY1IkzNAAAwpAgiA9DX1Ky2uUNHm9pNrgYAAM9BEBmAQH8fJYYFSGJUBACAoUQQGaCMmL4Fq6wTAQBgqBBEBmh4dN+CVUZEAAAYKgSRAaKXCAAAQ48gMkAZHH4HAMCQI4gM0PDjRkS6u93/DB0AAFwBQWSAkiOC5OdjUVtnt0rrWswuBwAAj0AQGSAfq0VpUUzPAAAwlAgig9C3YPVQBVt4AQAYCgSRQRgR27OF9yC9RAAAGBIEkUEY0Xv43UFGRAAAGBIEkUGwj4hUsEYEAIChQBAZhOG9vUSqGttU19xhcjUAALg/gsgghAT4KT605/A71okAAHDuCCKD1Dc9w84ZAADOHUFkkNg5AwDA0CGIDFJmLDtnAAAYKgSRQcrsXbBKEAEA4NwRRAapb2qm6GizWju6TK4GAAD3RhAZpJhhNoUG+MowpLxK+okAAHAuCCKDZLFYju2cYcEqAADnhCByFkawYBUAgCFBEDkLbOEFAGBoEETOQmYMTc0AABgKBJGz0DciklfVpK5uw+RqAABwXwSRs5AcESSbr1Xtnd0qrGk2uxwAANwWQeQs+FiP7ZzZX95gcjUAALgvgshZGh0XIknaX0YQAQDgbBFEztKo+N4gwoJVAADOGkHkLI2K652aYUQEAICzRhA5S6N6p2byqhrV0dVtcjUAALgngshZSgoPVLC/jzq6DBVUceYMAABngyByliwWi0b2jorksnMGAICzQhA5B/adM+UsWAUA4GwQRM7BSBasAgBwTggi52C0fQsvQQQAgLNBEDkHfVMzBVVNau3oMrkaAADcD0HkHMSE2BQW6KduQzpUyToRAAAGiyByDiwWi31U5AALVgEAGDSCyDnqW7DKFl4AAAaPIHKO7AtW2TkDAMCgEUTO0SiamgEAcNacEkReeuklZWRkKCAgQNnZ2Vq9erUzPtYpxsSHSpKKj7aovrXD5GoAAHAvDg8iS5cu1WOPPaYnn3xSOTk5mjNnjq688koVFhY6+qOdIizIT4lhAZKkXKZnAAAYFIcHkRdeeEELFizQAw88oDFjxuh//ud/lJKSopdfftnRH+00YxJ6RkX2Hqk3uRIAANyLQ4NIe3u7tm7dqnnz5vW7Pm/ePK1bt+6E17e1tam+vr7fwx1kJfSsEyGIAAAwOA4NIlVVVerq6lJcXFy/63FxcSorKzvh9YsWLVJYWJj9kZKS4sjyhsyxERGmZgAAGAynLFa1WCz9fm0YxgnXJOmJJ55QXV2d/VFUVOSM8s5ZVu+C1dyyBnV1GyZXAwCA+/B15G8eHR0tHx+fE0Y/KioqThglkSSbzSabzebIkhwiIzpYNl+rWjq6VFjTrIzoYLNLAgDALTh0RMTf31/Z2dlavnx5v+vLly/XzJkzHfnRTuVjtdgbm7FOBACAgXP41Mzjjz+uP/3pT3rttde0d+9e/fCHP1RhYaEWLlzo6I92qr5+IvsIIgAADJhDp2Yk6ZZbblF1dbX+8z//U0eOHNH48eP1ySefKC0tzdEf7VR9O2f2sGAVAIABc3gQkaSHHnpIDz30kDM+yjR9O2f2lTEiAgDAQHHWzBCh1TsAAINHEBkitHoHAGDwCCJDKItW7wAADApBZAiN7Q0ie0oJIgAADARBZAiNT+oJIrtK60yuBAAA90AQGULjEsMk9awRae/sNrkaAABcH0FkCCVHBCo0wFcdXYb2l7NgFQCAMyGIDCGLxaLxST2jIqwTAQDgzAgiQ6wviLBOBACAMyOIDLFxib0LVksIIgAAnAlBZIj1LVjde6RBXd2GydUAAODaCCJDLCM6WEH+Pmrp6FJ+VaPZ5QAA4NIIIkPMx2qxNzbbVcKCVQAATocg4gCsEwEAYGAIIg4wjp0zAAAMCEHEAcb3LljdXVovw2DBKgAAp0IQcYCRccPk72NVQ2unCmuazS4HAACXRRBxAD8fq7ISQiRJXxczPQMAwKkQRBxkQnLP9MzXxbXmFgIAgAsjiDjIhORwSdIORkQAADglgoiDTOwNIrtK6uiwCgDAKRBEHGRE7DAF+fuoub1LhyrpsAoAwMkQRBzEx2qxn8S7o6jW3GIAAHBRBBEHmmhfsMo6EQAAToYg4kB9C1bZOQMAwMkRRByob8Hq3iMNau/sNrcYAABcEEHEgVIiAxUR5Kf2rm7tK+MkXgAAvokg4kAWi0Xn9fUTYcEqAAAnIIg4WN+CVRqbAQBwIoKIg01kwSoAAKdEEHGwiSnhkqQDFY1qaO0wtxgAAFwMQcTBYkJsSo4IlGFIO4qYngEA4HgEESeYkhohSdpWeNTkSgAAcC0EESeYkhouScohiAAA0A9BxAkm946I5BTVyjA4iRcAgD4EEScYkxAqm69Vtc0dyqtqMrscAABcBkHECfx9rZrQ209k22GmZwAA6EMQcZLjp2cAAEAPgoiT9C1YZUQEAIBjCCJO0reFd395gxrbOk2uBgAA10AQcZLY0AAlhQeq2+AAPAAA+hBEnGgy/UQAAOiHIOJE2Wk90zNbWCcCAIAkgohTnZ8eKUnaeviourppbAYAAEHEibLiQxTs76OG1k7lljWYXQ4AAKYjiDiRr49VU3qnZzYX1JhcDQAA5iOIONm03ukZgggAAAQRp5t6XBDhADwAgLdzWBApKCjQggULlJGRocDAQGVmZuqpp55Se3u7oz7SLUxODZefj0Xl9W0qqmkxuxwAAEzl66jfeN++feru7tYf/vAHjRgxQrt27dKDDz6opqYmPffcc476WJcX4Oej85LCtK2wVpsKapQaFWR2SQAAmMZhQeSKK67QFVdcYf/18OHDlZubq5dfftmrg4jUs413W2GtthTU6MbsZLPLAQDANE5dI1JXV6fIyMhTPt/W1qb6+vp+D0/U109kEwtWAQBezmlB5NChQ/rNb36jhQsXnvI1ixYtUlhYmP2RkpLirPKcamp6zxbevMomVTW2mVwNAADmGXQQefrpp2WxWE772LJlS7/3lJaW6oorrtBNN92kBx544JS/9xNPPKG6ujr7o6ioaPB/IjcQHuSvUXHDJElbGBUBAHixQa8ReeSRR3Trrbee9jXp6en2/y4tLdXFF1+sGTNm6JVXXjnt+2w2m2w222BLckvTM6K0v7xRG/JqdMX4BLPLAQDAFIMOItHR0YqOjh7Qa0tKSnTxxRcrOztbixcvltVK25I+MzKj9NcNh7X+ULXZpQAAYBqH7ZopLS3VRRddpNTUVD333HOqrKy0PxcfH++oj3UbFwyPkiTlljeourFNUcO8YyQIAIDjOSyILFu2TAcPHtTBgweVnNx/iyodRaXIYH9lxYdoX1mDNuTV6OoJTM8AALyPw+ZK7r33XhmGcdIHevSNiqzPqzK5EgAAzMGiDRPNyOwNIqwTAQB4KYKIiaZnRMpikQ5VNqmivtXscgAAcDqCiInCg/w1Jj5UkrQ+j1ERAID3IYiYrG96ZkMejc0AAN6HIGKyGcP7gggjIgAA70MQMdm04ZGyWqT8qiaV1raYXQ4AAE5FEDFZaICfJqaES5LWHGAbLwDAuxBEXMCcET0t81cdqDzDKwEA8CwEERcwZ1SMJGndoWp1d9PwDQDgPQgiLmBSSriG2XxV09SuPUfqzS4HAACnIYi4AD8fq73dO9MzAABvQhBxEXNG9qwTYcEqAMCbEERcRF8Q2VJwVC3tXSZXAwCAcxBEXERGdLCSwgPV3tWtjfk0NwMAeAeCiIuwWCz2UZHVTM8AALwEQcSFzBnZs4135X4WrAIAHKehtUNf7C3Xf/1zj97aVGhqLb6mfjr6mT0iWj5Wiw5WNKqoplkpkUFmlwQA8AAdXd3KKazVmgOVWnOwSjuK69TV27dqWnqkbpuWalptBBEXEhbkp+zUCG0qqNGK3ArdNSPd7JIAAG7IMAwdrGjU6gNVWnOwShvzqtX0jY0Q6VFBmpEZrbmjok2qsgdBxMVcnBWrTQU1+iq3kiACABiwivpWrT1UpdUHqrT2YJXK69v6PR8V7K+ZI6I1Z0S0Zo6IUnKEa4y6E0RczMVZMfrvz/Zp3aEqtXZ0KcDPx+ySAAAuqKmtU5vya+zBI7e8od/zNl+rpmVEas7IaM0aEa0x8aGyWi0mVXtqBBEXMzouRAlhATpS16r1edW6eHSs2SUBAFyAYRjaXVqvlfsrtXJ/pXIKj6qj69j5ZBaLND4xTLNH9ox6TEmLcIsfZgkiLsZiseii0bF6a1OhVuyrIIgAgBerbW7XqgNVWplbqVUHKlXZ0H+6JTkiUHNGRmv2iBjNzIxSRLC/SZWePYKIC7okqyeIfJVbqacNQxaL6w2lAQCGXle3oZ0ldVqRW6GV+yu1o6hWxx/KHuTvo5m9C0wvHBWjtKhg84odIgQRFzQzM0r+PlYV1jTrUGWTRsQOM7skAICDVDa0afWBSq3IrdTqA5U62tzR7/ms+BDNHRWjuaNilJ0eIZuv60+3DAZBxAUF23w1fXikVh+o0pf7ygkiAOBBuroNbS86qq/2VWrF/grtKqnv93xIgK/mjIzW3FExunBUjBLCAk2q1DkIIi7q0qxYrT5QpX/tqdB3L8w0uxwAwDmob+3Q6v1V+mJvub7KrThh1GN8UqguGhWruaNjNCklXH4+3tP4nCDioi4bG6enP9qjLYdrVN3YpqhhNrNLAgAMQn5Vk77YW64v91VoU36NOo9b7BEa4Ku5o2N1Ue+oR0yI9/4bTxBxUckRQRqXGKrdpfX6Yl+Fbp6aYnZJAIDT6Ojq1paCo/pyX7m+2FehvMqmfs9nxgTr0jFxujQrVtlpEfL1olGP0yGIuLB5Y+O1u7Rey3aXE0QAwAUdbWrXyv2V+tfecq3cX6mG1k77c34+Fk3PiNIlWbG6JCtW6dHuv8PFEQgiLuzysXH6f//arzUHK9XS3qVAf89aKQ0A7qiwulnL9pRp2e5ybTlc0297bWSwvy4eHatLx8RqzshohQT4mVeomyCIuLAxCSFKjghU8dEWrTpQqfnj4s0uCQC8Tl9H02W7y7RsT7n2lfVvpZ4VH6JLx8Tqkqw4TUoJl48LtlF3ZQQRF2axWHT52DgtXlug5XvKCSIA4CSdXd3aVFCjZbvLtXxPuUpqW+zP+Vgtmp4Rqfnj4nXpmFiXOTzOXRFEXNy8sfFavLZAX+wtV2dXN4ubAMBBWtq7tHJ/pZbtKdOX+ypUe9wW20A/H80dFaN54+J0SVaswoPcr5W6qyKIuLjz0yMUHuSno80d2lRQo5mZ0WaXBAAeo6apXV/sLdeyPeVafaBSrR3d9ucigvx02Zg4zRsXrzkjo93iADl3RBBxcb4+Vs0bG6e/bSnWJzuPEEQA4BxVNrTps91l+nTnEW3Iq+632DQ5IlDzx8Vr3tg4ttg6CUHEDVx1XoL+tqVYn+0q0zPXjWchFAAMUnl9qz7bVaZPdh7RpoIaGceFj7EJoZo3Lk7zxsZrTEIIB406GUHEDcwaEa2wQD9VNbZrY341oyIAMACltS36bFeZPt11RFsOH+0XPiamhOuq8fG6cnyCUqNYbGomgogb8POxav44pmcA4EyKjzbrs11l+njnEeUU1vZ7bkpquK46L0FXjI9np4sLIYi4CaZnAODkimqa9fHOI/p05xHtKK6zX7dYpPPTInXlefG6Yny8x59i664IIm6C6RkAOKasrlUf7zyij3aUantRrf261SJNy4jUVeclaP64eMWFBphXJAaEIOImmJ4B4O1qmtr1SW/4OH7BqdUizciM0lXnJWje2HivPsnWHRFE3Ejf9MynO8v09LXj2FYGwOPVt3Zo2e5yfbSjVGsOVqnruL22U9MidN2kRF05PoHw4cYIIm5k1ohoRQb7q7qpXWsOVumi0bFmlwQAQ665vVNf7K3QRztKtSK3Uu1dx5qMnZcUpmsnJujqCYlKCmfNhycgiLgRPx+rrp2QoNfXH9YHOSUEEQAeo72zWyv3V+qjHaX6195yNbd32Z8bETtM101M1LUTE5URHWxilXAEgoib+dbkJL2+/rA+312uprZOBdu4hQDck2EY2nr4qN7PKdHHO4/0O9slNTJI105M0LUTEzU6jiZjnoxvMTczOSVcaVFBOlzdrOV7ynX95CSzSwKAQTlU2ah/5JTo/e0lKqo5dqptbIhN1/aOfExMDiN8eAmCiJuxWCz61qQkvfjFAX2wvYQgAsAtVDW26aMdpfogp6Rfr49gfx9dMT5BN0xO0ozMKHokeSGCiBu6flKiXvzigFYfqFJVY5uih7FaHIDraWnv0rI9Zfogp0SrDhzb8eJjtejCkdG6fnKS5o2NV6A/p9p6M6cEkba2Nk2fPl07duxQTk6OJk2a5IyP9VjDY4ZpYnKYdhTX6aMdpbpvVobZJQGAJKmr29C6Q1V6P6dEn+8qU9Nxi04nJofphslJumZiIj9Awc4pQeQnP/mJEhMTtWPHDmd8nFe4fnKSdhTX6b1txQQRAKY7WNGo97YV6+/bilVe32a/nhIZqBsmJelbk5OUGTPMxArhqhweRD799FMtW7ZM7733nj799FNHf5zXuH5SkhZ9sk+7Suq1u7RO4xLDzC4JgJepb+3QP3cc0Ttbi/odMBcW6KdrJiTo21OSNCU1gkWnOC2HBpHy8nI9+OCD+uCDDxQUdOaTDtva2tTWdixJ19fXO7I8txYR7K/Lx8bp451H9M6WYo27jiACwPH6pl7e2VKsz3eXqa2zp9mYj9Wii0bF6MbsZF0yJlY2X9Z9YGAcFkQMw9C9996rhQsXaurUqSooKDjjexYtWqRnnnnGUSV5nJumJuvjnUf0fk6JfnZllgL8+IsPwDHyKvumXkp0pK7Vfn1k7DDdNDVZ109KUiwHzOEsDDqIPP3002cMC5s3b9a6detUX1+vJ554YsC/9xNPPKHHH3/c/uv6+nqlpKQMtkSvMWdkjBLCAnSkrlX/2luuayYkml0SAA/S0Nqhj78+one3FmvL4aP262GBfvrWpETdmJ2s85Lo94FzYzEMwzjzy46pqqpSVVXVaV+Tnp6uW2+9VR999FG//0G7urrk4+OjO+64Q6+//voZP6u+vl5hYWGqq6tTaGjoYMr0Gs8vy9VvvjyoC0fF6C/3TzO7HABurrvb0Pq8ar2zpUif7S5Ta0fP1IvVIs0dFaMbs1N06ZhYRmBxWoP5/h50EBmowsLCfms8SktLNX/+fL377ruaPn26kpOTz/h7EETO7HB1k+Y+u0IWi7Tmp5dwCBSAs1JW16p3txZp6Zaift1OR8QO043ZybphcpLimHrBAA3m+9tha0RSU1P7/XrYsJ5tW5mZmQMKIRiYtKhgXTA8UhvyarR0U6Eenzfa7JIAuInOrm59lVuppZsL9eW+CvX2G1NIgK+um5iom6am0GodDkdnVQ9w5wVp2pBXo7c2F+n7l46Un4/V7JIAuLDC6mYt3VKod7YUq6Lh2E7FaemRuuX8FF11XgLdTuE0Tgsi6enpctAskNebNzZe0cNsqmxo07Ld5bp6QoLZJQFwMW2dXfp8d7mWbi7U2oPV9utRwf76Tnaybp6aohGxNByD8zEi4gH8fa26bVqKfvPlQb2x4TBBBIDd/vIGvb2pSH/PKVZtc4ckyWLp2XV36/kpumxMnPx9GUWFeQgiHuK2aan63VcHtT6vWgcrGjQiNsTskgCYpLm9U//8+oje3lSobcd1PE0IC9BNU1N0U3ayUiLP3GQScAaCiIdIDA/UpWPitHxPud7YUKinrxtndkkAnGx/eYOWbDisv28rUUNbpyTJ12rRpWNidev5qbpwVIx8rCw8hWshiHiQuy5I0/I95XpvW7F+PH+0gm3cXsDTtXV26bNdZVqyoVCbCmrs19OignTr+an6TnaSYkPYdgvXxTeVB5k9IlrDo4OVV9Wkd7cW656Z6WaXBMBBCqubtWTTYb2zpVg1Te2Ses57uWxMrO68IE2zMqNlZfQDboAg4kGsVovum52hX3ywS6+tzdedF6QxDAt4kM6ubn2xr0JLNhZq1f5K+/X40ADdNi1Vt5yfovgwRj/gXggiHuY7U5L03Oe5OlzdrC/2lmveuHizSwJwjsrqWvX25kK9valIZfXHDpy7cFSM7pyeqkuyYuVL/yC4KYKIhwny99Ud01P10opD+tOafIII4Ka6uw2tOVilJRsP6197K9TV2/Y0MthfN09N0e3TUpUaxc4XuD+CiAe6e0a6XlmVp035NdpZXKfzksPMLgnAANU2t+tvW4q0ZGOhDlc3269PS4/UHRek6orx8bL50vUUnoMg4oHiwwJ0zYQEfbC9VH9ak6f/vXWy2SUBOIPdpXX6y7rD+mB7ido6e068DbH56jvZybp9eqpGxdEbCJ6JIOKhHpgzXB9sL9VHO0r1b5ePZggXcEEdXd36bFeZ/rK+QJsLjtqvj0kI1T0z0nTdpEQF+fPPNDwb/4d7qPFJYZo7KkYr91fq96sO6Vc3nGd2SQB6VTS06q2NRVqy8bD90Dlfq0VXjI/XPTPTNTUtghNv4TUIIh7s4YtHaOX+Sr27pVg/uHSk4kLZ1geYxTAMbSs8qtfXHdanu46oo6tn8WlMiE23T0vV7dNT+TsKr0QQ8WDTMiJ1fnqENhcc1Z9W5+nJq8eaXRLgdVo7uvTh9lK9vr5Au0vr7dez0yJ094w0XTk+gUPn4NUIIh7uoYtH6L7Fm7VkY6EeumiEIoL9zS4J8ApFNc16Y+NhLd1cZD/11uZr1bcmJeruGekan8RuNkAiiHi8i0bFaGxCqPYcqdef1uTpx/OzzC4J8FiGYWjtwWr9eV2BvthXLqNn9kVJ4YG6a0aabpmawg8DwDcQRDycxWLRo5eO1MI3tmrx2gLdPytDUcNsZpcFeJTWji79Y3uJXltToNzyBvv1OSOjdfeMdF2SFctxC8ApEES8wPxxcRqfFKpdJfX6w6o8/fyqMWaXBHiEioZWvbH+sN7YWGg/eC7I30c3Zifr7hnpGhE7zOQKAddHEPECFotF/zZvtO5bvFmvryvQA7MzFMvqfOCs7S6t02trCvTRjlK1d/U0H0sKD9Q9M9N0y/mpCgv0M7lCwH0QRLzERaNiNCU1XNsKa/XSikN6+rpxZpcEuJWubkNf7qvQq2vytCGvxn59Smq4Fswervnj4jh4DjgLBBEvYbFY9KN5o3X7nzbqzY2FWjA7QymRdFsFzqSprVPvbCnS4nUF9rNffKwWXXVegu6fla7JqREmVwi4N4KIF5k5IlqzRkRp7cFqPbcslzNogNMoPtqs19cV6O3NRWpo7ZQkhQb46rbpqbpnRroSwwNNrhDwDAQRL/PElWN07W/X6B/bS3X/rAxNTAk3uyTAZfR1P31tTYE+212mru6e/bcZ0cG6f1a6vpOdzNkvwBDjb5SXGZ8UphsmJ+nv20r0fz/Zq6XfvYAzLeD1Orq69emuMr26Jl87imrt12eNiNKC2Rm6aFSsrGy/BRyCIOKFfjRvtD7++og25ddo+Z5yzRsXb3ZJgCnqmjv05qZC/WV9gY7UtUqS/H16up/ePztDYxJCTa4Q8HwEES+UGB6oB+Zk6HdfHdKiT/dp7ugY2Xx9zC4LcJq8ykYtXlugd7cWq6WjS5IUPcxfd16QpjumpykmhKZ/gLMQRLzUwrmZ+tuWYuVXNelPq/P18MUjzC4JcCjDMLTuULVeXZOvL/dV2K9nxYdowewMXTsxUQF+BHLA2QgiXiokwE9PXjVGjy3drt98eUDXT05SErsA4IH6Tr99bW2+9pX1tF+3WKRLs2J1/6wMzciMYp0UYCKCiBf71qREvbmpUJvya/TLf+7Ry3dmm10SMGQqG9r0xobDWrLxsKoae9qvB/r56KapybpvVoYyooNNrhCARBDxahaLRf/5rXG6+sU1+nRXmVbtr9SFo2LMLgs4J3tK6/Xa2nx9uP1Y+/XEsADdMzNdt56fqrAg2q8DroQg4uWy4kN178x0vbomX09+sFOfP3YhfRLgdrrt7dfztT6v2n59cmq4FszO0Pxx8fKj/TrgkvjGgX54+Sh9tqtMRTUten7Zfv3imrFmlwQMSFNbp97dWqzFa/NVcFz79SvHx+v+2RmaQvt1wOURRKBhNl/93xvG697Fm/Xa2nxdPSGBf8Dh0kpqW/SXdQV6a1Oh6nvbr4cE+Or2aam6e2Y6C68BN0IQgSTpotGx+vaUno6rP333a/3z0dn0FoHL2VZ4VK+uyddnu/q3X79vVrq+MyVZwTb+SQPcDX9rYfeLq8dqZW6lDlQ06oXl+/XElWPMLglQ53Ht17cf1359ZmaU7p+VoUuyaL8OuDOCCOwigv31q2+fp+/9dateWZWni0bFakZmlNllwUvVNXfo7c2Fen1dgUqPa79+3aRE3T8rQ2MTab8OeAKCCPqZPy5et56forc3F+nf/rZdnz52ocIC2e4I58mvatLitfl6d2uxmtt72q9HBfe0X7/zAtqvA56GIIIT/OKasVqfV63D1c36xQe79L+3TqLzJByqr/36a2vy9WVuhYye5R/Kig/R/bMzdB3t1wGPRRDBCYJtvvp/t0zSTb9frw93lGpGZpRum5ZqdlnwQK0dXfrH9hK9tqZAueUN9uuXZMVqwewMzaT9OuDxCCI4qSmpEfrRvNH678/26akPd+u8pDCNTwozuyx4iIr6Vv11w2Et2Viomqae9utB/j66KTtZ98xM1/CYYSZXCMBZCCI4pe9dOFxbCmr0xb4KPbRkmz76/mzWi+Cc7Cyu02tr8/XPr0vV0dUz/5IUHqh7Z6br5vNT+P8L8EIEEZyS1WrR8zdP1NUvrlFhTbMeX7pdr9w9VT5slcQgdHZ1a/mecr22Nl+bC47ar5+fHqH7Z2Xo8rFx8qX9OuC1CCI4rfAgf7185xTd+Pv1+mJfhX79+T76i2BA6lo69LfNRfrzugKV1LZIknytFl07MVH3zUrXhORwcwsE4BIIIjijCcnhevbGCfrB29v1h5V5Ghkbohuzk80uCy4qv6pJf16br3eO234bGeyvO6an6s4L0hQXGmByhQBcCUEEA/KtSUk6UN6o3351UD//+06lRgZpWkak2WXBRXR3G1p9sEqvryvQV8dtvx0dF6L7Z6frW5OS2H4L4KQIIhiwxy8fpYMVjfpsd5keeH2z/rZwhrLi6W7pzepbO/TulmL9dcNh5Vc12a9fmhWr+9l+C2AALIbR97OL66mvr1dYWJjq6uoUGsoXnitoae/Sna9u1NbDRxUXatN7/2emkiOCzC4LTpZb1qC/rC/Q+zkl9umXEJuvbpyarLsuSGP7LeDlBvP9TRDBoNU2t+um36/XgYpGDY8J1tLvzqDtthfo2/3y+voCbcirsV8fFTdMd89I1w2Tkzj9FoCkwX1/O3zP3Mcff6zp06crMDBQ0dHR+va3v+3oj4SDhQf56y8LpikxLEB5lU26/Y8bVNXYZnZZcJCqxjb99ssDmvPrr/R/lmzThrwa+VgtunJ8vN568AJ9/tiFuvOCNEIIgLPi0H853nvvPT344IP61a9+pUsuuUSGYWjnzp2O/Eg4SUJYoN588ALd8krPyMgdf9yoNx+crqhhjIx4AsMwtK2wVm9sOKyPvz6i9q5uST2Hz902LVW3T09VYnigyVUC8AQOm5rp7OxUenq6nnnmGS1YsOCsfg+mZlxfflWTbvnDelU0tGlk7DD9dcF0xYexPdNd1bd26IOcEr25sVD7yo6d/TIpJVz3zEzTVeclyObL7hcApzeY72+HjYhs27ZNJSUlslqtmjx5ssrKyjRp0iQ999xzGjdu3Enf09bWpra2Y0P89fX1jioPQyQjOlhvf/cC3fbHDTpQ0ajvvLxOf10wjcWKbsQwDG0vqtWbGwv10delau3oGf2w+Vp1zYRE3T0jTRNTws0tEoDHctiIyNtvv63bbrtNqampeuGFF5Senq7nn39ey5Yt0/79+xUZeWIPiqefflrPPPPMCdcZEXF9RTXNuvu1TcqvalJUsL9eu/d8vrxcXENrhz7YXqo3NxZq75FjoX9U3DDdPi1VN0xOVlgQZ78AGDyH7po5VVg43ubNm7V//37dcccd+sMf/qDvfve7knpGPJKTk/XLX/5S3/ve905438lGRFJSUggibqKqsU33vLZJu0vrZfO16vmbJ+qaCYlml4Xj9I1+LN1cpA93lNq33vr7WnXNeQm6fXqqstMi6P0B4Jw4dGrmkUce0a233nra16Snp6uhoWd+eezYsfbrNptNw4cPV2Fh4UnfZ7PZZLOx2NFdRQ+z6e3vXqBH38rRV7mVeuTNHB2saNSjl4yUlYPyTFVR36r3c0r0ztZiHaxotF/PjAnW7dPT9J0pSQoP8jexQgDeatBBJDo6WtHR0Wd8XXZ2tmw2m3JzczV79mxJUkdHhwoKCpSWljb4SuEWQgL89Kd7ztevPtmrV9fk63/+dUDbi2r1/E0T2VHjZO2d3fpib7ne2Vqslfsr1dXdM/gZ4GfVFePiddu0VE3LiGT0A4CpHLZYNTQ0VAsXLtRTTz2llJQUpaWl6dlnn5Uk3XTTTY76WLgAH6tFv7hmrEbHh+gXH+zSitxKXfXiar1462RNHx5ldnkeb1dJnd7dWqx/bC/R0eYO+/UpqeG6aWqKrp6QoNAA1n4AcA0O7SPy7LPPytfXV3fddZdaWlo0ffp0ffnll4qIiHDkx8JF3Dw1RROSw/Twkm06VNmk2/64QY9cMlKPXDxC/r4O76XnVYpqmvXhjlJ9uL1UueXHtt3Ghdr07SnJujE7WZnsZALggmjxDodrbu/Uf/xjt97dWiypZ1fGf39ngianEkjPRWVDmz7+ulT/2FGqnMJa+3V/H6suHxenm7KTNWdkjHxYnwPAyThrBi7pox2levrD3apuapfFIt07M13/Nm+0htEafMDqWjr0+e4yfbSjVGsPVql32YesFmlGZpS+NTFJ88fHKyyQqRcA5iGIwGUdbWrXf328R3/fViJJih7mr8cuG6Vbz0+Rrw/TNSdTUd+qZXvK9fnuMq0/VK3O7mN/ZSelhOu6iYm6ZkKCYkPpaAvANRBE4PJW7q/U0x/uVn5Vk6SebaQ/vSJLl4+NYxeHpMPVTfp8d5k+312ubYVHdfzf0lFxw3TdxERdOzFRaVHB5hUJAKdAEIFb6Ojq1psbC/W/XxxQTVO7JCkrPkQL52bqmgkJXjVC0t7ZrS0FNVq5v1Irciv7LTiVekY+5o+L1/xxcbTPB+DyCCJwK/WtHfr9ikN6fV2Bmno7fSZHBOremem6YXKSx/YfKapptgePdYeq7F1OpZ4t0DOGR2n+uDhdPjaegwQBuBWCCNxSXXOH/rqhQIvXFqi6d4TEz8eieePidcvUFM3MjHLbURLDMFRY06yNeTXakF+tjXk1Kqlt6fea6GE2zR0Vo4tGx2jOyGg6nQJwWwQRuLWW9i79PadYb28q0s6SOvv1iCA/XT42TleMj9fMzGgF+LnucfStHV3ae6ReO0vqtPXwUW3Mq1FZfWu/1/hYLZqSGq6LRsdq7qgYjU0IpRU+AI9AEIHH2FVSp6Wbi/TPr0v7dQm1+VqVnRahGcOjNCMzSuMSwxTob04wqW1u18GKRu0vb9Su0jp9XVyr3LIGdXT1/6vl52PRhORwTc+I1PThUcpOi2DrMgCPRBCBx+ns6tamghp9vqtMy/aU60hd/9EFq0XKjBmmcYmhykoIVXpUkFIjg5UWFaTgc/yy7+42VNXUppKjLSqtbVVpbYsKa5p1sKJRByoaVdXYdtL3RQb7a0JymD18TEmNMC0sAYAzEUTg0QzD0KHKJq3Pq9b6Q1XalF+jqsb2U74+xOaryGH+igz2V0SQvwL8rLL5+sjma5W/r1WG0bODp72zW+1d3Wrt6FZtc7uONrertrlDtS0d9gPjTiUpPFCZscM0Jj5EE5LDNSE5TMkRgWxFBuCVCCLwKoZhqKKhTbtL67SrpF4HKxp1uKZZhdVN/aZzzoXVIsWFBigpPFCJ4YFKighUZswwjYwdpszYYUyxAMBxBvP9zb+ecHsWi0VxoQGKCw3QJVlx/Z6rb+1QVUObapraVdXYrrqWdrV19ox+tHV2q62jS7JYZPO1ys/HIj+fntGS8CA/hQf52UdRIoP95eemO3YAwJURRODRQgP8FBrgp+ExZlcCADgZfsQDAACmIYgAAADTEEQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqXPn3XMAxJUn19vcmVAACAger73u77Hj8dlw4iDQ0NkqSUlBSTKwEAAIPV0NCgsLCw077GYgwkrpiku7tbpaWlCgkJkcVisV+vr69XSkqKioqKFBoaamKFOBnuj+vjHrk27o/r4x6dnmEYamhoUGJioqzW068CcekREavVquTk5FM+Hxoayv8ALoz74/q4R66N++P6uEendqaRkD4sVgUAAKYhiAAAANO4ZRCx2Wx66qmnZLPZzC4FJ8H9cX3cI9fG/XF93KOh49KLVQEAgGdzyxERAADgGQgiAADANAQRAABgGoIIAAAwjcsGkZdeekkZGRkKCAhQdna2Vq9ePaD3rV27Vr6+vpo0aZJjC/Ryg70/bW1tevLJJ5WWliabzabMzEy99tprTqrWOw32Hi1ZskQTJ05UUFCQEhISdN9996m6utpJ1XqXVatW6dprr1ViYqIsFos++OCDM75n5cqVys7OVkBAgIYPH67f//73ji/USw32/vz973/X5ZdfrpiYGIWGhmrGjBn6/PPPnVOsB3DJILJ06VI99thjevLJJ5WTk6M5c+boyiuvVGFh4WnfV1dXp7vvvluXXnqpkyr1Tmdzf26++WZ98cUXevXVV5Wbm6u33npLWVlZTqzauwz2Hq1Zs0Z33323FixYoN27d+udd97R5s2b9cADDzi5cu/Q1NSkiRMn6re//e2AXp+fn6+rrrpKc+bMUU5Ojn7+85/r0Ucf1XvvvefgSr3TYO/PqlWrdPnll+uTTz7R1q1bdfHFF+vaa69VTk6Ogyv1EIYLmjZtmrFw4cJ+17Kysoyf/exnp33fLbfcYvz7v/+78dRTTxkTJ050YIXebbD359NPPzXCwsKM6upqZ5QHY/D36NlnnzWGDx/e79qLL75oJCcnO6xG9JBkvP/++6d9zU9+8hMjKyur37Xvfe97xgUXXODAymAYA7s/JzN27FjjmWeeGfqCPJDLjYi0t7dr69atmjdvXr/r8+bN07p16075vsWLF+vQoUN66qmnHF2iVzub+/Phhx9q6tSp+vWvf62kpCSNGjVKP/rRj9TS0uKMkr3O2dyjmTNnqri4WJ988okMw1B5ebneffddXX311c4oGWewfv36E+7n/PnztWXLFnV0dJhUFU6lu7tbDQ0NioyMNLsUt+Byh95VVVWpq6tLcXFx/a7HxcWprKzspO85cOCAfvazn2n16tXy9XW5P5JHOZv7k5eXpzVr1iggIEDvv/++qqqq9NBDD6mmpoZ1Ig5wNvdo5syZWrJkiW655Ra1traqs7NT1113nX7zm984o2ScQVlZ2UnvZ2dnp6qqqpSQkGBSZTiZ559/Xk1NTbr55pvNLsUtuNyISB+LxdLv14ZhnHBNkrq6unT77bfrmWee0ahRo5xVntcb6P2Ren46sFgsWrJkiaZNm6arrrpKL7zwgv785z8zKuJAg7lHe/bs0aOPPqr/+I//0NatW/XZZ58pPz9fCxcudEapGICT3c+TXYe53nrrLT399NNaunSpYmNjzS7HLbjc8EF0dLR8fHxO+MmtoqLihJ8IJKmhoUFbtmxRTk6OHnnkEUk9X3yGYcjX11fLli3TJZdc4pTavcFg748kJSQkKCkpqd+R0GPGjJFhGCouLtbIkSMdWrO3OZt7tGjRIs2aNUs//vGPJUkTJkxQcHCw5syZo1/+8pf8xG2y+Pj4k95PX19fRUVFmVQVvmnp0qVasGCB3nnnHV122WVml+M2XG5ExN/fX9nZ2Vq+fHm/68uXL9fMmTNPeH1oaKh27typ7du32x8LFy7U6NGjtX37dk2fPt1ZpXuFwd4fSZo1a5ZKS0vV2Nhov7Z//35ZrVYlJyc7tF5vdDb3qLm5WVZr/38OfHx8JB37yRvmmTFjxgn3c9myZZo6dar8/PxMqgrHe+utt3TvvffqzTffZG3VYJm3TvbU3n77bcPPz8949dVXjT179hiPPfaYERwcbBQUFBiGYRg/+9nPjLvuuuuU72fXjGMN9v40NDQYycnJxo033mjs3r3bWLlypTFy5EjjgQceMOuP4PEGe48WL15s+Pr6Gi+99JJx6NAhY82aNcbUqVONadOmmfVH8GgNDQ1GTk6OkZOTY0gyXnjhBSMnJ8c4fPiwYRgn3p+8vDwjKCjI+OEPf2js2bPHePXVVw0/Pz/j3XffNeuP4NEGe3/efPNNw9fX1/jd735nHDlyxP6ora0164/gVlwyiBiGYfzud78z0tLSDH9/f2PKlCnGypUr7c/dc889xty5c0/5XoKI4w32/uzdu9e47LLLjMDAQCM5Odl4/PHHjebmZidX7V0Ge49efPFFY+zYsUZgYKCRkJBg3HHHHUZxcbGTq/YOX331lSHphMc999xjGMbJ78+KFSuMyZMnG/7+/kZ6errx8ssvO79wLzHY+zN37tzTvh6nZzEMxl0BAIA5XG6NCAAA8B4EEQAAYBqCCAAAMA1BBAAAmIYgAgAATEMQAQAApiGIAAAA0xBEAACAaQgiAADANAQRAABgGoIIAAAwDUEEAACY5v8DVFNSeP/dujsAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiIAAAGdCAYAAAAvwBgXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA5/ElEQVR4nO3dd3Tc1Z3//9eojXrvXa5yL3IvYMAYA6EmYHozBC8QQtjdJIRkgWw2/p5A+OUkBBISajCmG0gwYAdww90W7l29N0ujXj+/PyQNFm6SrZnPSPN8nDNn48/MeN7ej/G8dO/73msxDMMQAACACTzMLgAAALgvgggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDReZhdwJh0dHSoqKlJQUJAsFovZ5QAAgF4wDEO1tbWKj4+Xh8eZxzxcOogUFRUpKSnJ7DIAAMA5yM/PV2Ji4hlf49JBJCgoSFLnHyQ4ONjkagAAQG/YbDYlJSXZv8fPxKWDSPd0THBwMEEEAIABpjdtFTSrAgAA0xBEAACAaQgiAADANAQRAABgGoIIAAAwDUEEAACYhiACAABMQxABAACmIYgAAADTEEQAAIBpCCIAAMA0BBEAAGAalz70zlEOldTq/Z0FCvP30X/MG2p2OQAAuC23HBEprmnUi+uy9NE3hWaXAgCAW3PLIJIQ6idJKqpuNLkSAADcm1sGkbiuIGJralNdc5vJ1QAA4L7cMogEWr0U7NvZHlPMqAgAAKZxyyAiSfFdoyKFBBEAAEzj9kGkqLrJ5EoAAHBfbhxEfCV1rqABAADmcOMgwtQMAABmc98gEtIZRIqZmgEAwDTuG0S6e0SYmgEAwDRuG0TiQrp6RKqb1NFhmFwNAADuyW2DSGyIrywWqaW9Q5X1LWaXAwCAW3LbIOLt6aGYoM5REbZ6BwDAHG4bRCQpjiW8AACYyq2DyLdLeFk5AwCAGdw6iHAKLwAA5nLrIGJfOcPUDAAApnDrIMLUDAAA5nLrIMLUDAAA5nLrINI9NVNe26zmtnaTqwEAwP04LYgsXbpUFotFjzzyiLM+8qzCA3xk9er8f0FpTbPJ1QAA4H6cEkS2bdumF198UePHj3fGx/WaxWL5dnqGhlUAAJzO4UGkrq5Ot956q/72t78pLCzM0R/XZ92bmtEnAgCA8zk8iDz44IO68sorNX/+/LO+trm5WTabrcfD0eJDaFgFAMAsXo78zd966y3t3LlT27Zt69Xrly5dqqeeesqRJZ0kzj41wxJeAACczWEjIvn5+frxj3+sN954Q76+vr16z2OPPaaamhr7Iz8/31Hl2SUwNQMAgGkcNiKyY8cOlZWVKSMjw36tvb1d69at03PPPafm5mZ5enr2eI/VapXVanVUSacUz14iAACYxmFB5JJLLtGePXt6XLv77ruVnp6un/3sZyeFELN8G0SaZBiGLBaLyRUBAOA+HBZEgoKCNHbs2B7XAgICFBERcdJ1M3Uv361rblNNY6tC/X1MrggAAPfh1jurSpKvt6eigjqngwqOMz0DAIAzOXTVzHetWbPGmR/Xa4lhfiqvbVbB8QaNTQgxuxwAANyG24+ISFJimL8kRkQAAHA2gog6R0QkgggAAM5GENGJQaTB5EoAAHAvBBF9u3KGEREAAJyLIKKePSKGYZhcDQAA7oMgom+nZuqa22RrbDO5GgAA3AdBRJ17iUQGdu4lkk+fCAAATkMQ6cLKGQAAnI8g0oWVMwAAOB9BpAubmgEA4HwEkS5MzQAA4HwEkS4JTM0AAOB0BJEuSV1BpJC9RAAAcBqCSJeE0M4ekVr2EgEAwGkIIl38fDwVGegjib1EAABwFoLICRK6Vs4UVtOwCgCAMxBETsDKGQAAnIsgcgI2NQMAwLkIIidgUzMAAJyLIHKCxFCmZgAAcCaCyAnsUzNVDewlAgCAExBETtA9NVPb3KaaxlaTqwEAYPAjiJzAz8dT0UFWSVJuJQ2rAAA4GkHkO1IiOkdF8qoIIgAAOBpB5DuSwgkiAAA4C0HkO5K7gwhTMwAAOBxB5DuYmgEAwHkIIt+RzNQMAABOQxD5ju4ekeKaRrW0dZhcDQAAgxtB5DuiAq3y8/ZUh8EpvAAAOBpB5DssFgvTMwAAOAlB5BTsS3gr602uBACAwY0gcgqsnAEAwDkIIqfA1AwAAM5BEDmF7iDCeTMAADgWQeQUkrumZvKrGmQYhsnVAAAweBFETiEh1E8Wi1Tf0q6q+hazywEAYNAiiJyCr7enYoN9JUm59IkAAOAwBJHT6O4TySeIAADgMASR0+AUXgAAHI8gchr2lTOMiAAA4DAEkdNIZlMzAAAcjiByGvSIAADgeASR0+gOIsU1TWpqbTe5GgAABieCyGmEB/goyNdLEtMzAAA4CkHkNCwWi9IiAyRJ2RWcwgsAgCMQRM4gNaIziOQQRAAAcAiCyBmkdo2I5FQSRAAAcASHBpGlS5dq6tSpCgoKUnR0tK699lodOnTIkR/Zr1K7lvAyNQMAgGM4NIisXbtWDz74oDZv3qzVq1erra1NCxYsUH39wPhit4+IVNCsCgCAI3g58jf/7LPPevz6lVdeUXR0tHbs2KELLrjAkR/dL9K6ekRKbE1qbGmXn4+nyRUBADC4OLVHpKamRpIUHh5+yuebm5tls9l6PMwUFuCjED9vSfSJAADgCE4LIoZh6NFHH9WcOXM0duzYU75m6dKlCgkJsT+SkpKcVd5pfTs9QxABAKC/OS2IPPTQQ9q9e7eWL19+2tc89thjqqmpsT/y8/OdVd5ppXU3rDIiAgBAv3Noj0i3H/3oR/r444+1bt06JSYmnvZ1VqtVVqvVGSX1GiMiAAA4jkODiGEY+tGPfqQVK1ZozZo1SktLc+THOUQaK2cAAHAYhwaRBx98UG+++aY++ugjBQUFqaSkRJIUEhIiPz8/R350v+neXZWpGQAA+p9De0ReeOEF1dTUaN68eYqLi7M/3n77bUd+bL/qnpopr21WXXObydUAADC4OHxqZqAL8fNWeICPqupblFNRr7EJIWaXBADAoMFZM72Q0rVyhr1EAADoXwSRXkjjFF4AAByCINIL3X0i2aycAQCgXxFEeqE7iOQyNQMAQL8iiPSCfWqGIAIAQL8iiPRCamRns2pFXYtsTa0mVwMAwOBBEOmFIF9vRQV1bj2fVc6oCAAA/YUg0ktDozqnZ7LK60yuBACAwYMg0ktDowIlSccIIgAA9BuCSC8N6Q4iZUzNAADQXwgivWSfmqlgRAQAgP5CEOml7qmZnIoGtbV3mFwNAACDA0GklxJC/WT18lBLe4cKjjeaXQ4AAIMCQaSXPDws3/aJ0LAKAEC/IIj0wRD7El4aVgEA6A8EkT5gCS8AAP2LINIH3StnCCIAAPQPgkgffDsiwtQMAAD9gSDSB909IlX1LTpe32JyNQAADHwEkT7w9/FSfIivJDY2AwCgPxBE+mhoNFu9AwDQXwgifWTvE2FEBACA80YQ6SP7yhlGRAAAOG8EkT7q3l01iyW8AACcN4JIH3VPzeRWNailjcPvAAA4HwSRPooJtirQ6qX2DkO5lUzPAABwPggifWSxWOwrZ46UMT0DAMD5IIicgxFdQeRwaa3JlQAAMLARRM7BiJggSdKRUkZEAAA4HwSRczAshhERAAD6A0HkHHSPiGRX1Ku1nZUzAACcK4LIOYgP8VWg1UttHYZyKlg5AwDAuSKInAOLxaJh9oZV+kQAADhXBJFzNJyVMwAAnDeCyDmyr5wpI4gAAHCuCCLnaHjXyhmW8AIAcO4IIufoxJUznDkDAMC5IYico7gTV85w5gwAAOeEIHKOeq6coU8EAIBzQRA5DyNiWMILAMD5IIich2/PnGFEBACAc0EQOQ/D7Ut4GREBAOBcEETOQ/emZjmsnAEA4JwQRM5DXIivgrpWzmRz5gwAAH1GEDkPFotFI2I7p2cOlthMrgYAgIGHIHKe0u1BhIZVAAD6iiByntLjgiVJB4sZEQEAoK8IIudpVNeIyIFiRkQAAOgrpwSR559/XmlpafL19VVGRobWr1/vjI91iu4ekRJbk47Xt5hcDQAAA4vDg8jbb7+tRx55RI8//rgyMzM1d+5cXX755crLy3P0RztFsK+3EsP8JNEnAgBAXzk8iDz77LNavHix7r33Xo0aNUp/+MMflJSUpBdeeMHRH+00o7r7RFg5AwBAnzg0iLS0tGjHjh1asGBBj+sLFizQxo0bT3p9c3OzbDZbj8dA0N0ncpA+EQAA+sShQaSiokLt7e2KiYnpcT0mJkYlJSUnvX7p0qUKCQmxP5KSkhxZXr9JZ0QEAIBz4pRmVYvF0uPXhmGcdE2SHnvsMdXU1Ngf+fn5zijvvHXvJXKotFbtHYbJ1QAAMHB4OfI3j4yMlKen50mjH2VlZSeNkkiS1WqV1Wp1ZEkOkRIRIF9vDzW1dii3sl5DogLNLgkAgAHBoSMiPj4+ysjI0OrVq3tcX716tWbNmuXIj3YqTw+LRsawwyoAAH3l8KmZRx99VH//+9/18ssv68CBA/rJT36ivLw8LVmyxNEf7VTpseywCgBAXzl0akaSFi1apMrKSv36179WcXGxxo4dq5UrVyolJcXRH+1U6XFdO6wyIgIAQK85PIhI0gMPPKAHHnjAGR9lGvYSAQCg7zhrpp90r5zJr2pUbVOrydUAADAwEET6Sai/j+JCfCVJh5ieAQCgVwgi/ah7emZfEdMzAAD0BkGkH42N7w4iNSZXAgDAwEAQ6UdjEkIkSXsLGREBAKA3CCL9aEzXiMjh0lo1t7WbXA0AAK6PINKPEkL9FOrvrbYOQ4dL6swuBwAAl0cQ6UcWi0Vj4zunZ+gTAQDg7Agi/ax7emYvQQQAgLMiiPQzGlYBAOg9gkg/617Ce7DEprb2DpOrAQDAtRFE+llqRIACfDzV1NqhrIp6s8sBAMClEUT6mYeHRaO7+0QK6RMBAOBMCCIOMMa+coY+EQAAzoQg4gBjGBEBAKBXCCIOMLZr5cz+Ips6OgyTqwEAwHURRBxgWHSgfLw8VNvcpvzjDWaXAwCAyyKIOIC3p4dGxQZJkvYwPQMAwGkRRBxkXGLn9MzuAoIIAACnQxBxkPGJoZKkXfnVptYBAIArI4g4yMSkUEmdUzPtNKwCAHBKBBEHGRoVKH8fTzW0tOtYeZ3Z5QAA4JIIIg7i6WHRuK5lvN8wPQMAwCkRRBxoQtf0zO6CalPrAADAVRFEHGiCvWGVlTMAAJwKQcSBxnct4T1YYlNTa7vJ1QAA4HoIIg6UGOaniAAftbYbOlDMAXgAAHwXQcSBLBaLfVSEjc0AADgZQcTBuhtW2dgMAICTEUQczN6wysoZAABOQhBxsO6pmWPl9bI1tZpcDQAAroUg4mARgVYlhvlJkvbSJwIAQA8EESfo7hPJpE8EAIAeCCJOMDk5TJK0M/e4yZUAAOBaCCJOkJHSFUTyjsswOIkXAIBuBBEnGB0XLKuXh443tCq7ot7scgAAcBkEESfw8fKwr57ZwfQMAAB2BBEnmXzC9AwAAOhEEHGSjK6GVUZEAAD4FkHESbpHRI6U1ammkY3NAACQCCJOExloVUqEvwxD+ob9RAAAkEQQcSqmZwAA6Ikg4kTd0zOZNKwCACCJIOJU3TusZuZVq72Djc0AACCIONHI2CAF+HiqrrlNh0trzS4HAADTEUScyNPDokn0iQAAYEcQcbLuc2e25VSZXAkAAOYjiDjZ9LRwSdKWrCoOwAMAuD2HBZGcnBwtXrxYaWlp8vPz09ChQ/XEE0+opaXFUR85IExKDpOXh0UltiYVHG80uxwAAEzl5ajf+ODBg+ro6NBf//pXDRs2THv37tV9992n+vp6PfPMM476WJfn5+Op8Ykh2plXrS3ZVUoK9ze7JAAATOOwILJw4UItXLjQ/ushQ4bo0KFDeuGFF9w6iEjS9CERnUEkq1I/yEg0uxwAAEzj1B6RmpoahYeHn/b55uZm2Wy2Ho/BaFpXn8hWGlYBAG7OaUHk2LFj+tOf/qQlS5ac9jVLly5VSEiI/ZGUlOSs8pwqIyVMHhYpt7JBJTVNZpcDAIBp+hxEnnzySVksljM+tm/f3uM9RUVFWrhwoW644Qbde++9p/29H3vsMdXU1Ngf+fn5ff8TDQDBvt4aHR8siVERAIB763OPyEMPPaSbbrrpjK9JTU21/++ioiJddNFFmjlzpl588cUzvs9qtcpqtfa1pAFpelqE9hbatDW7UldPiDe7HAAATNHnIBIZGanIyMhevbawsFAXXXSRMjIy9Morr8jDg21Luk1LC9dLG7K1JYsREQCA+3LYqpmioiLNmzdPycnJeuaZZ1ReXm5/LjY21lEfO2BMTe1sWD1SVqfKumZFBLrHSBAAACdyWBBZtWqVjh49qqNHjyoxsecSVXYUlcIDfDQiJlCHS+u0Lee4Fo4lnAEA3I/D5kruuusuGYZxygc6dS/j3ZxVaXIlAACYg6YNE80a2tlrs/FYhcmVAABgDoKIiWYOiZDFIh0urVNZLfuJAADcD0HERGEBPhod17mfyKZjTM8AANwPQcRks4d1Ts98fZTpGQCA+yGImGzW0AhJ0tdHK2nkBQC4HYKIyaalhcvb06LC6kblVjaYXQ4AAE5FEDGZv4+XJiWFSZK+ZvUMAMDNEERcQHefyMajNKwCANwLQcQFzB7W2Sey8ViFOjroEwEAuA+CiAuYkBSqAB9PHW9o1YESm9nlAADgNAQRF+Dt6WHf7p1lvAAAd0IQcRHdfSLrjxBEAADugyDiIuaNjJIkbcmuUmNLu8nVAADgHAQRFzE0KlAJoX5qaevgNF4AgNsgiLgIi8WiC7tGRdYcKjO5GgAAnIMg4kIuHNEVRA6Xm1wJAGAwq2tu0xcHSvW//9qv5VvzTK3Fy9RPRw+zh0XKy8Oi3MoG5VTUKzUywOySAACDQHNbu3bmVmvjsQp9fbRCuwpq1N61b9XU1DDdPC3ZtNoIIi4k0OqlKalh2pxVpTWHynRXZJrZJQEABiDDMHS4tE7rj5Rrw9EKbcmqUmNrz4UQKRH+mjU0UhcMjzSpyk4EERczb2S0NmdVae3hct01myACAOidstomfX20QusPV2jD0QqV1Tb3eD4y0KrZwyI0e2ikZg2LUGKYv0mV9kQQcTEXjojS//v0oDZlVaqptV2+3p5mlwQAcEGNLe3akl2pDUc6g8fBktoez/t6e2haWoTmDovUnOGRSo8NksViMana0yOIuJj02CDFBvuqxNakrdlVuqCrgRUA4N46OgztK7Jp/dFybThSoe05x9XS3mF/3mKRxsQHa86wKF0wPFKTU8IGxA+zBBEXY7FYdOGIKL29PV9rDpUTRADAjVXVt2jd4XKtOVSmdUcqVFXf0uP5hFA/zeka8Zg9LFLhAT4mVXruCCIuaN7IziDyxcFS/ep7o1xyKA0A0P/aOwztLqjWmkPlWnO4XLsLqmWccCh7oNVLM4ZEaO7wzvAxJDJgwH9HEERc0NwRUfLx9FBuZYOOltVpeEyQ2SUBAByksq5Z646Ua82hcq07XK7jDa09nk+PDdK8kdGaNzJKGSlh8vYcXFuAEURcUKDVS7OGRWjNoXKtPlBKEAGAQaS9w9CurlGPtYfKtLuwpseoR5DVS3OGR2reyChdOCJasSG+5hXrBAQRFzV/VExnENlfqgfmDTO7HADAeahpaNWaw2X68mDZKUc9RsUFa97IKM0bEaXJg3DU40wIIi5q/qgY/fLDvfomv1pltU2KDhrciRgABpus8jp9caBM/z5Qqu25x+07mUpSkK+X5g6P1LwR0bpwZJRigt3333iCiIuKDfHV+MQQ7S6o0VcHy7Roqnnb7wIAzq6tvUPbco7ry4Ol+uJAmbIq6ns8PyImUBenx+ji9GhNSg51q1GPMyGIuLD5o2K0u6BGq/eXEkQAwAV1T7l8caBMaw6VydbUZn/O29Oi6WkRumRUtC5Jj1FyhGvsZOpqCCIu7NLRMXp29WGtP1KhxpZ2+fm4/sY0ADDYnWnKJczfWxeldwaPC0ZEKsjX28RKBwaCiAtLjw1SQqifCqsbteFohS4dHWN2SQDgdgzD0O6CGq3aX6LP95XqaFldj+eHRwfqklExmj8qWpOSw+TpMbD39XA2gogLs1gsunR0jF7dmKPV+0sIIgDgJG3tHdqaXaXP95Vo1f5SFdc02Z/z8rBoxhCmXPoLQcTFLbAHkVK1tnfQ3AQADtLY0q51R8r1+b4SfXmwTNUnLLH19/HUvJFRumxMrOaNjFaIH1Mu/YUg4uKmpYUrPMBHVfUt2pJVpTnDI80uCQAGjeqGFn1xoEyf7yvRuiPlamr99hC58AAfzR8VrcvGxGr2sMgBcYDcQEQQcXFenh66bEyslm/N0yd7igkiAHCeymxN+mxfiT7fV6LNWVU9mk0TQv102ZhYXTYmRhkpYfJiFNrhCCIDwJXj4rR8a54+31ei/71mDP9hAEAfldQ06dO9xVq5p1jbc4/32FI9PTZIC8bEasHoGI2JDx7wh8gNNASRAWDGkHCF+Xt3Ts9kV2n2MEZFAOBsimsa9emeEnv4ONHk5FAtHBurBaNjlRoZYFKFkAgiA0L39Mxb2/K1ck8xQQQATqOoulEr93SOfOzMq+7xXEZKmK4YF6fLx8YqPtTPnAJxEoLIAHHFuDi9tS1fn+8r0a+vGcs6dQDoUljdqE/3FOuTPcXKPCF8WCzSFHv4iBv0p9gOVASRAWLm0AiF+nuroq5FW7IrNWsooyIA3FdRdaM+2V2sf+0p1q78avt1i0WamhKuK8bF6vJxcW59mNxAQRAZILw9PbRgdIze2V6glXuKCSIA3E5lXbNW7inWP3cVa2tOlf26xSJNSw3XlePjtHBMrKIJHwMKQWQAuWJcnN7ZXqBP95ToiavGsLkZgEHP1tSqVftK9fGuIn19tKLHUttpaeG6anycLhsbq+ggwsdARRAZQOYMi1REgI8q61u04WiFLhoZbXZJANDvmlrb9cWBMn28q1BfHSpXS9u3m4yNSwjR1RPi9b0JcYoLoeF0MCCIDCBenh66akK8Xt2Yow8zCwkiAAaN1vYObThSoY93FWnVvhLVt7TbnxsWHdgZPsbHaUhUoIlVwhEIIgPMtZMS9OrGHK3aV6r65jYFWLmFAAamjg5DW3Oq9NE3Rfp0b3GPs10SQv101YR4XT0hXqPigthkbBDjW2yAmZAYorTIAGVX1GvV/hJdNynR7JIAoE+OltXqg52F+uibIhVWN9qvRwb66Mpxcbp6YrwmJ4cRPtwEQWSAsVgsumZivP7w7yNakVlEEAEwIFTUNevjb4q0IrNQewpr7NeDrF5aODZW10xM0Iwh4Rxh4YYIIgPQtRMT9Id/H9GGI+Uqq22iWxyAS2pqbdeq/aVasbNA6458u+LFy8OiC0dE6brJCZo/KoZTbd2cU4JIc3Ozpk+frl27dikzM1MTJ050xscOWqmRAZqUHKrMvGr9c1exFs9JM7skAJDU2fexObtSK3YW6tO9JaprbrM/NyExRNdNStBVE+IVEWg1sUq4EqcEkZ/+9KeKj4/Xrl27nPFxbuHaiQnKzKvWiswCgggA0x0prdUHmYX6KLNQRTVN9usJoX66blKCrp2UoGHRrHjByRweRD799FOtWrVK77//vj799FNHf5zbuGpCvH7zyX7tLbRpf5FNo+ODzS4JgJupbmjRx7uK9N6OAu0uOKHvw9dLV46L03WTEjQ1NVwenI2FM3BoECktLdV9992nDz/8UP7+/md9fXNzs5qbm+2/ttlsjixvQAsP8NGlo2O0ck+J3tmeryevHmN2SQDcQHuHoQ1HK/TO9nyt3leqlvbOzca8PCyaNzJK101K1CWjoun7QK85LIgYhqG77rpLS5Ys0ZQpU5STk3PW9yxdulRPPfWUo0oadBZNTdbKPSVakVmon1+ezn/4ABwmu6Je7+3I1wc7C1V8wtRLemyQbpySpGsm0veBc9PnIPLkk0+eNSxs27ZNGzdulM1m02OPPdbr3/uxxx7To48+av+1zWZTUlJSX0t0G3OGRSo+xFdFNU36fF+JrpmYYHZJAAaRuuY2rdxdrHd35GtbznH79VB/b10zIV43TEnSmPhg9vvAebEYhmGc/WXfqqioUEVFxRlfk5qaqptuukn//Oc/e/wFbW9vl6enp2699Va99tprZ/0sm82mkJAQ1dTUKDiYHohTeXb1Yf3xiyOaPSxCy+6dYXY5AAY4wzC0JbtK724v0Kd7i9XQtdW6h0W6YESUbshI0vzR0bJ6MQKL0+vL93efg0hv5eXl9ejxKCoq0mWXXab33ntP06dPV2Li2TfiIoicXX5Vgy54+isZhrT+pxcpKfzsvTgA8F1F1Y16f0eB3t1RoLyqBvv1IZEB+sGURF0/KVGxIexZhN7py/e3w3pEkpOTe/w6MLBz2dbQoUN7FULQO0nh/pozLFLrj3Q2j/3ngpFmlwRggGht79CXB8v01tY8rTlcru4fSwN8PHXVhHjdMCWRrdbhcOysOggsmpqk9Ucq9O72Av34kuFskQzgjHIr6/X2tny9u6NA5bXfrlScnhauG6ck6fJxsfL34esBzuG0v2mpqaly0CyQ27t0dIwiAnxUYmvSvw+UauHYOLNLAuBimtvatWpfqd7alqevj1bar0cG+ugHGUlaNDVJaZEBJlYId0XkHQSsXp66eVqynvvqqF7bmEsQAWB3tKxOb23N0weZhaqqb5EkWSzS3OFRunlqki4ZFSMfL0ZRYR6CyCBxy/RkPb/mqDZlVepwaa1GxASZXRIAkzS1tmvlnmIt35rXY9ltbLCvbpySqBumJNHYDpdBEBkk4kP9tGB0rD7bV6LXN+XoN9eOM7skAE52oNimt7bmaUVmoWxNnYfNeXpYdNHIaN08LUkXjoiihwwuhyAyiNwxK0Wf7SvRBzsL9dOF6Qr29Ta7JAAO1j368cbmXO3Mq7ZfTwzz001Tk3TDlCTFBLPsFq6LIDKIzBwSoeHRgTpSVqf3dxTo7tmcygsMVrmV9Vq2JU/vbs/X8YZWSZ3nvSwYE6ObpyVr9tBIDpvDgEAQGUQsFovumJmiX320T69vytWdM1P5hwgYRNraO/TFwTK9sTlX6498u8N1Qqifbp6WpBunJik6iNEPDCwEkUHmusmJ+t1nh5RdUa8vDpbp0tExZpcE4DyV2pr01tZ8vbUtz37gnMUiXTgiSrdNT9FF6dHy5IcODFAEkUEm0OqlW2Yk669rs/TiumMEEWCAMgxDG49V6o3NuVq9v1RtHZ37MIUH+OjGKUm6ZVqykiNY+YKBjyAyCN0zO00vb8jWtpzj2pl3XJOTw8wuCUAv1TS06t0d+XpzS56yKurt16emhum2GSlaODaWA+cwqBBEBqGYYF9dMzFB7+0o0Itrs/SX2zPMLgnAWewpqNHrm3L0z91FamrtkNR55sv1kxN164xkpcdy8CcGJ4LIIPXDC4bovR0F+nx/ibIr6tm6GXBBLW0d+nRvsV7dmKPME5bepscG6bYZKbp2UoICrfwzjcGNv+GD1IiYIF2cHq0vD5bp7+uz9H/XscEZ4CrKbE1atiVPb27Nsx865+1p0RXj4nTHzBROvIVbIYgMYj+8YIi+PFim93YU6Mfzh7OsDzCRYRjamVet1zbmaOWeYnvzaXSQVbdOT9HN01l6C/dEEBnEpqeFa1JyqDLzqvXi2iz98nujzS4JcDtNre36564ivbYpR3sLbfbrU1LCdOesVF02JpZD5+DWCCKDmMVi0Y8vGa67XtmmN7bk6v4LhyoqyGp2WYBbKKpu1Bubc/XWtnz7qbc+Xh66ZkK87pyVqrEJISZXCLgGgsggd+GIKE1ICtWu/Gr9bX2WfnHFKLNLAgYtwzC0OatKr2/K0ar9pWrvmn5JCPXTbTNStGhqksIDfEyuEnAtBJFBzmKx6JFLhuvuV7fpH5ty9cMLhigykFERoD81tLTpw8wivb4pRwdLau3XZw6J0J2zUjV/VDSn3gKnQRBxA/NGRmlCYoh2FdTob+uy9BijIkC/KKxu1Osbc7R8a55sTW2SJD9vT10/OUF3zEzVyNggkysEXB9BxA1YLBb9eP5w3fPqdr2+KVf3zh1CrwhwHnbmHddLG7L12d4S+/RLSoS/bp+RohumJCnEz9vkCoGBgyDiJi4aGW0fFfnTl0f062vGml0SMKC0tXfos30lemlDdo/Nx2YNjdA9s9N0cXo0p10D54Ag4iYsFot+dnm6bvnbFr25JU93z05jt1WgF2oaW/XW1jy9tjFHRV0n3/p4eujqifG6Z3aaRsez9TpwPggibmTW0EjNGxmlNYfK9cyqQ/rzLZPNLglwWTkV9Xrl62y9u6NADS3tkqSIAB/dNiNFt81IYXoT6CcEETfzs4XpWnu4XJ/sLtYP51ZrQlKo2SUBLqN7+e1LG7L1xcFSGZ3tHxoZE6TFc9J09cR4+Xpz8i3QnwgibmZUXLCun5So93cWaOmnB7T8vhmcaQG319zWrn/uKtbLG7K1v/jb3U8vGhmlxXOGaPawCP47ARyEIOKGHl0wQv/cXaTNWVVavb9UC8bEml0SYIrKumYt25Knf2zOtR8+5+vtoR9kJOru2WkaGhVocoXA4EcQcUMJoX66d06anl9zTP/7yX5dMCKK4Wa4lUMltXp5Q7ZWfFOolrYOSVJssK/umJWiW6YlK9Sf3U8BZyGIuKkHLxqmD3YWKr+qUS+uy9LDlww3uyTAoTo6DK09Uq6XN2Rr/ZEK+/UJiSG6Z06arhgXJ292PwWcjiDipgKsXvrFlaP08PJM/fmro7p+coISw/zNLgvod40t7Xp/Z4Fe+Tpbx8rrJUkeFumyMbFaPCdNGSlh9H8AJiKIuLGrxsdp2eZcbcmu0v99ckAv3JZhdklAvympadLrm3L05tY8VTe0SpKCrF5aNDVJd85KVVI4wRtwBQQRN2axWPTk1WP0vT9t0Kd7S7TmUJnmjYw2uyzgvOwuqNbLG7L1r93Fauvafj0p3E93z0rTDVMSFeTL9uuAKyGIuLlRccG6c2aqXv46W4+v2KtVP7lAAVb+WmBgae8wtHp/5/br23KO269PSw3XPXPSdOnoGHmy/TrgkvjGgf5zwQh9vq9EhdWNevrzQ3ry6jFmlwT0Sm1Tq97ZXqBXN2Yrv6pRkuTlYdFVEzq3Xx+XGGJyhQDOhiACBVi9tPT6cbrj5a16bVOOrpoQr4yUMLPLAk4rv6pBr27M0dvb8lXX3CZJCvX31q3Tk3XHzFTFBPuaXCGA3iKIQJJ0wYgofX9y546rP3t/tz55eI6sXuwtAtdhGIa25x7XS+uztWp/ibraPzQ0KkD3zEnT9ZMS5efD31lgoCGIwO5X3xultYfLdLSsTs+uOqzHrhhldkmAWts7tHJPsV7akK3dBTX263OHR2rxnDRdMDxKHvR/AAMWQQR2of4++u114/TDf+zQi+uzdOHIKM0aGml2WXBTx+tb9ObWPL2+KUelts7t1328PHT9pATdMydNI2KCTK4QQH8giKCHBWNidfO0JC3fmq//fGeXPvvxBQrxZ7kjnOdoWa1e/jpHH+wsUFNr5/brkYFW3TkzRbdMT1ZEoNXkCgH0J4IITvKr743W5qwqZVfU6xcf7tFzN09i50k4lGEYWn+kQi9tyNbaw+X262Pig7V4TpquHB9HzxIwSBFEcBJ/Hy/9YdFEff+Fjfpkd7EuGB6pRVOTzS4Lg1BTa7tWZBbq5Q3ZOlJWJ0myWKRLR8Vo8Zw0TUsLJwQDgxxBBKc0ISlUjy4Yod99dki/+mifxsSHaGwCezKgf5TZmvT6plwt25Kr413brwf4eOrGqUm6e1aakiPYfh1wFwQRnNaSC4ZqZ+5x/ftAmZa8sUP/+tEcjkfHedlbWKOXNmTrX7uL1Nreuf42McxPd81K1Y1TkxTM9uuA2yGI4LQ8PCz6/Q0TddVzG5RX1aBH3v5GL985laWS6JPO7ddL9fLX2dqaXWW/PjU1TIvnpGn+qBh5eXqYWCEAMxFEcEYh/t564bbJuv75jVpzqFzPrDqkny5MN7ssDACn2379e+PjdM+cNI1PDDW3QAAugSCCsxoTH6LfXjdO//nuLj2/5phSIwN045Qks8uCi8oqr9Prm3L13o4Ctl8HcFYEEfTK9zMSlV1Rr+e+OqpffLBHiWF+bHYGu44OQ2sPl+vVjTk9lt8Oiw7UPbPTdN2kBLZfB3BKBBH02qOXjlBOZb3+tbtYS/6xQx88MEvDotnd0p3VNLbq3e35+sfmXOVWNkjqXH578cho3TkrVXOHR7L8FsAZEUTQax4eFj1zwwQV1zRpR+5x3f7SVr1z/0wlhbPU0t0cLq3VaxtztCKzUA0t7ZKkYF8vLZqapNtnpLL8FkCvWQzDMMwu4nRsNptCQkJUU1Oj4OBgs8tBl6r6Fi366yYdKatTSoS/3r1/pqKZ9x/02jsM/ftAqV7bmKONxyrt10fGBOnOWam6dlK8/H342QZA376/Hb5m7pNPPtH06dPl5+enyMhIXX/99Y7+SDhYeICP3rh3upLD/ZVb2aDbXtqiqvoWs8uCg1TVt+gva4/pgt99pfv/sUMbj1XKwyItHBOr5ffN0GePzNUt05MJIQDOiUP/5Xj//fd133336be//a0uvvhiGYahPXv2OPIj4SQxwb5adu90/eAvG3W4tE63/G2z/rF4uqKCOJBsMDAMQ9tyjuvNLblauadELe2dh8+F+XvrpmnJum1GihJC/UyuEsBg4LCpmba2NqWmpuqpp57S4sWLz+n3YGrG9R0t6wwhZbXNGhIZoGX3TVdcCF9QA1VNY6tW7CzQsi159rNfJGlcQohun5miqyfEy9eb1S8Azqwv398OGxHZuXOnCgsL5eHhoUmTJqmkpEQTJ07UM888ozFjxpzyPc3NzWpubrb/2mazOao89JNh0YF65/6ZuvXvW5RVUa8b/rJJy+6drpSIALNLQy8ZhqHdBTVatiVXH+8qUlNr5+iHn7enrpkYr1umJ7P5GACHcdiIyFtvvaWbb75ZycnJevbZZ5Wamqrf//73WrVqlQ4fPqzw8PCT3vPkk0/qqaeeOuk6IyKur7C6Ubf+bbNyKhsUEeCjF++YooyUMLPLwhnUN7fp411FWrYlV3sLvw39I2OCdOuMZF07KYGzXwCck76MiPQ5iJwuLJxo27ZtOnz4sG699Vb99a9/1Q9/+ENJnSMeiYmJ+s1vfqP777//pPedakQkKSmJIDJAlNmadPer27SvyCYfLw89e+MEfW98vNll4QSGYWhn3nG9s61A/9pdpPqupbc+Xh66clycbp2erIyUMPb+AHBeHDo189BDD+mmm24642tSU1NVW1srSRo9erT9utVq1ZAhQ5SXl3fK91mtVlmtNDsOVNHBvnrn/pn68VuZ+veBMj30ZqaOltXp4YuHc1CeycpsTfogs1DvbM9XVnm9/XpaZIBumZas72ckKjyAk5UBOF+fg0hkZKQiI8++tXdGRoasVqsOHTqkOXPmSJJaW1uVk5OjlJSUvleKASHA6qW/3j5F//fJAb38dbb+8O8jysyr1v+3aCJfdE7W2t6hLw+W6d3t+frqULnaOzoHP/28PXXl+DjdOCVJU1MZ/QBgLoc1qwYHB2vJkiV64oknlJSUpJSUFD399NOSpBtuuMFRHwsX4Olh0f9cNVqj4oL0q4/2au3hcn3vj+v1p1sm0zfiYIZhaG+hTR9+U6gPMwtVecL+LhkpYbpxSqKuHB+vQCt7fgBwDQ791+jpp5+Wl5eXbr/9djU2Nmr69On68ssvFRbGl5E7uGFKksYlhug/3tip7Ip63fCXjfqPeUP18CXDZfViCWh/yqts6Awf3xT2mHqJCrLq+skJuiEjScOiA02sEABOjS3e4XC1Ta361Yd79eE3RZKk9NggPXPDBI1NCDG5soGtsq5Z/9pdrA+/KVRmXrX9utXLQ/NHx+i6iQmaNzJKXp4O30AZAHpw6KoZZyKIDC6f7S3W4yv2qrK+RZ4eFt0+I0U/uXSEQvxYItpbVfUtWr2/RCv3lGjD0Qp734eHRZo9LFLXTEzQZWNiFMSyWwAmIojAZVXUNeuJj/fpk93FkqSIAB/97PJ0fX9yojxZWXNKZbVN+nxfqT7bW6zNWVX28CF17nh67aQEXTU+joMHAbgMgghc3oYjFXri47061tXPMDw6UI9eOkKXjYllqa+k3Mp6fXGgTJ/tLdG23Cqd+F/pmPhgXT42VpePi9PQKPo+ALgegggGhJa2Dr22MUfPfXVUNY2tkjq/ZP9j3lAtHBPrVr0NLW0d2pZTpS8Plumrg2XKqqjv8fzEpNDO8DE2TskR/iZVCQC9QxDBgGJratXf12fr5Q3ZqmtukyQlhPrpzlkpWjQlWSH+g6/fwTAM5VY2aOOxSq07XK4NRyvsf3ZJ8vKwaGpquOaPjtHlY2MVz0m3AAYQgggGpOP1LXplY46Wbc6173/h4+WhS0fH6AeTEzV3eOSAHiUpqm7UxmOV2nSsUpuOVaiopqnH85GBVl00MkoXp0drzvBIGk4BDFgEEQxoTa3t+uibQr3ydY4OltTar0cG+uiS9BjNHx2jOcMi5efjunuRNLe1a3+RTZl51crMr1Zm3nEVHG/s8RpvT4smJYdp9tBIXZQepbHxIfTHABgUCCIYFAzD0L4im97bUaCPdxWp6oRdQq1eHpqWFq6pqZ2PScmh8vU2J5jUNLbqUEmtDpbYdKC4VgeKbdpfZFNLe0eP13lYpPGJoZo1NEKzhkYqIyXMpcMUAJwrgggGnZa2Dm3JrtQXB8q0en+pCqt7ji54eVg0NCpQI2ODlB4XpGFRgUoI81NiqL+C/bzO6zyVtvYOVdW3qNTWrLyqhq5HvfKqGpRdXn/SFEu38AAfTUoK1aTkUE1KDtP4xBCmWwC4BYIIBjXDMHS4tE5bsiu1NbtKW7OrVFbbfNrXB1q9FBVkVbCft4J9vRTi5y0/b095eljk4WGRh0UyDKmptUONrW1qbGlXQ0u7qupbVFHXrOMNrWetKSHUT+ldIWhkbLAmJoYqKdyPA+UAuCWCCNyKYRgqqmnSoa6pkYMltcqpqFdhdWOP6Zzz4WGRwgOsSg73U3K4v5IjApQc7q/UCH8Njwlid1gAOEFfvr85ghMDnsViUUKonxJC/XRxekyP5xpb2lVY3ajKumbZmtpka2xVTWOrmtra1dFhqL1Dau/K4v4+nvLz9pRf1/8ND/BRRKCPIgOtCvP3YedXAHAAgggGNT8fTw2LDuTkWQBwUQN3UwYAADDgEUQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDQEEQAAYBqCCAAAMI1Ln75rdB3PbrPZTK4EAAD0Vvf3dvf3+Jm4dBCpra2VJCUlJZlcCQAA6Kva2lqFhISc8TUWozdxxSQdHR0qKipSUFCQLBaL/brNZlNSUpLy8/MVHBxsYoU4Fe6P6+MeuTbuj+vjHp2ZYRiqra1VfHy8PDzO3AXi0iMiHh4eSkxMPO3zwcHB/AVwYdwf18c9cm3cH9fHPTq9s42EdKNZFQAAmIYgAgAATDMgg4jVatUTTzwhq9Vqdik4Be6P6+MeuTbuj+vjHvUfl25WBQAAg9uAHBEBAACDA0EEAACYhiACAABMQxABAACmcdkg8vzzzystLU2+vr7KyMjQ+vXre/W+r7/+Wl5eXpo4caJjC3Rzfb0/zc3Nevzxx5WSkiKr1aqhQ4fq5ZdfdlK17qmv92jZsmWaMGGC/P39FRcXp7vvvluVlZVOqta9rFu3TldddZXi4+NlsVj04YcfnvU9a9euVUZGhnx9fTVkyBD95S9/cXyhbqqv9+eDDz7QpZdeqqioKAUHB2vmzJn6/PPPnVPsIOCSQeTtt9/WI488oscff1yZmZmaO3euLr/8cuXl5Z3xfTU1Nbrjjjt0ySWXOKlS93Qu9+fGG2/UF198oZdeekmHDh3S8uXLlZ6e7sSq3Utf79GGDRt0xx13aPHixdq3b5/effddbdu2Tffee6+TK3cP9fX1mjBhgp577rlevT47O1tXXHGF5s6dq8zMTP3iF7/Qww8/rPfff9/Blbqnvt6fdevW6dJLL9XKlSu1Y8cOXXTRRbrqqquUmZnp4EoHCcMFTZs2zViyZEmPa+np6cbPf/7zM75v0aJFxi9/+UvjiSeeMCZMmODACt1bX+/Pp59+aoSEhBiVlZXOKA9G3+/R008/bQwZMqTHtT/+8Y9GYmKiw2pEJ0nGihUrzvian/70p0Z6enqPa/fff78xY8YMB1YGw+jd/TmV0aNHG0899VT/FzQIudyISEtLi3bs2KEFCxb0uL5gwQJt3LjxtO975ZVXdOzYMT3xxBOOLtGtncv9+fjjjzVlyhT97ne/U0JCgkaMGKH/+q//UmNjozNKdjvnco9mzZqlgoICrVy5UoZhqLS0VO+9956uvPJKZ5SMs9i0adNJ9/Oyyy7T9u3b1draalJVOJ2Ojg7V1tYqPDzc7FIGBJc79K6iokLt7e2KiYnpcT0mJkYlJSWnfM+RI0f085//XOvXr5eXl8v9kQaVc7k/WVlZ2rBhg3x9fbVixQpVVFTogQceUFVVFX0iDnAu92jWrFlatmyZFi1apKamJrW1tenqq6/Wn/70J2eUjLMoKSk55f1sa2tTRUWF4uLiTKoMp/L73/9e9fX1uvHGG80uZUBwuRGRbhaLpcevDcM46Zoktbe365ZbbtFTTz2lESNGOKs8t9fb+yN1/nRgsVi0bNkyTZs2TVdccYWeffZZvfrqq4yKOFBf7tH+/fv18MMP63/+53+0Y8cOffbZZ8rOztaSJUucUSp64VT381TXYa7ly5frySef1Ntvv63o6GizyxkQXG74IDIyUp6enif95FZWVnbSTwSSVFtbq+3btyszM1MPPfSQpM4vPsMw5OXlpVWrVuniiy92Su3uoK/3R5Li4uKUkJDQ40joUaNGyTAMFRQUaPjw4Q6t2d2cyz1aunSpZs+erf/+7/+WJI0fP14BAQGaO3eufvOb3/ATt8liY2NPeT+9vLwUERFhUlX4rrfffluLFy/Wu+++q/nz55tdzoDhciMiPj4+ysjI0OrVq3tcX716tWbNmnXS64ODg7Vnzx5988039seSJUs0cuRIffPNN5o+fbqzSncLfb0/kjR79mwVFRWprq7Ofu3w4cPy8PBQYmKiQ+t1R+dyjxoaGuTh0fOfA09PT0nf/uQN88ycOfOk+7lq1SpNmTJF3t7eJlWFEy1fvlx33XWX3nzzTXqr+sq8PtnTe+uttwxvb2/jpZdeMvbv32888sgjRkBAgJGTk2MYhmH8/Oc/N26//fbTvp9VM47V1/tTW1trJCYmGj/4wQ+Mffv2GWvXrjWGDx9u3HvvvWb9EQa9vt6jV155xfDy8jKef/5549ixY8aGDRuMKVOmGNOmTTPrjzCo1dbWGpmZmUZmZqYhyXj22WeNzMxMIzc31zCMk+9PVlaW4e/vb/zkJz8x9u/fb7z00kuGt7e38d5775n1RxjU+np/3nzzTcPLy8v485//bBQXF9sf1dXVZv0RBhSXDCKGYRh//vOfjZSUFMPHx8eYPHmysXbtWvtzd955p3HhhRee9r0EEcfr6/05cOCAMX/+fMPPz89ITEw0Hn30UaOhocHJVbuXvt6jP/7xj8bo0aMNPz8/Iy4uzrj11luNgoICJ1ftHr766itD0kmPO++80zCMU9+fNWvWGJMmTTJ8fHyM1NRU44UXXnB+4W6ir/fnwgsvPOPrcWYWw2DcFQAAmMPlekQAAID7IIgAAADTEEQAAIBpCCIAAMA0BBEAAGAagggAADANQQQAAJiGIAIAAExDEAEAAKYhiAAAANMQRAAAgGkIIgAAwDT/P8DwUliUNgrHAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -699,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 26,
    "id": "79a2bb61-0a5e-4a3a-b195-46d027738a0e",
    "metadata": {},
    "outputs": [],
@@ -709,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 27,
    "id": "b4e6e0c9-a2c6-40ab-884e-a46e16c37b04",
    "metadata": {},
    "outputs": [
@@ -747,7 +686,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -758,7 +697,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 28,
+   "id": "c81e5148-3da3-428d-bf01-4608f7fdb978",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pr.exists_storage('murn')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
    "id": "cef7c46f-551f-401e-96c2-214628e23967",
    "metadata": {},
    "outputs": [
@@ -774,20 +736,20 @@
     }
    ],
    "source": [
-    "murn = GenericTinyJob(pr, 'murn')\n",
-    "murn.task_class = MurnaghanTask\n",
-    "murn.input.task = AseStaticTask()\n",
+    "murn = pr.create.job.Murnaghan(\"murn\")\n",
+    "murn.input.task = pr.create.task.AseStatic()\n",
     "murn.input.task.input.calculator = MorsePotential()\n",
-    "murn.input.structure = bulk(\"Fe\", a=1.2)\n",
+    "murn.input.structure = pr.create.structure.bulk(\"Fe\", a=1.2).to_ase()\n",
     "murn.input.set_strain_range(.5, 500)\n",
-    "murn.input.child_executor = ProcessExecutor\n",
-    "murn.run()\n",
+    "exe = murn.run(executor='process')\n",
+    "if exe is not None:\n",
+    "    exe.wait()\n",
     "murn.output.plot()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 30,
    "id": "e8a7ee30-d7a6-46fc-bf98-1b52c981470f",
    "metadata": {},
    "outputs": [
@@ -848,7 +810,7 @@
        "0  MurnaghanTask  "
       ]
      },
-     "execution_count": 52,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -859,36 +821,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 31,
    "id": "30871447-3e20-46ee-a58e-853d4f4cb5d9",
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:pyiron_log:Not supported parameter used!\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "<pyiron_contrib.tinybase.executor.FuturesExecutionContext at 0x7f15fa17bfd0>"
+       "<pyiron_contrib.tinybase.executor.FuturesExecutionContext at 0x7fad4d845150>"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "j = GenericTinyJob(pr, 'md')\n",
-    "j.task_class = AseMDTask\n",
-    "j.input.structure = bulk('Fe', a=1.2, cubic=True).repeat(2)\n",
+    "j = pr.create.job.AseMD('md')\n",
+    "j.input.structure = pr.create.structure.bulk('Fe', a=1.2, cubic=True).repeat(2).to_ase()\n",
     "j.input.calculator = MorsePotential()\n",
     "j.input.steps = 100\n",
     "j.input.timestep = 3.0\n",
     "j.input.temperature = 600.0\n",
     "j.input.output_steps = 20\n",
-    "j.run(how='background')"
+    "j.run(executor='background')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 32,
    "id": "e63d43c1-341f-4ec0-b0cf-9cd5ead51926",
    "metadata": {},
    "outputs": [
@@ -963,7 +931,7 @@
        "1      AseMDTask  "
       ]
      },
-     "execution_count": 55,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -982,25 +950,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 33,
    "id": "80da39e2-76d1-42e6-977f-241d2683188d",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<pyiron_contrib.tinybase.executor.FuturesExecutionContext at 0x7f15fa16f640>"
-      ]
-     },
-     "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'bulk' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[33], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m sub \u001b[38;5;241m=\u001b[39m pr\u001b[38;5;241m.\u001b[39mopen_location(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m/foo\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m j \u001b[38;5;241m=\u001b[39m sub\u001b[38;5;241m.\u001b[39mcreate\u001b[38;5;241m.\u001b[39mjob\u001b[38;5;241m.\u001b[39mAseMD(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mmd\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 3\u001b[0m j\u001b[38;5;241m.\u001b[39minput\u001b[38;5;241m.\u001b[39mstructure \u001b[38;5;241m=\u001b[39m \u001b[43mbulk\u001b[49m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mFe\u001b[39m\u001b[38;5;124m'\u001b[39m, a\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1.2\u001b[39m, cubic\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\u001b[38;5;241m.\u001b[39mrepeat(\u001b[38;5;241m2\u001b[39m)\n\u001b[1;32m      4\u001b[0m j\u001b[38;5;241m.\u001b[39minput\u001b[38;5;241m.\u001b[39mcalculator \u001b[38;5;241m=\u001b[39m MorsePotential()\n\u001b[1;32m      5\u001b[0m j\u001b[38;5;241m.\u001b[39minput\u001b[38;5;241m.\u001b[39msteps \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m100\u001b[39m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'bulk' is not defined"
+     ]
     }
    ],
    "source": [
     "sub = pr.open_location(\"/foo\")\n",
-    "j = GenericTinyJob(sub, 'md')\n",
-    "j.task_class = AseMDTask\n",
+    "j = sub.create.job.AseMD('md')\n",
     "j.input.structure = bulk('Fe', a=1.2, cubic=True).repeat(2)\n",
     "j.input.calculator = MorsePotential()\n",
     "j.input.steps = 100\n",
@@ -1012,100 +980,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "a567f96a-cbb3-4d2d-95d1-6dcecee7ddb8",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>username</th>\n",
-       "      <th>name</th>\n",
-       "      <th>jobtype_id</th>\n",
-       "      <th>project_id</th>\n",
-       "      <th>status_id</th>\n",
-       "      <th>location</th>\n",
-       "      <th>status</th>\n",
-       "      <th>type</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>pyiron</td>\n",
-       "      <td>murn</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>/</td>\n",
-       "      <td>finished</td>\n",
-       "      <td>MurnaghanTask</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>pyiron</td>\n",
-       "      <td>md</td>\n",
-       "      <td>2</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>/</td>\n",
-       "      <td>finished</td>\n",
-       "      <td>AseMDTask</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>pyiron</td>\n",
-       "      <td>md</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>/foo</td>\n",
-       "      <td>running</td>\n",
-       "      <td>AseMDTask</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   id username  name  jobtype_id  project_id  status_id location    status  \\\n",
-       "0   1   pyiron  murn           1           1          1        /  finished   \n",
-       "1   2   pyiron    md           2           1          2        /  finished   \n",
-       "2   3   pyiron    md           2           2          3     /foo   running   \n",
-       "\n",
-       "            type  \n",
-       "0  MurnaghanTask  \n",
-       "1      AseMDTask  \n",
-       "2      AseMDTask  "
-      ]
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pr.job_table()"
    ]
@@ -1120,7 +998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "a6fefefb-b09c-4cee-b632-29f88bccfeee",
    "metadata": {},
    "outputs": [],
@@ -1130,21 +1008,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "3419f273-b94b-48cf-9373-7441baec2353",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DatabaseEntry(name='murn', username='pyiron', project='/', status='finished', jobtype='MurnaghanTask')"
-      ]
-     },
-     "execution_count": 60,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "db.get_item(1)"
    ]
@@ -1159,7 +1026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "id": "cf75b2e8-ec15-4846-bda4-9b6661e8b5fa",
    "metadata": {},
    "outputs": [],
@@ -1169,7 +1036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "1b23728b-1050-47a4-bda0-bd5967ceed2e",
    "metadata": {},
    "outputs": [],
@@ -1179,7 +1046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "4cd73be9-2c6d-4501-8a6c-0afc6083a4b9",
    "metadata": {},
    "outputs": [],
@@ -1189,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "e9d9a3e2-5c86-46b4-b6d0-bec3a9f448b0",
    "metadata": {},
    "outputs": [],
@@ -1199,107 +1066,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "id": "99059ff6-18bd-40b9-85fc-d76e1828f7ac",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.query(Job.id).where(Job.name == \"min\", ).all()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "id": "cb4bb9fe-13bf-4736-aa68-662b980d4f00",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(2, 'finished')]"
-      ]
-     },
-     "execution_count": 66,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.query(JobStatus.__table__).select_from(Job).where(Job.id == 2, Job.status_id == JobStatus.id).all()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "id": "4641b048-b7c7-46a2-b67c-835c08916cb0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(1, 'finished'), (2, 'finished'), (3, 'finished')]"
-      ]
-     },
-     "execution_count": 67,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.query(JobStatus.__table__).all()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "id": "94364e54-b980-48cc-995b-daf977437b1b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(1, '/'), (2, '/foo')]"
-      ]
-     },
-     "execution_count": 68,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.query(DProject.__table__).all()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "id": "f32c43d5-19c8-4505-bf5c-9ac32bca51d0",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(1, 'MurnaghanTask'), (2, 'AseMDTask')]"
-      ]
-     },
-     "execution_count": 69,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.query(JobType.__table__).all()"
    ]

--- a/pyiron_contrib/tinybase/creator.py
+++ b/pyiron_contrib/tinybase/creator.py
@@ -90,7 +90,7 @@ class JobCreator(Creator):
                 else:
                     if not isinstance(job.task, task):
                         raise ValueError(
-                            f"Job with given name already exists, but is of different type!"
+                            "Job with given name already exists, but is of different type!"
                         )
                     return job
             except JobNotFoundError:

--- a/pyiron_contrib/tinybase/creator.py
+++ b/pyiron_contrib/tinybase/creator.py
@@ -1,0 +1,250 @@
+"""
+Creators of various things.
+
+They serve to give easy access to various classes, so that users do not have to
+manually import them.
+
+Rough spec:
+
+    1. RootCreator is merely the entry point and delegates to sub creators
+    based on name
+    2. Sub creators should be type homogenous or related by functionality, i.e.
+    one of jobs, one for tasks, one for structures, etc.
+    3. Each project gets its own RootCreator, but should keep that instance
+    alive so that sub creators may cache certain things
+"""
+
+import abc
+import importlib
+from typing import Union
+from functools import wraps
+from os import sched_getaffinity
+
+import pyiron_contrib.tinybase.job
+from pyiron_contrib.tinybase.executor import (
+        Executor,
+        ProcessExecutor,
+        BackgroundExecutor,
+        DaskExecutor
+)
+from pyiron_atomistics import ase_to_pyiron, Atoms
+
+import ase.build
+
+class Creator(abc.ABC):
+
+    @abc.abstractmethod
+    def __init__(self, project, config):
+        pass
+
+    #TODO add all methods
+
+def load_class(class_path):
+    module, klass = class_path.rsplit(".", maxsplit=1)
+    try:
+        return getattr(importlib.import_module(module), klass)
+    except ImportError as e:
+        raise ValueError(f"Importing task class '{class_path}' failed: {e.args}!") from None
+
+class JobCreator(Creator):
+
+    def __init__(self, project, job_dict):
+        self._project = project
+        self._jobs = job_dict.copy()
+
+    def __dir__(self):
+        return tuple(self._jobs.keys())
+
+    def __getattr__(self, task_type):
+        if task_type not in self._jobs:
+            raise ValueError(f"Unknown task type {task_type}!")
+        task = self._jobs[task_type]
+        if isinstance(task, str):
+            task = self._jobs[task_type] = load_class(task)
+
+        def create(
+                name: str,
+                delete_existing_job: bool = False,
+                delete_aborted_job: bool = False
+        ):
+            """
+            Create or load a new job.
+
+            Args:
+                name (str): name of the job
+                delete_existing_job (bool): if a job of this name and type
+                    exists, delete it first
+                delete_existing_job (bool): if a job if this name and type
+                    exists and its status is aborted, delete it first
+            """
+            task = self._jobs[task_type]
+            if self._project.exists_storage(name):
+                try:
+                    job = self._project.create_storage(name).to_object()
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Failed to reload run job from storage: {e}"
+                    ) from None
+                if not isinstance(job, pyiron_contrib.tinybase.job.TinyJob):
+                    raise ValueError(f"Storage with name {name} exists, but is not a job! {job}")
+                if not isinstance(job.task, task):
+                    raise ValueError(f"Job with given name already exists, but is of different type!")
+                return job
+            else:
+                return pyiron_contrib.tinybase.job.TinyJob(
+                    task(), self._project, name
+                )
+
+        return create
+
+    def register(self, task: Union["AbstractTask", str], name: str):
+        """
+        Register a new task.
+
+        Args:
+            task (AbstractTask): new task to register
+
+        Returns:
+            AbstractTask: the newly registered task
+        """
+        if name is None:
+            name = type(task).__name__
+        if name in self._jobs:
+            if task != self._jobs[name]:
+                raise ValueError("Refusing to register task: different task of the same name already exists!")
+            else:
+                return self._jobs[name]
+        self._jobs[name] = task
+        return task
+
+class TaskCreator(Creator):
+
+    def __init__(self, project, config):
+        self._tasks = config.copy()
+
+    def __dir__(self):
+        return tuple(self._tasks.keys())
+
+    def __getattr__(self, name):
+        task = self._tasks[name]
+        if isinstance(task, str):
+            task = self._tasks[name] = load_class(task)
+        return task
+
+    def register(self, task: Union["AbstractTask", str], name: str):
+        """
+        Register a new task.
+
+        Args:
+            task (AbstractTask): new task to register
+
+        Returns:
+            AbstractTask: the newly registered task
+        """
+        if name is None:
+            name = type(task).__name__
+        if name in self._jobs:
+            if task != self._jobs[name]:
+                raise ValueError("Refusing to register task: different task of the same name already exists!")
+            else:
+                return self._jobs[name]
+        self._jobs[name] = task
+        return task
+
+class StructureCreator(Creator):
+
+    def __init__(self, project, config):
+        pass
+
+    @wraps(ase.build.bulk)
+    def bulk(self, *args, **kwargs):
+        return ase_to_pyiron(ase.build.bulk(*args, **kwargs))
+
+    @wraps(Atoms)
+    def atoms(self, *args, **kwargs):
+        return Atoms(*args, **kwargs)
+
+
+
+class ExecutorCreator(Creator):
+
+    _DEFAULT_CPUS = min(int(0.5 * len(sched_getaffinity(0))), 8)
+
+    def __init__(self, project, config):
+        self._most_recent = None
+
+    def most_recent(self):
+        if self._most_recent is None:
+            self._most_recent = Executor()
+        return self._most_recent
+
+    def _save(func):
+        @wraps(func)
+        def f(self, *args, **kwargs):
+            self._most_recent = func(self, *args, **kwargs)
+            return self._most_recent
+        return f
+
+    @wraps(ProcessExecutor)
+    @_save
+    def process(self, max_processes=_DEFAULT_CPUS):
+        return ProcessExecutor(max_processes=max_processes)
+
+    @wraps(BackgroundExecutor)
+    @_save
+    def background(self, max_threads=4):
+        return BackgroundExecutor(max_threads=max_threads)
+
+    @wraps(DaskExecutor.from_localcluster)
+    @_save
+    def dask_local(self, max_workers=_DEFAULT_CPUS, **kwargs):
+        return DaskExecutor.from_localcluster(max_workers=max_workers, **kwargs)
+
+    @wraps(DaskExecutor.from_cluster)
+    @_save
+    def dask_cluster(self, cluster):
+        return DaskExecutor.from_cluster(cluster)
+
+    del _save
+
+class RootCreator:
+
+    def __init__(self, project, config):
+        self._project = project
+        self._subcreators = {}
+        for name, (subcreator, subconfig) in config.items():
+            self._subcreators[name] = subcreator(project, subconfig)
+
+    def __dir__(self):
+        return tuple(self._subcreators.keys())
+
+    def register(self, name, subcreator, force=False):
+        """
+        Add a new creator.
+        """
+        if name not in self._subcreators or force:
+            self._subcreators[name] = subcreator
+        else:
+            raise ValueError(f"Already registered a creator under name {name}!")
+
+    def __getattr__(self, name):
+        try:
+            return self._subcreators[name]
+        except KeyError:
+            raise AttributeError(f"No creator of name {name} registered!")
+
+TASK_CONFIG = {
+        "AseStatic": "pyiron_contrib.tinybase.ase.AseStaticTask",
+        "AseMinimize": "pyiron_contrib.tinybase.ase.AseMinimizeTask",
+        "AseMD": "pyiron_contrib.tinybase.ase.AseMDTask",
+        "Murnaghan": "pyiron_contrib.tinybase.murn.MurnaghanTask",
+}
+
+
+
+CREATOR_CONFIG = {
+        "job": (JobCreator, TASK_CONFIG),
+        "task": (TaskCreator, TASK_CONFIG),
+        "structure": (StructureCreator, {}),
+        "executor": (ExecutorCreator, {})
+}

--- a/pyiron_contrib/tinybase/creator.py
+++ b/pyiron_contrib/tinybase/creator.py
@@ -166,9 +166,7 @@ class StructureCreator(Creator):
     def bulk(self, *args, **kwargs):
         return ase_to_pyiron(ase.build.bulk(*args, **kwargs))
 
-    @wraps(Atoms)
-    def atoms(self, *args, **kwargs):
-        return Atoms(*args, **kwargs)
+    atoms = Atoms
 
 
 class ExecutorCreator(Creator):

--- a/pyiron_contrib/tinybase/executor.py
+++ b/pyiron_contrib/tinybase/executor.py
@@ -115,7 +115,7 @@ class ExecutionContext:
     def run(self):
         self._run_machine.step()
 
-    def wait(self, until="finished", max_wait=inf, sleep=0.1):
+    def wait(self, until="finished", timeout=None, sleep=0.1):
         """
         Sleep until specified state of the run state machine is reached.
 
@@ -125,18 +125,20 @@ class ExecutionContext:
         Args:
             until (str): wait until the executor has reached this state; must
                 be a valid state name of :class:`.RunMachine.Code`.
-            max_wait (float): maximum amount of seconds to wait; wait
+            timeout (float): maximum amount of seconds to wait; wait
                 indefinitely by default
             sleep (float): amount of seconds to sleep in between status checks
 
         Raises:
             ValueError: if the current state is `init`
         """
+        if timeout is None:
+            timeout = inf
         if self._run_machine.state == RunMachine.Code("init"):
             raise ValueError("Still in state 'init'! Call run() first!")
         until = RunMachine.Code(until)
         start = time.monotonic()
-        while until != self._run_machine.state and time.monotonic() - start < max_wait:
+        while until != self._run_machine.state and time.monotonic() - start < timeout:
             time.sleep(sleep)
 
     @property

--- a/pyiron_contrib/tinybase/job.py
+++ b/pyiron_contrib/tinybase/job.py
@@ -156,6 +156,22 @@ class TinyJob(Storable):
         else:
             logging.info("Job already finished!")
 
+    def wait(self, timeout: Optional[float] = None):
+        """
+        Wait until job is finished.
+
+        Args:
+            timeout (float, optional): maximum time to wait in seconds; wait
+                indefinitely by default
+
+        Raises:
+            ValueError: if job status is not `finished` or `running`
+        """
+        if self.status == "finished": return
+        if self.status != "running":
+            raise ValueError("Job not running!")
+        self._executor.wait(timeout=timeout)
+
     def remove(self):
         """
         Remove the job from the database and storage.

--- a/pyiron_contrib/tinybase/job.py
+++ b/pyiron_contrib/tinybase/job.py
@@ -125,7 +125,9 @@ class TinyJob(Storable):
         self._executor._run_machine.observe("collect", self._update_status("collect"))
         self._executor._run_machine.observe("finished", self._update_status("finished"))
 
-    def run(self, executor: Union[Executor, str, None] = None) -> Optional[ExecutionContext]:
+    def run(
+        self, executor: Union[Executor, str, None] = None
+    ) -> Optional[ExecutionContext]:
         """
         Start execution of the job.
 
@@ -144,7 +146,7 @@ class TinyJob(Storable):
             or self.project.database.get_item(self.id).status == "ready"
         ):
             if executor is None:
-                executor = 'most_recent'
+                executor = "most_recent"
             if isinstance(executor, str):
                 executor = getattr(self.project.create.executor, executor)()
             exe = self._executor = executor.submit(tasks=[self.task])

--- a/pyiron_contrib/tinybase/job.py
+++ b/pyiron_contrib/tinybase/job.py
@@ -1,6 +1,6 @@
 import abc
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from pyiron_contrib.tinybase.task import AbstractTask
 from pyiron_contrib.tinybase.storage import (
@@ -11,6 +11,7 @@ from pyiron_contrib.tinybase.storage import (
 )
 from pyiron_contrib.tinybase.executor import (
     Executor,
+    ExecutionContext,
     BackgroundExecutor,
     ProcessExecutor,
 )
@@ -19,7 +20,7 @@ from pyiron_contrib.tinybase.project import ProjectInterface, ProjectAdapter
 from pyiron_base.state import state
 
 
-class TinyJob(Storable, abc.ABC):
+class TinyJob(Storable):
     """
     A tiny job unifies an executor, a task and its output.
 
@@ -43,22 +44,12 @@ class TinyJob(Storable, abc.ABC):
     You can use :class:`.GenericTinyJob` to dynamically specify which task the job should execute.
     """
 
-    _executors = {
-        "foreground": Executor(),
-        "background": BackgroundExecutor(max_threads=4),
-        "process": ProcessExecutor(max_processes=4),
-    }
-
-    def __init__(self, project: ProjectInterface, job_name: str):
+    def __init__(self, task: AbstractTask, project: ProjectInterface, job_name: str):
         """
         Create a new job.
 
-        If the given `job_name` is already present in the `project` it is reloaded.  No checks are performed that the
-        task type of the already present job and the current one match.  This is also not always necessary, e.g. when
-        reloading a :class:`.GenericTinyJob` it will automatically read the
-        correct task from storage.
-
         Args:
+            task (:class:`.AbstractTask`): the underlying task to run
             project (:class:`.ProjectInterface`): the project the job should live in
             job_name (str): the name of the job.
         """
@@ -66,19 +57,11 @@ class TinyJob(Storable, abc.ABC):
             project = ProjectAdapter(project)
         self._project = project
         self._name = job_name
-        self._task = None
+        self._task = task
         self._output = None
         self._storage = None
         self._executor = None
         self._id = None
-        # FIXME: this should go into the job creation logic on the project
-        if project.exists_storage(job_name):
-            try:
-                self.load()
-            except Exception as e:
-                raise RuntimeError(
-                    f"Failed to reload run job from storage: {e}"
-                ) from None
 
     @property
     def name(self):
@@ -95,19 +78,8 @@ class TinyJob(Storable, abc.ABC):
     def project(self):
         return self._project
 
-    @abc.abstractmethod
-    def _get_task(self) -> AbstractTask:
-        """
-        Return an instance of the :class:`.AbstractTask`.
-
-        The value return from here is saved automatically in :prop:`.task`.
-        """
-        pass
-
     @property
     def task(self):
-        if self._task is None:
-            self._task = self._get_task()
         return self._task
 
     @property
@@ -146,14 +118,16 @@ class TinyJob(Storable, abc.ABC):
         self._executor._run_machine.observe("collect", self._update_status("collect"))
         self._executor._run_machine.observe("finished", self._update_status("finished"))
 
-    def run(self, how="foreground") -> Optional[Executor]:
+    def run(self, executor: Union[Executor, str, None] = None) -> Optional[ExecutionContext]:
         """
         Start execution of the job.
 
         If the job already has a database id and is not in "ready" state, do nothing.
 
         Args:
-            how (string): specifies which executor to use
+            executor (:class:`~.Executor`, str): specifies which executor to
+                use, if `str` must be a method name of :class:`.ExecutorCreator`;
+                if not given use the last created executor
 
         Returns:
             :class:`.Executor`: the executor that is running the task or nothing.
@@ -162,7 +136,11 @@ class TinyJob(Storable, abc.ABC):
             self._id is None
             or self.project.database.get_item(self.id).status == "ready"
         ):
-            exe = self._executor = self._executors[how].submit(tasks=[self.task])
+            if executor is None:
+                executor = 'most_recent'
+            if isinstance(executor, str):
+                executor = getattr(self.project.create.executor, executor)()
+            exe = self._executor = executor.submit(tasks=[self.task])
             self._setup_executor_callbacks()
             exe.run()
             return exe
@@ -225,39 +203,7 @@ class TinyJob(Storable, abc.ABC):
 
     @classmethod
     def _restore(cls, storage, version):
-        job = cls(project=storage.project, job_name=storage.name)
+        task = pickle_load(storage["task"])
+        job = cls(task=task, project=storage.project, job_name=storage.name)
         job.load(storage=storage)
         return job
-
-
-# I'm not perfectly happy with this, but two thoughts led to this class:
-# 1. I want to be able to set any task on a tiny job without subclassing, to make the prototyping new jobs in the notebook
-#    easy
-# 2. I do *not* want people to accidently change the task instance/class while the job is running
-class GenericTinyJob(TinyJob):
-    """
-    A generic tiny job is a tiny job that allows to set any task class after instantiating it.
-
-    Set a task class via :attr:`.task_class`, e.g.
-
-    >>> from somewhere import MyTask
-    >>> job = GenericTinyJob(Project(...), "myjob")
-    >>> job.task_class = MyTask
-    >>> isinstance(job.input, type(MyTask.input))
-    True
-    """
-
-    def __init__(self, project, job_name):
-        super().__init__(project=project, job_name=job_name)
-        self._task_class = None
-
-    @property
-    def task_class(self):
-        return self._task_class
-
-    @task_class.setter
-    def task_class(self, cls):
-        self._task_class = cls
-
-    def _get_task(self):
-        return self.task_class()

--- a/pyiron_contrib/tinybase/job.py
+++ b/pyiron_contrib/tinybase/job.py
@@ -167,7 +167,8 @@ class TinyJob(Storable):
         Raises:
             ValueError: if job status is not `finished` or `running`
         """
-        if self.status == "finished": return
+        if self.status == "finished":
+            return
         if self.status != "running":
             raise ValueError("Job not running!")
         self._executor.wait(timeout=timeout)

--- a/pyiron_contrib/tinybase/job.py
+++ b/pyiron_contrib/tinybase/job.py
@@ -79,6 +79,13 @@ class TinyJob(Storable):
         return self._project
 
     @property
+    def status(self):
+        try:
+            return self._project.database.get_item(self.id).status
+        except ValueError:
+            return "initialized"
+
+    @property
     def task(self):
         return self._task
 

--- a/pyiron_contrib/tinybase/project.py
+++ b/pyiron_contrib/tinybase/project.py
@@ -36,6 +36,15 @@ class ProjectInterface(abc.ABC):
     def database(self):
         return self._get_database()
 
+    @property
+    def create(self):
+        if not hasattr(self, '_creator'):
+            from pyiron_contrib.tinybase.creator import RootCreator, CREATOR_CONFIG
+            self._creator = RootCreator(
+                    self, CREATOR_CONFIG
+            )
+        return self._creator
+
     def load(self, name_or_id: int | str) -> "TinyJob":
         # if a name is given, job must be in the current project
         if isinstance(name_or_id, str):

--- a/pyiron_contrib/tinybase/project.py
+++ b/pyiron_contrib/tinybase/project.py
@@ -10,8 +10,10 @@ from pyiron_contrib.tinybase.storage import (
 )
 from pyiron_contrib.tinybase.database import TinyDB, GenericDatabase
 
+
 class JobNotFoundError(Exception):
     pass
+
 
 class ProjectInterface(abc.ABC):
     @classmethod
@@ -41,11 +43,10 @@ class ProjectInterface(abc.ABC):
 
     @property
     def create(self):
-        if not hasattr(self, '_creator'):
+        if not hasattr(self, "_creator"):
             from pyiron_contrib.tinybase.creator import RootCreator, CREATOR_CONFIG
-            self._creator = RootCreator(
-                    self, CREATOR_CONFIG
-            )
+
+            self._creator = RootCreator(self, CREATOR_CONFIG)
         return self._creator
 
     def load(self, name_or_id: Union[int, str]) -> "TinyJob":

--- a/pyiron_contrib/tinybase/task.py
+++ b/pyiron_contrib/tinybase/task.py
@@ -6,7 +6,12 @@ from typing import Optional, Callable, List, Generator, Tuple
 from pyiron_base.interfaces.object import HasStorage
 
 from pyiron_contrib.tinybase.storage import Storable, pickle_dump, pickle_load
-from pyiron_contrib.tinybase.container import AbstractInput, AbstractOutput, StorageAttribute
+from pyiron_contrib.tinybase.container import (
+    AbstractInput,
+    AbstractOutput,
+    StorageAttribute,
+)
+
 
 class ReturnStatus:
     """


### PR DESCRIPTION
Add creator classes for jobs, tasks, structures and executors so that users don't need to import them.  With it there are some changes in TinyJob:

1. it is no longer an abstract class, but requires a task instance to be instantiated.  Reloading already run jobs can be done with TinyJob.restore
2. as a consequence GenericTinyJob is no longer needed
3. because Executors are easily created now, the _executors class attribute is also gone; TinyJob.run now takes an argument 'executor', either an executor or a method name of the ExecutorCreator as a short hand

The creators are very similar to the ones already existing in pyiron_base.  Notable is the ExecutorCreator which as a method `most_recent` that simply returns the last created executor, which is also used by TinyJob.run by default, freeing the user from lugging around executor instances on their own.