### PR TITLE
[minor] Expose `Composite.disconnect_run` publicly

### DIFF
--- a/pyiron_contrib/workflow/composite.py
+++ b/pyiron_contrib/workflow/composite.py
@@ -135,7 +135,13 @@ class Composite(Node, ABC):
             node.run()
         return DotDict(self.outputs.to_value_dict())
 
-    def _disconnect_run(self) -> list[tuple[Channel, Channel]]:
+    def disconnect_run(self) -> list[tuple[Channel, Channel]]:
+        """
+        Disconnect all `signals.input.run` connections on all child nodes.
+
+        Returns:
+            list[tuple[Channel, Channel]]: Any disconnected pairs.
+        """
         disconnected_pairs = []
         for node in self.nodes.values():
             disconnected_pairs.extend(node.signals.disconnect_run())
@@ -149,7 +155,7 @@ class Composite(Node, ABC):
         Raises:
             ValueError: When the data connections do not form a DAG.
         """
-        self._disconnect_run()
+        self.disconnect_run()
         self._set_run_connections_and_starting_nodes_according_to_linear_dag()
         # TODO: Replace this linear setup with something more powerful
 

--- a/pyiron_contrib/workflow/macro.py
+++ b/pyiron_contrib/workflow/macro.py
@@ -167,7 +167,7 @@ class Macro(Composite):
         return self._outputs
 
     def _configure_graph_execution(self):
-        run_signals = self._disconnect_run()
+        run_signals = self.disconnect_run()
 
         has_signals = len(run_signals) > 0
         has_starters = len(self.starting_nodes) > 0
@@ -188,7 +188,7 @@ class Macro(Composite):
             )
 
     def _reconnect_run(self, run_signal_pairs_to_restore):
-        self._disconnect_run()
+        self.disconnect_run()
         for pairs in run_signal_pairs_to_restore:
             pairs[0].connect(pairs[1])
 


### PR DESCRIPTION
This is useful if you're manually setting up execution flows on a workflow instance and want to start from a clean slate.