### PR TITLE
Hotfix: represeting NotData

### DIFF
--- a/pyiron_contrib/workflow/channels.py
+++ b/pyiron_contrib/workflow/channels.py
@@ -145,7 +145,7 @@ class NotData:
     def __repr__(cls):
         # We use the class directly (not instances of it) where there is not yet data
         # So give it a decent repr, even as just a class
-        return cls
+        return cls.__name__
 
 
 class DataChannel(Channel, ABC):

--- a/tests/unit/workflow/test_function.py
+++ b/tests/unit/workflow/test_function.py
@@ -325,6 +325,15 @@ class TestSingleValue(unittest.TestCase):
                 "actually still a Function and not just the value you're seeing.)"
         )
 
+    def test_repr(self):
+        svn = SingleValue(no_default, "output")
+        self.assertIs(svn.outputs.output.value, NotData)
+        self.assertTrue(
+            svn.__repr__().endswith(NotData.__name__),
+            msg="When the output is still not data, the representation should indicate "
+                "this"
+        )
+
     def test_easy_output_connection(self):
         svn = SingleValue(plus_one, "y")
         regular = Function(plus_one, "y")


### PR DESCRIPTION
Since we use `NotData` to directly populate data channels before they hold data, we need to make sure that the class itself has a decent `__repr__`.

I pushed the first crack at this directly to main by accident, sorry.