### PR TITLE
Use bidict for IO maps

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,6 +2,7 @@ channels:
 - conda-forge
 dependencies:
 - ase =3.22.1
+- bidict
 - cloudpickle
 - coveralls
 - coverage

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -2,6 +2,7 @@ channels:
 - conda-forge
 dependencies:
 - ase =3.22.1
+- bidict
 - cloudpickle
 - coveralls
 - coverage

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,7 @@ dependencies:
 - ipykernel
 - nbsphinx
 - ase =3.22.1
+- bidict
 - cloudpickle
 - coveralls
 - coverage

--- a/pyiron_contrib/workflow/composite.py
+++ b/pyiron_contrib/workflow/composite.py
@@ -9,6 +9,7 @@ from abc import ABC
 from functools import partial
 from typing import Literal, Optional, TYPE_CHECKING
 
+from bidict import bidict
 from toposort import toposort_flatten, CircularDependencyError
 
 from pyiron_contrib.workflow.interfaces import Creator, Wrappers
@@ -55,6 +56,15 @@ class Composite(Node, ABC):
     requirement is still passed on to children.
 
     Attributes:
+        inputs/outputs_map (bidict|None): Maps in the form
+         `{"node_label__channel_label": "some_better_name"}` that expose canonically
+         named channels of child nodes under a new name. This can be used both for re-
+         naming regular IO (i.e. unconnected child channels), as well as forcing the
+         exposure of irregular IO (i.e. child channels that are already internally
+         connected to some other child channel). Non-`None` values provided at input
+         can be in regular dictionary form, but get re-cast as a clean bidict to ensure
+         the bijective nature of the maps (i.e. there is a 1:1 connection between any
+         IO exposed at the `Composite` level and the underlying channels).
         nodes (DotDict[pyiron_contrib.workflow.node.Node]): The owned nodes that
          form the composite subgraph.
         strict_naming (bool): When true, repeated assignment of a new node to an
@@ -86,18 +96,39 @@ class Composite(Node, ABC):
         *args,
         parent: Optional[Composite] = None,
         strict_naming: bool = True,
-        inputs_map: Optional[dict] = None,
-        outputs_map: Optional[dict] = None,
+        inputs_map: Optional[dict | bidict] = None,
+        outputs_map: Optional[dict | bidict] = None,
         **kwargs,
     ):
         super().__init__(*args, label=label, parent=parent, **kwargs)
         self.strict_naming: bool = strict_naming
+        self._inputs_map = None
+        self._outputs_map = None
         self.inputs_map = inputs_map
         self.outputs_map = outputs_map
         self.nodes: DotDict[str:Node] = DotDict()
         self.starting_nodes: list[Node] = []
         self._creator = self.create
         self.create = self._owned_creator  # Override the create method from the class
+
+    @property
+    def inputs_map(self) -> bidict | None:
+        return self._inputs_map
+
+    @inputs_map.setter
+    def inputs_map(self, new_map: dict | bidict | None):
+        new_map = new_map if new_map is None else bidict(new_map)
+        self._inputs_map = new_map
+
+    @property
+    def outputs_map(self) -> bidict | None:
+        return self._outputs_map
+
+    @outputs_map.setter
+    def outputs_map(self, new_map: dict | bidict | None):
+        new_map = new_map if new_map is None else bidict(new_map)
+        self._outputs_map = new_map
+
 
     @property
     def _owned_creator(self):

--- a/pyiron_contrib/workflow/macro.py
+++ b/pyiron_contrib/workflow/macro.py
@@ -6,10 +6,13 @@ interface and are not intended to be internally modified after instantiation.
 from __future__ import annotations
 
 from functools import partialmethod
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from pyiron_contrib.workflow.composite import Composite
 from pyiron_contrib.workflow.io import Outputs, Inputs
+
+if TYPE_CHECKING:
+    from bidict import bidict
 
 
 class Macro(Composite):
@@ -138,8 +141,8 @@ class Macro(Composite):
         label: Optional[str] = None,
         parent: Optional[Composite] = None,
         strict_naming: bool = True,
-        inputs_map: Optional[dict] = None,
-        outputs_map: Optional[dict] = None,
+        inputs_map: Optional[dict | bidict] = None,
+        outputs_map: Optional[dict | bidict] = None,
         **kwargs,
     ):
         self._parent = None

--- a/pyiron_contrib/workflow/workflow.py
+++ b/pyiron_contrib/workflow/workflow.py
@@ -13,6 +13,8 @@ from pyiron_contrib.workflow.io import Inputs, Outputs
 
 
 if TYPE_CHECKING:
+    from bidict import bidict
+
     from pyiron_contrib.workflow.node import Node
 
 
@@ -166,8 +168,8 @@ class Workflow(Composite):
         label: str,
         *nodes: Node,
         strict_naming: bool = True,
-        inputs_map: Optional[dict] = None,
-        outputs_map: Optional[dict] = None,
+        inputs_map: Optional[dict | bidict] = None,
+        outputs_map: Optional[dict | bidict] = None,
         automate_execution: bool = True,
     ):
         super().__init__(

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
             'moto==4.1.14'
         ],
         'workflow': [
+            'bidict',
             'cloudpickle',
             'python>=3.10',
             'graphviz',

--- a/tests/unit/workflow/test_workflow.py
+++ b/tests/unit/workflow/test_workflow.py
@@ -2,6 +2,8 @@ import unittest
 from sys import version_info
 from time import sleep
 
+from bidict import ValueDuplicationError
+
 from pyiron_contrib.workflow.channels import NotData
 from pyiron_contrib.workflow.files import DirectoryObject
 from pyiron_contrib.workflow.util import DotDict
@@ -337,6 +339,52 @@ class TestWorkflow(unittest.TestCase):
             cyclic.n1l.inputs.y = cyclic.n2l
             with self.assertRaises(ValueError):
                 cyclic()
+
+    def test_io_label_maps_are_bijective(self):
+
+        with self.subTest("Null case"):
+            Workflow(
+                "my_workflow",
+                Workflow.create.Function(plus_one, label="foo1"),
+                Workflow.create.Function(plus_one, label="foo2"),
+                inputs_map={
+                    "foo1__x": "x1",
+                    "foo2__x": "x2"
+                },
+                outputs_map=None
+            )
+
+        with self.subTest("At instantiation"):
+            with self.assertRaises(ValueDuplicationError):
+                Workflow(
+                    "my_workflow",
+                    Workflow.create.Function(plus_one, label="foo1"),
+                    Workflow.create.Function(plus_one, label="foo2"),
+                    inputs_map={
+                        "foo1__x": "x",
+                        "foo2__x": "x"
+                    }
+                )
+
+        with self.subTest("Post-facto assignment"):
+            wf = Workflow(
+                "my_workflow",
+                Workflow.create.Function(plus_one, label="foo1"),
+                Workflow.create.Function(plus_one, label="foo2"),
+            )
+            wf.outputs_map = None
+            with self.assertRaises(ValueDuplicationError):
+                wf.inputs_map = {"foo1__x": "x", "foo2__x": "x"}
+
+        with self.subTest("Post-facto update"):
+            wf = Workflow(
+                "my_workflow",
+                Workflow.create.Function(plus_one, label="foo1"),
+                Workflow.create.Function(plus_one, label="foo2"),
+            )
+            wf.inputs_map = {"foo1__x": "x1", "foo2__x": "x2"}
+            with self.assertRaises(ValueDuplicationError):
+                wf.inputs_map["foo2__x"] = "x1"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
So that IO panel/underlying channel name maps stay unique.

Closes #865 