### PR TITLE
Replace reading of configs in Mlip

### DIFF
--- a/pyiron_contrib/atomistics/mlip/cfgs.py
+++ b/pyiron_contrib/atomistics/mlip/cfgs.py
@@ -177,3 +177,18 @@ def savecfgs(filename, cfgs, desc=None):
         for cfg in cfgs:
             savecfg(file, cfg, desc)
             print("", file=file)
+
+
+def load_grades_ids_and_timesteps(filename):
+    ids = []
+    timesteps = []
+    grades = []
+    with open(filename) as f:
+        for line in f:
+            if line.startswith("FEATURE   MV_GRADE"):
+                grades.append(float(line.split()[-1]))
+            elif line.startswith("FEATURE   PYIRON"):
+                i, t = map(int, line.rsplit(maxsplit=1)[-1].split("_"))
+                ids.append(i)
+                timesteps.append(t)
+    return np.array(grades), np.array(ids), np.array(timesteps)


### PR DESCRIPTION
The old code relied on `dtype=object` arrays and it turned out easier to replace the whole thing than fixing it.