### PR TITLE
Use IO panel keys to label graphviz channels

### DIFF
--- a/pyiron_contrib/workflow/draw.py
+++ b/pyiron_contrib/workflow/draw.py
@@ -94,11 +94,11 @@ class _Channel(WorkflowGraphvizMap, ABC):
     parlance.
     """
 
-    def __init__(self, parent: _IO, channel: WorkflowChannel):
+    def __init__(self, parent: _IO, channel: WorkflowChannel, local_name: str):
         self.channel = channel
         self._parent = parent
-        self._name = self.parent.name + self.channel.label
-        self._label = self._build_label()
+        self._name = self.parent.name + local_name
+        self._label = local_name + self._build_label_suffix()
         self.channel: WorkflowChannel = channel
 
         self.graph.node(
@@ -114,14 +114,14 @@ class _Channel(WorkflowGraphvizMap, ABC):
     def shape(self) -> str:
         pass
 
-    def _build_label(self):
-        label = self.channel.label
+    def _build_label_suffix(self):
+        suffix = ""
         try:
             if self.channel.type_hint is not None:
-                label += ": " + self.channel.type_hint.__name__
+                suffix += ": " + self.channel.type_hint.__name__
         except AttributeError:
             pass  # Signals have no type
-        return label
+        return suffix
 
     @property
     def parent(self) -> _IO | None:
@@ -182,8 +182,12 @@ class _IO(WorkflowGraphvizMap, ABC):
         )
 
         self.channels = [
-            SignalChannel(self, channel) for channel in self.signals_io
-        ] + [DataChannel(self, channel) for channel in self.data_io]
+            SignalChannel(self, channel, panel_label)
+            for panel_label, channel in self.signals_io.items()
+        ] + [
+            DataChannel(self, channel, panel_label)
+            for panel_label, channel in self.data_io.items()
+        ]
 
         self.parent.graph.subgraph(self.graph)
 


### PR DESCRIPTION
Instead of relying on the raw channel label to label the channel's graphviz representation, the local name at the IO panel is used. Since names are unique at the IO level by construction, this ensures that each drawn channel also gets a unique name and label to close #866.

i.e.

```python
from pyiron_contrib.workflow import Workflow

@Workflow.wrap_as.single_value_node()
def get_y(x):
    result = x * 2
    return result

@Workflow.wrap_as.single_value_node()
def get_z(x):
    result = x * 3
    return result

wf = Workflow('MyWorkflow')
wf.add(get_y())
wf.add(get_z())

wf.inputs_map = {"get_y__x": "yx"}

wf.draw()
```

Produces:

![pr_example](https://github.com/pyiron/pyiron_contrib/assets/20283329/06d53988-22d8-48cb-9060-d713bdf2ce12)


Which now aligns with the underlying model labels:

```python
wf.inputs.labels, wf.outputs.labels
>>> (['yx', 'get_z__x'], ['get_y__result', 'get_z__result'])
```