### PR TITLE
Better workflow representation

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 - coveralls
 - coverage
 - codacy-coverage
-- ipython
 - matplotlib =3.7.2
 - numpy =1.24.3
 - pyiron_base =0.6.3

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 - coveralls
 - coverage
 - codacy-coverage
-- ipython
 - matplotlib =3.7.2
 - numpy =1.24.3
 - pyiron_base =0.6.3

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,6 @@ dependencies:
 - coveralls
 - coverage
 - codacy-coverage
-- ipython
 - matplotlib =3.7.2
 - numpy =1.24.3
 - pyiron_base =0.6.3

--- a/pyiron_contrib/workflow/composite.py
+++ b/pyiron_contrib/workflow/composite.py
@@ -238,7 +238,14 @@ class Composite(Node, ABC):
             super().__setattr__(label, node)
 
     def __getattr__(self, key):
-        return self.nodes[key]
+        try:
+            return self.nodes[key]
+        except KeyError:
+            # Raise an attribute error from getattr to make sure hasattr works well!
+            raise AttributeError(
+                f"Could not find attribute {key} on {self.label} "
+                f"({self.__class__.__name__}) or in its nodes ({self.nodes.keys()})"
+            )
 
     def __getitem__(self, item):
         return self.__getattr__(item)

--- a/pyiron_contrib/workflow/has_to_dict.py
+++ b/pyiron_contrib/workflow/has_to_dict.py
@@ -17,3 +17,6 @@ class HasToDict(ABC):
 
     def repr_json(self):
         return JSON(self.to_dict())
+
+    def __str__(self):
+        return str(self.to_dict())

--- a/pyiron_contrib/workflow/has_to_dict.py
+++ b/pyiron_contrib/workflow/has_to_dict.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from json import dumps
 
-from IPython.display import JSON
-
 
 class HasToDict(ABC):
     @abstractmethod
@@ -14,9 +12,6 @@ class HasToDict(ABC):
 
     def info(self):
         print(dumps(self.to_dict(), indent=2))
-
-    def repr_json(self):
-        return JSON(self.to_dict())
 
     def __str__(self):
         return str(self.to_dict())

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -70,7 +70,14 @@ class IO(HasToDict, ABC):
         pass
 
     def __getattr__(self, item) -> Channel:
-        return self.channel_dict[item]
+        try:
+            return self.channel_dict[item]
+        except KeyError:
+            # Raise an attribute error from getattr to make sure hasattr works well!
+            raise AttributeError(
+                f"Could not find attribute {item} on {self.__class__.__name__} object "
+                f"nor in its channels ({self.labels})"
+            )
 
     def __setattr__(self, key, value):
         if key in self.channel_dict.keys():

--- a/pyiron_contrib/workflow/io.py
+++ b/pyiron_contrib/workflow/io.py
@@ -125,6 +125,9 @@ class IO(HasToDict, ABC):
     def __dir__(self):
         return set(super().__dir__() + self.labels)
 
+    def __str__(self):
+        return f"{self.__class__.__name__} {self.labels}"
+
     def to_dict(self):
         return {
             "label": self.__class__.__name__,
@@ -224,3 +227,6 @@ class Signals:
             "input": self.input.to_dict(),
             "output": self.output.to_dict(),
         }
+
+    def __str__(self):
+        return f"{str(self.input)}\n{str(self.output)}"

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -315,7 +315,9 @@ class Node(HasToDict, ABC):
         return self.update()
 
     def __str__(self):
-        return f"{self.label} ({self.__class__.__name__}):\n" \
-               f"{str(self.inputs)}\n" \
-               f"{str(self.outputs)}\n" \
-               f"{str(self.signals)}"
+        return (
+            f"{self.label} ({self.__class__.__name__}):\n"
+            f"{str(self.inputs)}\n"
+            f"{str(self.outputs)}\n"
+            f"{str(self.signals)}"
+        )

--- a/pyiron_contrib/workflow/node.py
+++ b/pyiron_contrib/workflow/node.py
@@ -313,3 +313,9 @@ class Node(HasToDict, ABC):
     def __call__(self, **kwargs) -> None:
         self._batch_update_input(**kwargs)
         return self.update()
+
+    def __str__(self):
+        return f"{self.label} ({self.__class__.__name__}):\n" \
+               f"{str(self.inputs)}\n" \
+               f"{str(self.outputs)}\n" \
+               f"{str(self.signals)}"

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         'workflow': [
             'cloudpickle',
             'python>=3.10',
-            'ipython',
             'typeguard==4.1.0'
         ],
         'tinybase': [


### PR DESCRIPTION
Some custom string representations for workflow objects, and squashing the bug that was stopping `_repr_json_` from triggering automatically on a couple of classes.

Closes #804.
Closes #756 (there is still useful conversation there to think about as we keep working on this code, but this was the last of the todo items for immediate resolution). 