### PR TITLE
Workflow: Better io

### DIFF
--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -387,6 +387,7 @@ class OutputData(DataChannel):
     On `update`, Output channels propagate their value to all the input channels to
     which they are connected by invoking their `update` method.
     """
+
     def _after_update(self) -> None:
         for inp in self.connections:
             inp.update(self.value)
@@ -446,6 +447,7 @@ class InputSignal(SignalChannel):
     """
     Invokes a callback when called.
     """
+
     def __init__(
         self,
         label: str,
@@ -481,6 +483,7 @@ class OutputSignal(SignalChannel):
     """
     Calls all the input signal objects in its connections list when called.
     """
+
     def __call__(self) -> None:
         for c in self.connections:
             c()

--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing
 from abc import ABC, abstractmethod
-from json import dumps
 from warnings import warn
 
 from pyiron_contrib.workflow.has_channel import HasChannel

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -5,6 +5,7 @@ Collections of channel objects.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from warnings import warn
 
 from pyiron_contrib.workflow.channels import (
     Channel,
@@ -76,9 +77,9 @@ class IO(HasToDict, ABC):
             self._assign_value_to_existing_channel(self.channel_dict[key], value)
         elif isinstance(value, self._channel_class):
             if key != value.label:
-                raise ValueError(
-                    f"Channels can only be assigned to attributes matching their label,"
-                    f"but just tried to assign the channel {value.label} to {key}"
+                warn(
+                    f"Assigning a channel with the label {value.label} to the io key "
+                    f"{key}"
                 )
             self.channel_dict[key] = value
         else:

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -1,3 +1,7 @@
+"""
+Collections of channel objects.
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -19,24 +23,24 @@ from pyiron_contrib.workflow.util import DotDict
 class IO(HasToDict, ABC):
     """
     IO is a convenience layer for holding and accessing multiple input/output channels.
-    It allows key and dot-based access to the underlying channels based on their name.
+    It allows key and dot-based access to the underlying channels.
     Channels can also be iterated over, and there are a number of helper functions to
     alter the properties of or check the status of all the channels at once.
 
-    A new channel can be assigned as an attribute of an IO collection, as long as the
-    attribute name matches the channel's label and type (i.e. `OutputChannel` for
-    `Outputs` and `InputChannel` for `Inputs`).
-
-    New channels can also be added using the `add` method, which must be implemented in
-    child classes to add channels of the correct type.
+    A new channel can be assigned as an attribute of an IO collection, as long as it
+    matches the channel's type (e.g. `OutputChannel` for `Outputs`, `InputChannel`
+    for `Inputs`, etc...).
 
     When assigning something to an attribute holding an existing channel, if the
-    assigned object is a `Channel`, then it is treated like a `connection`, otherwise
-    it is treated like a value `update`. I.e.
+    assigned object is a `Channel`, then an attempt is made to make a `connection`
+    between the two channels, otherwise we fall back on a value assignment that must
+    be defined in child classes under `_assign_value_to_existing_channel`, i.e.
     >>> some_io.some_existing_channel = 5
 
     is equivalent to
-    >>> some_io.some_existing_channel.update(5)
+    >>> some_io._assign_value_to_existing_channel(
+    ...     some_io["some_existing_channel"], 5
+    ... )
 
     and
     >>> some_io.some_existing_channel = some_other_channel

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -206,6 +206,7 @@ class Signals:
         input (InputSignals): An empty input signals IO container.
         output (OutputSignals): An empty input signals IO container.
     """
+
     def __init__(self):
         self.input = InputSignals()
         self.output = OutputSignals()

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -135,6 +135,10 @@ class IO(HasToDict, ABC):
 
 
 class DataIO(IO, ABC):
+    """
+    Extends the base IO class with helper methods relevant to data channels.
+    """
+
     def _assign_a_non_channel_value(self, channel: DataChannel, value) -> None:
         channel.update(value)
 
@@ -195,6 +199,13 @@ class OutputSignals(SignalIO):
 
 
 class Signals:
+    """
+    A meta-container for input and output signal IO containers.
+
+    Attributes:
+        input (InputSignals): An empty input signals IO container.
+        output (OutputSignals): An empty input signals IO container.
+    """
     def __init__(self):
         self.input = InputSignals()
         self.output = OutputSignals()

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -40,6 +40,13 @@ class TestIO(TestCase):
         with self.assertRaises(TypeError):
             self.input.foo = "not an input channel"
 
+        with self.assertRaises(TypeError):
+            # Right label, and a channel, but wrong type of channel
+            self.input.b = self.post_facto_output
+
+        with self.subTest("Successful channel assignment"):
+            self.output.b = self.post_facto_output
+
         with self.subTest("Can assign to a key that is not the label"):
             label_before_assignment = self.post_facto_output.label
             self.output.not_this_channels_name = self.post_facto_output
@@ -54,13 +61,6 @@ class TestIO(TestCase):
                 msg="Labels should not get updated on assignment of channels to IO "
                     "collections"
             )
-
-        with self.assertRaises(TypeError):
-            # Right label, and a channel, but wrong type of channel
-            self.input.b = self.post_facto_output
-
-        with self.subTest("Successful channel assignment"):
-            self.output.b = self.post_facto_output
 
     def test_connection(self):
         self.input.x = self.input.y

--- a/tests/unit/workflow/test_io.py
+++ b/tests/unit/workflow/test_io.py
@@ -40,8 +40,20 @@ class TestIO(TestCase):
         with self.assertRaises(TypeError):
             self.input.foo = "not an input channel"
 
-        with self.assertRaises(ValueError):
+        with self.subTest("Can assign to a key that is not the label"):
+            label_before_assignment = self.post_facto_output.label
             self.output.not_this_channels_name = self.post_facto_output
+            self.assertIs(
+                self.output.not_this_channels_name,
+                self.post_facto_output,
+                msg="Expected channel to get assigned"
+            )
+            self.assertEqual(
+                self.post_facto_output.label,
+                label_before_assignment,
+                msg="Labels should not get updated on assignment of channels to IO "
+                    "collections"
+            )
 
         with self.assertRaises(TypeError):
             # Right label, and a channel, but wrong type of channel


### PR DESCRIPTION
This is docs and type hints _except_ that now the key under which a channel is stored in an IO collection doesn't need to be that channel's label. 

The rationale for this is that workflows should dynamically be creating IO collections with keys like `f"{node.label}_{channel.label}"`, but I don't want them to be altering the underlying channel label. Right now `Workflow` does this by just making a (dot)dict out of the channel objects, but it would be nice to use the formal `IO` class for the collection so we get access to its helper methods and can have consistent typing between `Workflow` and `Node` for what `inputs` and `outputs` look like.

@samwaseda, because this is _almost_ just doc changes, and I want the functional change for us in #729, I'll probably merge it without review. But if you want to take a peek anyhow and leave some comments where anything is unclear/poorly worded, I would be happy to open a patching PR to polish it up.