### PR TITLE
Remove TrainingContainer.to_dict(), because GenericJob now defines th…

### DIFF
--- a/pyiron_contrib/atomistics/atomistics/job/trainingcontainer.py
+++ b/pyiron_contrib/atomistics/atomistics/job/trainingcontainer.py
@@ -200,9 +200,6 @@ class TrainingContainer(GenericJob, HasStructure):
         """
         return self._container.to_list(filter_function)
 
-    def to_dict(self):
-        return self._container.to_dict()
-
     def write_input(self):
         pass
 


### PR DESCRIPTION
…is for something unrelated in base

Technically this breaks API, but I believe the method is not widely used.