### PR TITLE
Introduce running on an executor

### DIFF
--- a/pyiron_contrib/workflow/composite.py
+++ b/pyiron_contrib/workflow/composite.py
@@ -10,6 +10,7 @@ from functools import partial
 from typing import Optional
 from warnings import warn
 
+from pyiron_contrib.executors import CloudpickleProcessPoolExecutor
 from pyiron_contrib.workflow.node import Node
 from pyiron_contrib.workflow.function import (
     Function,
@@ -30,6 +31,12 @@ class _NodeDecoratorAccess:
     function_node = function_node
     slow_node = slow_node
     single_value_node = single_value_node
+
+
+class Creator:
+    """A shortcut interface for creating non-Node objects from the workflow class."""
+
+    CloudpickleProcessPoolExecutor = CloudpickleProcessPoolExecutor
 
 
 class Composite(Node, ABC):
@@ -77,6 +84,8 @@ class Composite(Node, ABC):
 
     wrap_as = _NodeDecoratorAccess  # Class method access to decorators
     # Allows users/devs to easily create new nodes when using children of this class
+
+    create = Creator
 
     def __init__(
         self,

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -9,10 +9,10 @@ from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from typing import Optional, TYPE_CHECKING
 
+from pyiron_contrib.executors import CloudpickleProcessPoolExecutor
 from pyiron_contrib.workflow.files import DirectoryObject
 from pyiron_contrib.workflow.has_to_dict import HasToDict
 from pyiron_contrib.workflow.io import Signals, InputSignal, OutputSignal
-from pyiron_contrib.workflow.util import CloudpickleProcessPoolExecutor
 
 if TYPE_CHECKING:
     from pyiron_base.jobs.job.extension.server.generic import Server

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -49,6 +49,11 @@ class Node(HasToDict, ABC):
     Their value is controlled automatically in the defined `run` and `finish_run`
     methods.
 
+    Nodes can be run on the main python process that owns them, or by assigning an
+    appropriate executor to their `executor` attribute.
+    In case they are run with an executor, their `future` attribute will be populated
+    with the resulting future object.
+
     This is an abstract class.
     Children *must* define how `inputs` and `outputs` are constructed, and what will
     happen `on_run`.

--- a/pyiron_contrib/workflow/util.py
+++ b/pyiron_contrib/workflow/util.py
@@ -1,6 +1,35 @@
+from concurrent.futures import ProcessPoolExecutor
+
+import cloudpickle
+
+
 class DotDict(dict):
     def __getattr__(self, item):
         return self.__getitem__(item)
 
     def __setattr__(self, key, value):
         self[key] = value
+
+
+def _apply_cloudpickle(fn, /, *args, **kwargs):
+    fn = cloudpickle.loads(fn)
+    return fn(*args, **kwargs)
+
+
+class CloudpickleProcessPoolExecutor(ProcessPoolExecutor):
+    """
+    In our workflows, it is common to dynamically create classes from functions using a
+    decorator;
+    This makes the underlying function object mismatch with the pickle-findable
+    "function" (actually a class after wrapping).
+    The result is that a regular `ProcessPoolExecutor` cannot pickle our node functions.
+
+    An alternative is to force the executor to use pickle under the hood, which _can_
+    handle these sort of dynamic objects.
+    This solution comes from u/mostsquares @ stackoverflow:
+    https://stackoverflow.com/questions/62830970/submit-dynamically-loaded-functions-to-the-processpoolexecutor
+    """
+    def submit(self, fn, /, *args, **kwargs):
+        return super().submit(
+            _apply_cloudpickle, cloudpickle.dumps(fn), *args, **kwargs
+        )

--- a/pyiron_contrib/workflow/util.py
+++ b/pyiron_contrib/workflow/util.py
@@ -1,35 +1,6 @@
-from concurrent.futures import ProcessPoolExecutor
-
-import cloudpickle
-
-
 class DotDict(dict):
     def __getattr__(self, item):
         return self.__getitem__(item)
 
     def __setattr__(self, key, value):
         self[key] = value
-
-
-def _apply_cloudpickle(fn, /, *args, **kwargs):
-    fn = cloudpickle.loads(fn)
-    return fn(*args, **kwargs)
-
-
-class CloudpickleProcessPoolExecutor(ProcessPoolExecutor):
-    """
-    In our workflows, it is common to dynamically create classes from functions using a
-    decorator;
-    This makes the underlying function object mismatch with the pickle-findable
-    "function" (actually a class after wrapping).
-    The result is that a regular `ProcessPoolExecutor` cannot pickle our node functions.
-
-    An alternative is to force the executor to use pickle under the hood, which _can_
-    handle these sort of dynamic objects.
-    This solution comes from u/mostsquares @ stackoverflow:
-    https://stackoverflow.com/questions/62830970/submit-dynamically-loaded-functions-to-the-processpoolexecutor
-    """
-    def submit(self, fn, /, *args, **kwargs):
-        return super().submit(
-            _apply_cloudpickle, cloudpickle.dumps(fn), *args, **kwargs
-        )


### PR DESCRIPTION
EDIT: This now exploits the `pyiron_contrib.executors.cloudpickleprocesspool.CloudPickleProcessPoolExecutor`, which extends `concurrent.futures.ProcessPoolExecutor` to handle the dynamically defined nodes (and can also handle if we start passing around unpickleable (but cloudpickleable) args and return values. An appropriate test is included.




I'll keep working on it, but I wanted to push what's here.

In the case that the new `executor` attribute is of the right type, nodes now take their functionality and arguments and pass them to the executor for computation, and register a callback that processes the result and exposes it to the output channels.

The only real complication is that it's very common for our nodes to be dynamically generated from decorated functions, which shoots `pickle` right in the foot. `cloudpickle` can handle these things, so for now I'm super pragmatic and steal [this stackoverflow solution](https://stackoverflow.com/questions/62830970/submit-dynamically-loaded-functions-to-the-processpoolexecutor) to wrap `concurrent.futures.ProcessPoolExecutor` so it uses `cloudpickle` instead. Seems to be working fine:

```python
from pyiron_contrib.workflow.util import CloudpickleProcessPoolExecutor
from pyiron_contrib.workflow.workflow import Workflow

executor = CloudpickleProcessPoolExecutor(max_workers=2)

wf = Workflow("parallel_workflow", strict_naming=False)
wf.structure = wf.add.atomistics.BulkStructure(
    cubic=True, 
    element="Al",
    update_on_instantiation=False
)
wf.structure.executor = executor
wf.structure.update()
wf.structure.future.done()
>>> False
```

And we're released to do other calculations on the main python process. After a bit the executor finishes and both `wf.structure.future.result()` and `wf.structure.outputs.structure.value` store the expected structure. This means the output has been updated and all the run-finishing stuff for the node is firing.

I believe `Node.server` is obsolete in this paradigm.

The rough plan:
- [x] ~~Add unit tests~~ Executor unit tests are over in `pyiorn_contrib.executors`
- [x] ~~Add an integration test~~ This functionality only takes 20s to test in the regular workflow unit tests, so it's there
- [x] Add a creator on the `Workflow` so this funky executor can be accessed from our single import
- [x] Discuss at the Monday meeting

@jan-janssen if you want to stay as up-to-date as possible with the combination of executors and workflows, I guess this is the place to watch. But so far, other than the hiccup where we need cloudpickle, it's delightfully boring and should work with anything that follows the python `Executor` pattern.