### PR TITLE
[patch] replace logger with snippets version

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -19,6 +19,7 @@ dependencies:
 - moto =5.0.8
 - pycp2k =0.2.2
 - aws-sam-translator =1.77.0
+- pymatgen =2024.5.1
 - pympipool =0.7.17
 - distributed =2024.5.1
 - h5io_browser =0.0.10
@@ -26,4 +27,3 @@ dependencies:
 - lammps
 - nglview >=3.0.8
 - pyiron-data >=0.0.25
-- pymatgen =2024.5.1

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -26,3 +26,4 @@ dependencies:
 - lammps
 - nglview >=3.0.8
 - pyiron-data >=0.0.25
+- pymatgen =2024.5.1

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -5,4 +5,3 @@ dependencies:
   - lammps
   - nglview >=3.0.8
   - pyiron-data >=0.0.25
-  - pymatgen =2024.5.1

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -5,3 +5,4 @@ dependencies:
   - lammps
   - nglview >=3.0.8
   - pyiron-data >=0.0.25
+  - pymatgen =2024.5.1

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -19,6 +19,7 @@ dependencies:
 - moto =5.0.8
 - pycp2k =0.2.2
 - aws-sam-translator =1.77.0
+- pymatgen =2024.5.1
 - pympipool =0.7.17
 - distributed =2024.5.1
 - h5io_browser =0.0.10

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -24,6 +24,7 @@ dependencies:
 - moto =5.0.8
 - pycp2k =0.2.2
 - aws-sam-translator =1.77.0
+- pymatgen =2024.5.1
 - pympipool =0.7.17
 - distributed =2024.5.1
 - h5io_browser =0.0.10

--- a/pyiron_contrib/repair/__init__.py
+++ b/pyiron_contrib/repair/__init__.py
@@ -12,7 +12,7 @@ from pyiron_atomistics import ase_to_pyiron
 from ase.io import read as ase_read
 from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 from pyiron_base import GenericJob, GenericMaster
-from pyiron_base.state.logger import logger
+from pyiron_snippets.logger import logger
 
 from tqdm.auto import tqdm
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         ],
         'tinybase': [
             'distributed==2024.5.1',
+            'pymatgen==2024.5.1',
             'pympipool==0.7.17',
             'h5io_browser==0.0.10',
         ]


### PR DESCRIPTION
i.e. pyiron_base.state.logger.logger with pyiron_snippets.logger.logger. The original location leaves a re-direct for backwards compatibility.