### PR TITLE
Update lammps notebook

### DIFF
--- a/notebooks/tinybase/Lammps.ipynb
+++ b/notebooks/tinybase/Lammps.ipynb
@@ -9,17 +9,9 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/poul/pyiron/contrib/pyiron_contrib/__init__.py:9: UserWarning: pyiron module not found, importing Project from pyiron_base\n",
-      "  warnings.warn(\"pyiron module not found, importing Project from pyiron_base\")\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49e565b4cb784276848f55d7ada29e56",
+       "model_id": "43a6621164964abab0c96113e4b9d35d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -66,13 +58,30 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "aedb78ac-e1a9-499d-a8b6-d02326076655",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "cwd = Path.cwd()\n",
+    "if cwd.name == \"tinybase\":\n",
+    "    # Then the notebook was started locally\n",
+    "    notebook_dir = cwd\n",
+    "else:\n",
+    "    # We are probably executing from papermill on the CI\n",
+    "    notebook_dir = cwd / \"notebooks\" / \"tinybase\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "8c340f6c-c687-4461-9c33-f98b768773d6",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "state.settings.resource_paths.insert(0, '/home/poul/pyiron/contrib/notebooks/tinybase/resources')"
+    "state.settings.resource_paths.insert(0, str(notebook_dir / \"resources\"))"
    ]
   },
   {
@@ -85,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "id": "64c9b3d4-e6e1-4e21-86fc-318940c4c8e8",
    "metadata": {
     "tags": []
@@ -97,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "id": "df4de500-24f5-4160-933d-57cf3d0f15a6",
    "metadata": {
     "tags": []
@@ -109,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "id": "4e5c69d6-fee8-4166-8e06-ba8a2e58e707",
    "metadata": {
     "tags": []
@@ -129,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 9,
    "id": "1056c4b6-603c-4603-8021-a89c64f84255",
    "metadata": {
     "scrolled": true,
@@ -146,7 +155,7 @@
        " '2003--Mendelev-M-I--Fe-2--LAMMPS--ipr3']"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -157,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 10,
    "id": "a6af7f64-5435-40b1-b44c-960528fc0cc5",
    "metadata": {
     "tags": []
@@ -169,19 +178,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 11,
    "id": "8a699e68-ad89-4d52-bdff-3b86d9624a4b",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n"
+     ]
+    }
+   ],
    "source": [
     "ret, out = lmp.execute()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 12,
+   "id": "c4e2d57f-9def-4ab4-a003-95bc4e245a1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "LammpsStaticOutput(forces=array([[-0.02987269, -0.00282932, -0.12843858],\n",
+       "       [-0.15820356,  0.0453781 , -0.03744197],\n",
+       "       [-0.18450471, -0.08204103,  0.07020649],\n",
+       "       [-0.06351491,  0.03401585,  0.00719245],\n",
+       "       [-0.0037588 ,  0.1333546 ,  0.1740541 ],\n",
+       "       [ 0.05387634, -0.00118085, -0.09480989],\n",
+       "       [ 0.07405356,  0.11763504, -0.20276011],\n",
+       "       [ 0.02384882, -0.05766377,  0.10891183],\n",
+       "       [ 0.04153901, -0.08675459,  0.09708118],\n",
+       "       [ 0.00966064,  0.03839169, -0.03484355],\n",
+       "       [ 0.11122156, -0.23955637, -0.05193921],\n",
+       "       [ 0.10710042, -0.19785464,  0.08232861],\n",
+       "       [-0.03485634,  0.2108871 ,  0.10971198],\n",
+       "       [-0.01956278, -0.10410639, -0.02254802],\n",
+       "       [ 0.0187732 ,  0.08581792,  0.07211624],\n",
+       "       [ 0.05420023,  0.10650667, -0.14882155]]), energy_kin=0.0, energy_pot=-69.0339463780543)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "8b837b3d-7bd0-4930-817b-d497e8ae1ead",
    "metadata": {
     "tags": []
@@ -193,7 +249,7 @@
        "ReturnStatus(Code.DONE, None)"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 14,
    "id": "c4793e9e-b7f1-476f-807c-c313718ed49b",
    "metadata": {
     "tags": []
@@ -224,7 +280,7 @@
        "-69.0339463780543"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -235,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 15,
    "id": "afe5c4a1-08ae-4e3a-bb0a-f501dacf4be4",
    "metadata": {
     "tags": []
@@ -247,7 +303,7 @@
        "0.0"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 16,
    "id": "6b48188a-b84c-482a-9add-26d61a4e65f2",
    "metadata": {
     "tags": []
@@ -285,7 +341,7 @@
        "       [ 0.05420023,  0.10650667, -0.14882155]])"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -306,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 17,
    "id": "cc50f529-e3bc-4f36-af63-f496f6c1405f",
    "metadata": {
     "tags": []
@@ -319,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 18,
    "id": "1fb9a556-d882-4b21-99fa-0fd30023d3f4",
    "metadata": {
     "tags": []
@@ -331,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 19,
    "id": "cab52837-17eb-4f33-8182-cb5e917d02ec",
    "metadata": {
     "tags": []
@@ -343,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 20,
    "id": "c95da0c4-fbdb-48d7-8086-f890f82c7725",
    "metadata": {
     "tags": []
@@ -357,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 21,
    "id": "edb93bf2-9e70-4717-9929-101a3101599b",
    "metadata": {
     "tags": []
@@ -369,18 +425,224 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 22,
    "id": "9eab17d8-380a-4199-88b0-50910b5e5296",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:186: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(StringIO(\"\".join(lines)), delim_whitespace=True)\n",
+      "/home/poul/micromamba/envs/pyiron_contrib/lib/python3.11/site-packages/pymatgen/io/lammps/outputs.py:75: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  data = pd.read_csv(StringIO(\"\\n\".join(lines[9:])), names=data_head, delim_whitespace=True)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 256 ms, sys: 634 ms, total: 890 ms\n",
-      "Wall time: 8.49 s\n"
+      "CPU times: user 559 ms, sys: 1.02 s, total: 1.57 s\n",
+      "Wall time: 19.9 s\n"
      ]
     }
    ],
@@ -395,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 23,
    "id": "44ffaf29-f35c-451f-a3fd-9f342035569b",
    "metadata": {
     "tags": []
@@ -418,17 +680,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 24,
    "id": "c6d3f82b-7acb-47f1-ab0c-c0380382e7a7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "93594.71816845893"
+       "94700.42445783262"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -439,17 +701,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 25,
    "id": "f8911ebd-bcc6-4696-89f4-498c60aad544",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "93594.71816845887"
+       "94700.42445783273"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,17 +722,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 26,
    "id": "620c128d-fcd4-4842-8f49-cd6f7052b4c3",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Atoms(symbols='Fe8000', pbc=True, cell=[[-28.602047036763544, 28.602047036763544, 28.602047036763544], [28.602047036763544, -28.602047036763544, 28.602047036763544], [28.602047036763544, 28.602047036763544, -28.602047036763544]])"
+       "Atoms(symbols='Fe8000', pbc=True, cell=[[-28.71423903603843, 28.71423903603843, 28.71423903603843], [28.71423903603843, -28.71423903603843, 28.71423903603843], [28.71423903603843, 28.71423903603843, -28.71423903603843]])"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -496,7 +758,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/tinybase/resources/lammps/bin/run_lammps_default.sh
+++ b/notebooks/tinybase/resources/lammps/bin/run_lammps_default.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-lmp -in control.inp
+lmp_mpi -in control.inp


### PR DESCRIPTION
The example resource wants to use lmp, but lammps conda package provides lmp_mpi only. Maybe that changed recently?

Also updated the notebook to not hard code my own filesystem paths anymore. Oops.