### PR TITLE
Shell commands

### DIFF
--- a/pyiron_contrib/workflow/meta.py
+++ b/pyiron_contrib/workflow/meta.py
@@ -372,7 +372,8 @@ def python_script(
 
         for process_output in macro.script.outputs.labels:
             macro.outputs_map[
-                f"{macro.script.label}__{process_output}"] = process_output
+                f"{macro.script.label}__{process_output}"
+            ] = process_output
 
     return type(
         script.title().replace("_", "").replace(" ", ""),  # fnc_name to CamelCase

--- a/pyiron_contrib/workflow/meta.py
+++ b/pyiron_contrib/workflow/meta.py
@@ -299,7 +299,7 @@ def while_loop(
     return macro_node()(make_loop)
 
 
-def meta_python_script(
+def python_script(
         script: str,
         args: Optional[dict[str, type[Any]]] = None,
         kwargs: Optional[dict[str, Any]] = None,
@@ -391,7 +391,7 @@ meta_nodes = DotDict(
         for_loop.__name__: for_loop,
         input_to_list.__name__: input_to_list,
         list_to_output.__name__: list_to_output,
-        meta_python_script.__name__: meta_python_script,
+        python_script.__name__: python_script,
         while_loop.__name__: while_loop,
     }
 )

--- a/pyiron_contrib/workflow/meta.py
+++ b/pyiron_contrib/workflow/meta.py
@@ -357,7 +357,7 @@ def python_script(
             return "python " + script + " " + " ".join(inputs_list)
 
         macro.command = inputs_to_command(macro.input_collator)
-        macro.script = macro.create.standard.shell_command(cmd=macro.command)
+        macro.script = macro.create.standard.ShellCommand(cmd=macro.command)
         node_directory = str(macro.script.working_directory.path.absolute())
         macro.script.inputs.cwd = node_directory
 

--- a/pyiron_contrib/workflow/meta.py
+++ b/pyiron_contrib/workflow/meta.py
@@ -363,7 +363,7 @@ def python_script(
 
         for channel_label, filename in output_files.items():
             fout = macro.create.standard.UserInput(
-                os.path.join(filename, node_directory),
+                os.path.join(node_directory, filename),
                 label=channel_label,
                 run_on_updates=False,
             )

--- a/pyiron_contrib/workflow/node_library/standard.py
+++ b/pyiron_contrib/workflow/node_library/standard.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from inspect import isclass
+import subprocess
 from typing import Optional
 
 import numpy as np
 from matplotlib import pyplot as plt
 
 from pyiron_contrib.workflow.channels import NotData, OutputSignal
-from pyiron_contrib.workflow.function import SingleValue, single_value_node
+from pyiron_contrib.workflow.function import (
+    function_node, SingleValue, single_value_node
+)
 
 
 @single_value_node(output_labels="fig")
@@ -16,6 +19,28 @@ def scatter(
 ):
     return plt.scatter(x, y)
 
+
+@function_node()
+def shell_command(
+        cmd: str,
+        cwd: Optional[str] = None,
+        timeout: Optional[float | int] = None,
+        check: bool = True,
+):
+    out = subprocess.run(
+        cmd,
+        cwd=cwd,
+        timeout=timeout,
+        shell=True,
+        capture_output=True,
+        universal_newlines=True,
+        check=check,
+
+    )
+    stdout = out.stdout
+    stderr = out.stderr
+    returncode = out.returncode
+    return stdout, stderr, returncode
 
 @single_value_node()
 def user_input(user_input):
@@ -53,6 +78,7 @@ class If(SingleValue):
 
 nodes = [
     scatter,
+    shell_command,
     user_input,
     If,
 ]

--- a/tests/integration/test_script_execution.py
+++ b/tests/integration/test_script_execution.py
@@ -15,8 +15,7 @@ class TestPythonScriptCLI(unittest.TestCase):
         my_plot = MyPlot()
         my_plot(x_max=5.5, n_points=10, linestyle="'--'", linecolor="'green'")
 
-        print(my_plot.outputs.plot.value)
         self.assertTrue(os.path.isfile(my_plot.outputs.plot.value))
 
-        # my_plot.working_directory.delete()
+        my_plot.working_directory.delete()
 

--- a/tests/integration/test_script_execution.py
+++ b/tests/integration/test_script_execution.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+
+from pyiron_contrib.workflow import Workflow
+
+
+class TestPythonScriptCLI(unittest.TestCase):
+    def test_python_script(self):
+        MyPlot = Workflow.create.meta.python_script(
+            os.path.abspath("../static/plot_script.py"),
+            {"x_max": float, "n_points": int},
+            kwargs={"--linestyle": None, "--linecolor": "k"},
+            output_files={"plot": "plot.png"}
+        )
+        my_plot = MyPlot()
+        my_plot(x_max=5.5, n_points=10, linestyle="'--'", linecolor="'green'")
+
+        print(my_plot.outputs.plot.value)
+        self.assertTrue(os.path.isfile(my_plot.outputs.plot.value))
+
+        # my_plot.working_directory.delete()
+

--- a/tests/static/plot_script.py
+++ b/tests/static/plot_script.py
@@ -1,0 +1,24 @@
+import argparse
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main(x_max, n_points, linestyle, linecolor):
+    x = np.linspace(0, x_max, n_points)
+    y = x * x
+    fig, ax = plt.subplots()
+    ax.plot(x, y, linestyle=linestyle, color=linecolor)
+    fig.savefig("plot.png", format="png")
+
+    print(f"{np.amax(x)}^2 = {np.amax(y)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Args for plotting.')
+    parser.add_argument('length', type=float, help='domain length from 0..length')
+    parser.add_argument('n_points', type=int, help='How many data points on the domain')
+    parser.add_argument('--linestyle', type=str, default=None)
+    parser.add_argument('--linecolor', type=str, default="k")
+    args = parser.parse_args()
+    main(args.length, args.n_points, args.linestyle, args.linecolor)


### PR DESCRIPTION
A first attack at (meta) node(s) for running shell commands via the workflows.

I'm relatively content with the `ShellCommand` node, although certainly open to criticism and extensions, e.g. thinking about how such a node is going to interact with executors.

As a first extension, I tried using `ShellCommand` as the core of a meta-node that runs executable python scripts with CLI args and kwargs.
I absolutely hate the implementation right now -- it's ugly as sin -- but the UI is not so bad.
@srmnitc, please take a peek at the user-facing side of things in the new integration test and let me know what you think! (Of course you're very welcome to give feedback on the implementation too, but that's still a hot mess and I don't demand that you subject yourself to that 🤣)